### PR TITLE
moving things around + statics + forking + exec cleanup + fixed cmd_focus return + keep exec programs out of logs

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -5,7 +5,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <sys/wait.h>
 #include <ctype.h>
 #include "stringop.h"
 #include "layout.h"
@@ -109,19 +108,7 @@ static bool cmd_bindsym(struct sway_config *config, int argc, char **argv) {
 	return true;
 }
 
-static void cmd_exec_cleanup(int signal) {
-	while (waitpid((pid_t)-1, 0, WNOHANG) > 0){};
-}
-
 static bool cmd_exec_always(struct sway_config *config, int argc, char **argv) {
-	/* setup signal handler to cleanup dead proccesses */
-	/* TODO: replace this with a function that has constructor attribute? */
-	static bool cleanup = false;
-	if (cleanup == false) {
-		signal(SIGCHLD, cmd_exec_cleanup);
-		cleanup = true;
-	}
-
 	if (checkarg(argc, "exec_always", EXPECTED_MORE_THEN, 0) == false) {
 		return false;
 	}

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -30,14 +30,14 @@ static struct modifier_key modifiers[] = {
 };
 
 enum expected_args {
-	EXPECTED_MORE_THEN,
-	EXPECTED_LESS_THEN,
+	EXPECTED_MORE_THAN,
+	EXPECTED_LESS_THAN,
 	EXPECTED_SAME_AS
 };
 
 static bool checkarg(int argc, char *name, enum expected_args type, int val) {
 	switch (type) {
-		case EXPECTED_MORE_THEN:
+		case EXPECTED_MORE_THAN:
 			if (argc > val) {
 				return true;
 			}
@@ -45,7 +45,7 @@ static bool checkarg(int argc, char *name, enum expected_args type, int val) {
 				"(expected more then %d argument%s, got %d",
 				name, val, (char*[2]){"s", ""}[argc==1], argc);
 			break;
-		case EXPECTED_LESS_THEN:
+		case EXPECTED_LESS_THAN:
 			if (argc  < val) {
 				return true;
 			};
@@ -66,7 +66,7 @@ static bool checkarg(int argc, char *name, enum expected_args type, int val) {
 
 
 static bool cmd_bindsym(struct sway_config *config, int argc, char **argv) {
-	if (checkarg(argc, "bindsym", EXPECTED_MORE_THEN, 1) == false) {
+	if (!checkarg(argc, "bindsym", EXPECTED_MORE_THAN, 1)) {
 		return false;
 	};
 
@@ -109,7 +109,7 @@ static bool cmd_bindsym(struct sway_config *config, int argc, char **argv) {
 }
 
 static bool cmd_exec_always(struct sway_config *config, int argc, char **argv) {
-	if (checkarg(argc, "exec_always", EXPECTED_MORE_THEN, 0) == false) {
+	if (!checkarg(argc, "exec_always", EXPECTED_MORE_THAN, 0)) {
 		return false;
 	}
 
@@ -144,7 +144,7 @@ static bool cmd_exec(struct sway_config *config, int argc, char **argv) {
 }
 
 static bool cmd_exit(struct sway_config *config, int argc, char **argv) {
-	if (checkarg(argc, "exit", EXPECTED_SAME_AS, 0) == false) {
+	if (!checkarg(argc, "exit", EXPECTED_SAME_AS, 0)) {
 		return false;
 	}
 	// TODO: Some kind of clean up is probably in order
@@ -153,7 +153,7 @@ static bool cmd_exit(struct sway_config *config, int argc, char **argv) {
 }
 
 static bool cmd_focus(struct sway_config *config, int argc, char **argv) {
-	if (checkarg(argc, "focus", EXPECTED_SAME_AS, 1) == false) {
+	if (!checkarg(argc, "focus", EXPECTED_SAME_AS, 1)) {
 		return false;
 	}
 	if (strcasecmp(argv[0], "left") == 0) {
@@ -171,7 +171,7 @@ static bool cmd_focus(struct sway_config *config, int argc, char **argv) {
 }
 
 static bool cmd_focus_follows_mouse(struct sway_config *config, int argc, char **argv) {
-	if (checkarg(argc, "focus_follows_mouse", EXPECTED_SAME_AS, 1) == false) {
+	if (!checkarg(argc, "focus_follows_mouse", EXPECTED_SAME_AS, 1)) {
 		return false;
 	}
 
@@ -180,7 +180,7 @@ static bool cmd_focus_follows_mouse(struct sway_config *config, int argc, char *
 }
 
 static bool cmd_layout(struct sway_config *config, int argc, char **argv) {
-	if (checkarg(argc, "layout", EXPECTED_MORE_THEN, 0) == false) {
+	if (!checkarg(argc, "layout", EXPECTED_MORE_THAN, 0)) {
 		return false;
 	}
 	swayc_t *parent = get_focused_container(&root_container);
@@ -204,7 +204,7 @@ static bool cmd_layout(struct sway_config *config, int argc, char **argv) {
 }
 
 static bool cmd_reload(struct sway_config *config, int argc, char **argv) {
-	if (checkarg(argc, "reload", EXPECTED_SAME_AS, 0) == false) {
+	if (!checkarg(argc, "reload", EXPECTED_SAME_AS, 0)) {
 		return false;
 	}
 	if (!load_config()) {
@@ -215,7 +215,7 @@ static bool cmd_reload(struct sway_config *config, int argc, char **argv) {
 }
 
 static bool cmd_set(struct sway_config *config, int argc, char **argv) {
-	if (checkarg(argc, "set", EXPECTED_SAME_AS, 2) == false) {
+	if (!checkarg(argc, "set", EXPECTED_SAME_AS, 2)) {
 		return false;
 	}
 	struct sway_variable *var = malloc(sizeof(struct sway_variable));
@@ -231,7 +231,7 @@ static bool _do_split(struct sway_config *config, int argc, char **argv, int lay
 	char *name = layout == L_VERT  ? "splitv":
 	             layout == L_HORIZ ? "splith":
 	                                 "split";
-	if (checkarg(argc, name, EXPECTED_SAME_AS, 0) == false) {
+	if (!checkarg(argc, name, EXPECTED_SAME_AS, 0)) {
 		return false;
 	}
 	swayc_t *focused = get_focused_container(&root_container);
@@ -263,7 +263,7 @@ static bool cmd_splith(struct sway_config *config, int argc, char **argv) {
 }
 
 static bool cmd_log_colors(struct sway_config *config, int argc, char **argv) {
-	if (checkarg(argc, "log_colors", EXPECTED_SAME_AS, 1) == false) {
+	if (!checkarg(argc, "log_colors", EXPECTED_SAME_AS, 1)) {
 		return false;
 	}
 	if (strcasecmp(argv[0], "no") != 0 && strcasecmp(argv[0], "yes") != 0) {
@@ -276,7 +276,7 @@ static bool cmd_log_colors(struct sway_config *config, int argc, char **argv) {
 }
 
 static bool cmd_fullscreen(struct sway_config *config, int argc, char **argv) {
-	if (checkarg(argc, "fullscreen", EXPECTED_SAME_AS, 0) == false) {
+	if (!checkarg(argc, "fullscreen", EXPECTED_SAME_AS, 0)) {
 		return false;
 	}
 
@@ -289,7 +289,7 @@ static bool cmd_fullscreen(struct sway_config *config, int argc, char **argv) {
 }
 
 static bool cmd_workspace(struct sway_config *config, int argc, char **argv) {
-	if (checkarg(argc, "workspace", EXPECTED_SAME_AS, 1) == false) {
+	if (!checkarg(argc, "workspace", EXPECTED_SAME_AS, 1)) {
 		return false;
 	}
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -32,7 +32,7 @@ static struct modifier_key modifiers[] = {
 enum expected_args {
 	EXPECTED_MORE_THAN,
 	EXPECTED_LESS_THAN,
-	EXPECTED_SAME_AS
+	EXPECTED_EQUAL_TO
 };
 
 static bool checkarg(int argc, char *name, enum expected_args type, int val) {
@@ -53,7 +53,7 @@ static bool checkarg(int argc, char *name, enum expected_args type, int val) {
 				"(expected less then %d argument%s, got %d",
 				name, val, (char*[2]){"s", ""}[argc==1], argc);
 			break;
-		case EXPECTED_SAME_AS:
+		case EXPECTED_EQUAL_TO:
 			if (argc == val) {
 				return true;
 			};
@@ -144,7 +144,7 @@ static bool cmd_exec(struct sway_config *config, int argc, char **argv) {
 }
 
 static bool cmd_exit(struct sway_config *config, int argc, char **argv) {
-	if (!checkarg(argc, "exit", EXPECTED_SAME_AS, 0)) {
+	if (!checkarg(argc, "exit", EXPECTED_EQUAL_TO, 0)) {
 		return false;
 	}
 	// TODO: Some kind of clean up is probably in order
@@ -153,7 +153,7 @@ static bool cmd_exit(struct sway_config *config, int argc, char **argv) {
 }
 
 static bool cmd_focus(struct sway_config *config, int argc, char **argv) {
-	if (!checkarg(argc, "focus", EXPECTED_SAME_AS, 1)) {
+	if (!checkarg(argc, "focus", EXPECTED_EQUAL_TO, 1)) {
 		return false;
 	}
 	if (strcasecmp(argv[0], "left") == 0) {
@@ -171,7 +171,7 @@ static bool cmd_focus(struct sway_config *config, int argc, char **argv) {
 }
 
 static bool cmd_focus_follows_mouse(struct sway_config *config, int argc, char **argv) {
-	if (!checkarg(argc, "focus_follows_mouse", EXPECTED_SAME_AS, 1)) {
+	if (!checkarg(argc, "focus_follows_mouse", EXPECTED_EQUAL_TO, 1)) {
 		return false;
 	}
 
@@ -204,7 +204,7 @@ static bool cmd_layout(struct sway_config *config, int argc, char **argv) {
 }
 
 static bool cmd_reload(struct sway_config *config, int argc, char **argv) {
-	if (!checkarg(argc, "reload", EXPECTED_SAME_AS, 0)) {
+	if (!checkarg(argc, "reload", EXPECTED_EQUAL_TO, 0)) {
 		return false;
 	}
 	if (!load_config()) {
@@ -215,7 +215,7 @@ static bool cmd_reload(struct sway_config *config, int argc, char **argv) {
 }
 
 static bool cmd_set(struct sway_config *config, int argc, char **argv) {
-	if (!checkarg(argc, "set", EXPECTED_SAME_AS, 2)) {
+	if (!checkarg(argc, "set", EXPECTED_EQUAL_TO, 2)) {
 		return false;
 	}
 	struct sway_variable *var = malloc(sizeof(struct sway_variable));
@@ -231,7 +231,7 @@ static bool _do_split(struct sway_config *config, int argc, char **argv, int lay
 	char *name = layout == L_VERT  ? "splitv":
 	             layout == L_HORIZ ? "splith":
 	                                 "split";
-	if (!checkarg(argc, name, EXPECTED_SAME_AS, 0)) {
+	if (!checkarg(argc, name, EXPECTED_EQUAL_TO, 0)) {
 		return false;
 	}
 	swayc_t *focused = get_focused_container(&root_container);
@@ -263,7 +263,7 @@ static bool cmd_splith(struct sway_config *config, int argc, char **argv) {
 }
 
 static bool cmd_log_colors(struct sway_config *config, int argc, char **argv) {
-	if (!checkarg(argc, "log_colors", EXPECTED_SAME_AS, 1)) {
+	if (!checkarg(argc, "log_colors", EXPECTED_EQUAL_TO, 1)) {
 		return false;
 	}
 	if (strcasecmp(argv[0], "no") != 0 && strcasecmp(argv[0], "yes") != 0) {
@@ -276,7 +276,7 @@ static bool cmd_log_colors(struct sway_config *config, int argc, char **argv) {
 }
 
 static bool cmd_fullscreen(struct sway_config *config, int argc, char **argv) {
-	if (!checkarg(argc, "fullscreen", EXPECTED_SAME_AS, 0)) {
+	if (!checkarg(argc, "fullscreen", EXPECTED_EQUAL_TO, 0)) {
 		return false;
 	}
 
@@ -289,7 +289,7 @@ static bool cmd_fullscreen(struct sway_config *config, int argc, char **argv) {
 }
 
 static bool cmd_workspace(struct sway_config *config, int argc, char **argv) {
-	if (!checkarg(argc, "workspace", EXPECTED_SAME_AS, 1)) {
+	if (!checkarg(argc, "workspace", EXPECTED_EQUAL_TO, 1)) {
 		return false;
 	}
 

--- a/sway/handlers.h
+++ b/sway/handlers.h
@@ -4,21 +4,6 @@
 #include <stdbool.h>
 #include <wlc/wlc.h>
 
-bool handle_output_created(wlc_handle output);
-void handle_output_destroyed(wlc_handle output);
-void handle_output_resolution_change(wlc_handle output, const struct wlc_size *from, const struct wlc_size *to);
-void handle_output_focused(wlc_handle output, bool focus);
-
-bool handle_view_created(wlc_handle view);
-void handle_view_destroyed(wlc_handle view);
-void handle_view_focus(wlc_handle view, bool focus);
-void handle_view_geometry_request(wlc_handle view, const struct wlc_geometry* geometry);
-
-bool handle_key(wlc_handle view, uint32_t time, const struct wlc_modifiers
-		*modifiers, uint32_t key, uint32_t sym, enum wlc_key_state state);
-
-bool handle_pointer_motion(wlc_handle view, uint32_t time, const struct wlc_origin *origin);
-bool handle_pointer_button(wlc_handle view, uint32_t time, const struct wlc_modifiers *modifiers,
-		uint32_t button, enum wlc_button_state state);
+extern struct wlc_interface interface;
 
 #endif

--- a/sway/log.c
+++ b/sway/log.c
@@ -2,6 +2,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <fcntl.h>
+#include <unistd.h>
 
 int colored = 1;
 int v = 0;
@@ -15,6 +17,16 @@ const char *verbosity_colors[] = {
 
 void init_log(int verbosity) {
 	v = verbosity;
+	/* set FD_CLOEXEC flag to prevent programs called with exec to write into
+	 * logs */
+	int i, flag;
+	int fd[] = { STDOUT_FILENO, STDIN_FILENO, STDERR_FILENO };
+	for (i = 0; i < 3; ++i) {
+		flag = fcntl(fd[i], F_GETFD);
+		if (flag != -1) {
+			fcntl(fd[i], F_SETFD, flag | FD_CLOEXEC);
+		}
+	}
 }
 
 void sway_log_colors(int mode) {

--- a/sway/main.c
+++ b/sway/main.c
@@ -2,15 +2,22 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <wlc/wlc.h>
+#include <sys/wait.h>
+#include <signal.h>
 #include "layout.h"
 #include "config.h"
 #include "log.h"
 #include "handlers.h"
 
+static void sigchld_handle(int signal);
 
 int main(int argc, char **argv) {
 	init_log(L_DEBUG); // TODO: Control this with command line arg
 	init_layout();
+
+	/* Signal handling */
+	signal(SIGCHLD, sigchld_handle);
+
 
 	setenv("WLC_DIM", "0", 0);
 	if (!wlc_init(&interface, argc, argv)) {
@@ -24,4 +31,9 @@ int main(int argc, char **argv) {
 
 	wlc_run();
 	return 0;
+}
+
+static void sigchld_handle(int signal) {
+	(void) signal;
+	while (waitpid((pid_t)-1, 0, WNOHANG) > 0);
 }

--- a/sway/main.c
+++ b/sway/main.c
@@ -12,31 +12,6 @@ int main(int argc, char **argv) {
 	init_log(L_DEBUG); // TODO: Control this with command line arg
 	init_layout();
 
-	static struct wlc_interface interface = {
-		.output = {
-			.created = handle_output_created,
-			.destroyed = handle_output_destroyed,
-			.resolution = handle_output_resolution_change,
-			.focus = handle_output_focused
-		},
-		.view = {
-			.created = handle_view_created,
-			.destroyed = handle_view_destroyed,
-			.focus = handle_view_focus,
-			.request = {
-				.geometry = handle_view_geometry_request
-			}
-		},
-		.keyboard = {
-			.key = handle_key
-		},
-		.pointer = {
-			.motion = handle_pointer_motion,
-			.button = handle_pointer_button
-		}
-
-	};
-
 	setenv("WLC_DIM", "0", 0);
 	if (!wlc_init(&interface, argc, argv)) {
 		return 1;

--- a/sway/movement.c
+++ b/sway/movement.c
@@ -5,7 +5,7 @@
 #include "layout.h"
 #include "movement.h"
 
-int move_focus(enum movement_direction direction) {
+bool move_focus(enum movement_direction direction) {
 	swayc_t *current = get_focused_container(&root_container);
 	swayc_t *parent = current->parent;
 
@@ -14,12 +14,12 @@ int move_focus(enum movement_direction direction) {
 		parent  = parent->parent;
 		if (parent->type == C_ROOT) {
 			sway_log(L_DEBUG, "Focus cannot move to parent");
-			return 1;
+			return false;
 		} else {
 			sway_log(L_DEBUG, "Moving focus away from %p", current);
 			unfocus_all(parent);
 			focus_view(parent);
-			return 0;
+			return true;
 		}
 	}
 
@@ -56,7 +56,7 @@ int move_focus(enum movement_direction direction) {
 			} else {
 				unfocus_all(&root_container);
 				focus_view(parent->children->items[desired]);
-				return 0;
+				return true;
 			}
 		}
 		if (!can_move) {
@@ -65,7 +65,7 @@ int move_focus(enum movement_direction direction) {
 			parent = parent->parent;
 			if (parent->type == C_ROOT) {
 				// Nothing we can do
-				return 1;
+				return false;
 			}
 		}
 	}

--- a/sway/movement.h
+++ b/sway/movement.h
@@ -12,6 +12,6 @@ enum movement_direction {
 	MOVE_PARENT
 };
 
-int move_focus(enum movement_direction direction);
+bool move_focus(enum movement_direction direction);
 
 #endif


### PR DESCRIPTION
moved `struct wlc_interface` into `handler.c` accessable via `extern` in `handler.h`

basic forking safety checks, and reduce code duplication.

added signal handler to cleanup dead processes.

added error handling function for checking argument count.

fixed `cmd_focus` movement function return values.

added `FD_CLOEXEC` flag to stdout|in|err so programs called with exec dont write stuff to logs

also sorry for the mess of adding a bunch of different stuff.