### PR TITLE
Workspace and varsub fixes.

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -41,14 +41,12 @@ bool cmd_bindsym(struct sway_config *config, int argc, char **argv) {
 	binding->command = join_args(argv + 1, argc - 1);
 
 	//Set the first workspace name found to the init_workspace
-	list_t *cargs = split_string(binding->command, " ");
 	if (!config->init_workspace) {
-		if (strcmp("workspace", cargs->items[0]) == 0) {
-			argv[0] = do_var_replacement(config, argv[0]);
-			config->init_workspace = do_var_replacement(config, cargs->items[1]);
+		if (strcmp("workspace", argv[1]) == 0) {
+			config->init_workspace = malloc(strlen(argv[2]) + 1);
+			strcpy(config->init_workspace, argv[2]);
 		}
 	}
-	list_free(cargs);
 
 	list_t *split = split_string(argv[0], "+");
 	int i;
@@ -391,7 +389,10 @@ bool handle_command(struct sway_config *config, char *exec) {
 		char **argv = split_directive(exec + strlen(handler->command), &argc);
 		int i;
 
-		argv[0] = do_var_replacement(config, argv[0]);
+		//Perform var subs on all parts of the command
+		for (i = 0; i < argc; ++i) {
+			argv[i] = do_var_replacement(config, argv[i]);
+		}
 
 		exec_success = handler->handle(config, argc, argv);
 		for (i = 0; i < argc; ++i) {

--- a/sway/config.c
+++ b/sway/config.c
@@ -8,6 +8,8 @@
 #include "commands.h"
 #include "config.h"
 
+struct sway_config *config;
+
 bool load_config() {
 	sway_log(L_INFO, "Loading config");
 	// TODO: Allow use of more config file locations
@@ -34,6 +36,7 @@ void config_defaults(struct sway_config *config) {
 	config->current_mode = malloc(sizeof(struct sway_mode));
 	config->current_mode->name = NULL;
 	config->current_mode->bindings = create_list();
+	config->init_workspace = NULL;
 	list_add(config->modes, config->current_mode);
 	// Flags
 	config->focus_follows_mouse = true;
@@ -82,7 +85,12 @@ _continue:
 	}
 
 	if (is_active) {
-		config->reloading = true;
+		config->reloading = false;
+	}
+	
+	if (!config->init_workspace) {
+		sway_log(L_INFO, "No workspace names set, defaulting to 1");
+		config->init_workspace = "1";
 	}
 
 	return config;

--- a/sway/config.c
+++ b/sway/config.c
@@ -90,7 +90,9 @@ _continue:
 	
 	if (!config->init_workspace) {
 		sway_log(L_INFO, "No workspace names set, defaulting to 1");
-		config->init_workspace = "1";
+		char* default_init_workspace = "1";
+		config->init_workspace = malloc(strlen(default_init_workspace) + 1);
+		strcpy(config->init_workspace, default_init_workspace);
 	}
 
 	return config;

--- a/sway/config.h
+++ b/sway/config.h
@@ -25,6 +25,7 @@ struct sway_config {
 	list_t *symbols;
 	list_t *modes;
 	struct sway_mode *current_mode;
+	char *init_workspace;
 
 	// Flags
 	bool focus_follows_mouse;

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -341,7 +341,7 @@ void add_output(wlc_handle output) {
 
 	swayc_t *workspace = create_container(container, -1);
 	workspace->type = C_WORKSPACE;
-	workspace->name = workspace_next_name();
+	workspace->name = workspace_init_name();
 	workspace->width = size->w; // TODO: gaps
 	workspace->height = size->h;
 	workspace->layout = L_HORIZ; // TODO: Get default layout from config

--- a/sway/main.c
+++ b/sway/main.c
@@ -7,7 +7,6 @@
 #include "log.h"
 #include "handlers.h"
 
-struct sway_config *config;
 
 int main(int argc, char **argv) {
 	init_log(L_DEBUG); // TODO: Control this with command line arg
@@ -38,15 +37,16 @@ int main(int argc, char **argv) {
 
 	};
 
+	if (!load_config()) {
+		sway_abort("Unable to load config");
+	}
+
 	setenv("WLC_DIM", "0", 0);
 	if (!wlc_init(&interface, argc, argv)) {
 		return 1;
 	}
-
 	setenv("DISPLAY", ":1", 1);
-	if (!load_config()) {
-		sway_abort("Unable to load config");
-	}
+
 
 	wlc_run();
 	return 0;

--- a/sway/workspace.c
+++ b/sway/workspace.c
@@ -6,21 +6,17 @@
 #include "list.h"
 #include "log.h"
 #include "container.h"
+#include "config.h"
 
 swayc_t *active_workspace = NULL;
 
 int ws_num = 1;
 
-char *workspace_next_name(void) {
-	int l = 1;
-	if (ws_num >= 10) {
-		l = 2;
-	} else if (ws_num >= 100) {
-		l = 3;
-	}
-	char *name = malloc(l + 1);
-	sprintf(name, "%d", ws_num++);
-	return name;
+char *workspace_init_name(void) {
+	//It should be fine to just return the init name, since
+	//any non bound workspace can't be used outside of the very
+	//first workspace created
+	return config->init_workspace;
 }
 
 swayc_t *workspace_create(const char* name) {

--- a/sway/workspace.h
+++ b/sway/workspace.h
@@ -5,7 +5,7 @@
 #include "list.h"
 #include "layout.h"
 
-char *workspace_next_name(void);
+char *workspace_init_name(void);
 swayc_t *workspace_create(const char*);
 swayc_t *workspace_find_by_name(const char*);
 void workspace_switch(swayc_t*);


### PR DESCRIPTION
I've fixed stuff so that the initially spawned workspace will take on the first defined user workspace name, or default to a predefined value. workspace_next_name has been renamed to workspace_init_name, because(as far as I know) the only time a workspace will be created without a name given explicitly is at startup time. All other workspace commands either specify a name, or refer to an existing workspace. 

In addition, I've altered the subsitution so that it applies to all arguments, since there are many i3 commands which use multiple variables in them.