### PR TITLE
destroys empty workspace + minor fixes

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -360,7 +360,7 @@ struct cmd_handler *find_handler(struct cmd_handler handlers[], int l, char *lin
 	return res;
 }
 
-int handle_command(struct sway_config *config, char *exec) {
+bool handle_command(struct sway_config *config, char *exec) {
 	sway_log(L_INFO, "Handling command '%s'", exec);
 	char *ptr, *cmd;
 	bool exec_success;

--- a/sway/commands.h
+++ b/sway/commands.h
@@ -8,6 +8,6 @@ struct cmd_handler {
 	bool (*handle)(struct sway_config *config, int argc, char **argv);
 };
 
-int handle_command(struct sway_config *config, char *command);
+bool handle_command(struct sway_config *config, char *command);
 
 #endif

--- a/sway/config.c
+++ b/sway/config.c
@@ -9,6 +9,7 @@
 #include "config.h"
 
 bool load_config() {
+	sway_log(L_INFO, "Loading config");
 	// TODO: Allow use of more config file locations
 	const char *name = "/.sway/config";
 	const char *home = getenv("HOME");
@@ -65,7 +66,7 @@ struct sway_config *read_config(FILE *file, bool is_active) {
 			goto _continue;
 		}
 
-		if (!temp_depth && handle_command(config, line) != 0) {
+		if (!temp_depth && handle_command(config, line) != true) {
 			success = false;
 		}
 
@@ -76,7 +77,7 @@ _continue:
 		free(line);
 	}
 
-	if (!success) {
+	if (success == false) {
 		exit(1);
 	}
 

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -119,7 +119,7 @@ void arrange_windows(swayc_t *container, int width, int height) {
 	}
 }
 
-void init_layout() {
+void init_layout(void) {
 	root_container.type = C_ROOT;
 	root_container.layout = L_NONE;
 	root_container.children = create_list();
@@ -128,6 +128,9 @@ void init_layout() {
 
 void free_swayc(swayc_t *container) {
 	// NOTE: Does not handle moving children into a different container
+	if (container->parent) {
+		remove_container_from_parent(container->parent, container);
+	}
 	list_free(container->children);
 	if (container->name) {
 		free(container->name);

--- a/sway/layout.h
+++ b/sway/layout.h
@@ -45,7 +45,7 @@ typedef struct sway_container swayc_t;
 
 extern swayc_t root_container;
 
-void init_layout();
+void init_layout(void);
 void add_child(swayc_t *parent, swayc_t *child);
 void add_output(wlc_handle output);
 void destroy_output(wlc_handle output);
@@ -58,6 +58,7 @@ swayc_t *find_container(swayc_t *container, bool (*test)(swayc_t *view, void *da
 swayc_t *get_focused_container(swayc_t *parent);
 int remove_container_from_parent(swayc_t *parent, swayc_t *container);
 swayc_t *create_container(swayc_t *parent, wlc_handle handle);
+void free_swayc(swayc_t *container);
 swayc_t *get_swayc_for_handle(wlc_handle handle, swayc_t *parent);
 
 #endif

--- a/sway/list.c
+++ b/sway/list.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-list_t *create_list() {
+list_t *create_list(void) {
 	list_t *list = malloc(sizeof(list_t));
 	list->capacity = 10;
 	list->length = 0;

--- a/sway/list.h
+++ b/sway/list.h
@@ -7,7 +7,7 @@ typedef struct {
 	void **items;
 } list_t;
 
-list_t *create_list();
+list_t *create_list(void);
 void list_free(list_t *list);
 void list_add(list_t *list, void *item);
 void list_insert(list_t *list, int index, void *item);

--- a/sway/workspace.c
+++ b/sway/workspace.c
@@ -62,11 +62,8 @@ swayc_t *workspace_find_by_name(const char* name) {
 }
 
 void workspace_switch(swayc_t *workspace) {
-	if (active_workspace) {
+	if (workspace != active_workspace && active_workspace) {
 		sway_log(L_DEBUG, "workspace: changing from '%s' to '%s'", active_workspace->name, workspace->name);
-		if (active_workspace == workspace) {
-			return;
-		}
 		uint32_t mask = 1;
 		// set all c_views in the old workspace to the invisible mask
 		container_map(active_workspace, set_mask, &mask);

--- a/sway/workspace.c
+++ b/sway/workspace.c
@@ -39,7 +39,7 @@ bool workspace_by_name(swayc_t *view, void *data) {
 
 bool workspace_destroy(swayc_t *workspace) {
 	//Dont destroy if there are children
-	if(workspace->children->length) {
+	if (workspace->children->length) {
 		return false;
 	}
 	sway_log(L_DEBUG, "Workspace: Destroying workspace '%s'", workspace->name);
@@ -64,8 +64,8 @@ swayc_t *workspace_find_by_name(const char* name) {
 void workspace_switch(swayc_t *workspace) {
 	if (active_workspace) {
 		sway_log(L_DEBUG, "workspace: changing from '%s' to '%s'", active_workspace->name, workspace->name);
-		if(strcmp(active_workspace->name, workspace->name) == 0) {
-			return; //Dont do anything if they are the same workspace
+		if (active_workspace == workspace) {
+			return;
 		}
 		uint32_t mask = 1;
 		// set all c_views in the old workspace to the invisible mask

--- a/sway/workspace.h
+++ b/sway/workspace.h
@@ -5,7 +5,7 @@
 #include "list.h"
 #include "layout.h"
 
-char *workspace_next_name();
+char *workspace_next_name(void);
 swayc_t *workspace_create(const char*);
 swayc_t *workspace_find_by_name(const char*);
 void workspace_switch(swayc_t*);


### PR DESCRIPTION
destroys empty workspaces. 
`() -> (void)`, as () takes any number of arguments when it should take none.
`int -> bool` for `handle_command` return type.
put `free_swayc()` into header for `destroy_workspace` to use
temporary fix to `workspace_next_name()` as it returned an unfreeable name.

https://github.com/SirCmpwn/sway/issues/11