### PR TITLE
Added in proper workspace name generation and command queue

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -229,7 +229,7 @@ static bool cmd_set(struct sway_config *config, int argc, char **argv) {
 
 static bool _do_split(struct sway_config *config, int argc, char **argv, int layout) {
 	char *name = layout == L_VERT  ? "splitv":
-                 layout == L_HORIZ ? "splith":"split";
+		   layout == L_HORIZ ? "splith":"split";
 	if (!checkarg(argc, name, EXPECTED_EQUAL_TO, 0)) {
 		return false;
 	}

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -229,8 +229,8 @@ static bool cmd_set(struct sway_config *config, int argc, char **argv) {
 
 static bool _do_split(struct sway_config *config, int argc, char **argv, int layout) {
 	char *name = layout == L_VERT  ? "splitv":
-	             layout == L_HORIZ ? "splith":
-	                                 "split";
+				 layout == L_HORIZ ? "splith":
+									 "split";
 	if (!checkarg(argc, name, EXPECTED_EQUAL_TO, 0)) {
 		return false;
 	}

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -229,7 +229,7 @@ static bool cmd_set(struct sway_config *config, int argc, char **argv) {
 
 static bool _do_split(struct sway_config *config, int argc, char **argv, int layout) {
 	char *name = layout == L_VERT  ? "splitv":
-		   layout == L_HORIZ ? "splith":"split";
+		     layout == L_HORIZ ? "splith":"split";
 	if (!checkarg(argc, name, EXPECTED_EQUAL_TO, 0)) {
 		return false;
 	}

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -229,8 +229,7 @@ static bool cmd_set(struct sway_config *config, int argc, char **argv) {
 
 static bool _do_split(struct sway_config *config, int argc, char **argv, int layout) {
 	char *name = layout == L_VERT  ? "splitv":
-				 layout == L_HORIZ ? "splith":
-									 "split";
+                 layout == L_HORIZ ? "splith":"split";
 	if (!checkarg(argc, name, EXPECTED_EQUAL_TO, 0)) {
 		return false;
 	}

--- a/sway/config.c
+++ b/sway/config.c
@@ -70,7 +70,7 @@ struct sway_config *read_config(FILE *file, bool is_active) {
 		}
 
 		// Any command which would require wlc to be initialized
-		// should be queue for later execution
+		// should be queued for later execution
 		list_t *args = split_string(line, " ");
 		if (strcmp("workspace", args->items[0]) == 0) {
 			sway_log(L_DEBUG, "Deferring command %s", line);

--- a/sway/config.c
+++ b/sway/config.c
@@ -72,7 +72,6 @@ struct sway_config *read_config(FILE *file, bool is_active) {
 		// Any command which would require wlc to be initialized
 		// should be queue for later execution
 		list_t *args = split_string(line, " ");
-		sway_log(L_DEBUG, "Checking command %s", line);
 		if (strcmp("workspace", args->items[0]) == 0) {
 			sway_log(L_DEBUG, "Deferring command %s", line);
 			char *cmd = malloc(strlen(line) + 1);
@@ -92,7 +91,6 @@ _continue:
 	}
 
 	if (success == false) {
-		sway_log(L_DEBUG, "Config load failed, exiting");
 		exit(1);
 	}
 

--- a/sway/config.c
+++ b/sway/config.c
@@ -77,7 +77,7 @@ struct sway_config *read_config(FILE *file, bool is_active) {
 			char *cmd = malloc(strlen(line) + 1);
 			strcpy(cmd, line);
 			list_add(config->cmd_queue, cmd);
-		}else if (!temp_depth && !handle_command(config, line)) {
+		} else if (!temp_depth && !handle_command(config, line)) {
 			sway_log(L_DEBUG, "Config load failed for line %s", line);
 			success = false;
 		} 

--- a/sway/config.h
+++ b/sway/config.h
@@ -24,6 +24,7 @@ struct sway_mode {
 struct sway_config {
 	list_t *symbols;
 	list_t *modes;
+	list_t *cmd_queue;
 	struct sway_mode *current_mode;
 
 	// Flags

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -167,7 +167,6 @@ static void handle_wlc_ready(void) {
 	sway_log(L_DEBUG, "Compositor is ready, executing cmds in queue");
 	int i;
 	for (i = 0; i < config->cmd_queue->length; ++i) {
-		sway_log(L_DEBUG, "Handling command %s", config->cmd_queue->items[i]);
 		handle_command(config, config->cmd_queue->items[i]);
 	}
 	list_free(config->cmd_queue);

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -169,7 +169,7 @@ static void handle_wlc_ready(void) {
 	for (i = 0; i < config->cmd_queue->length; ++i) {
 		handle_command(config, config->cmd_queue->items[i]);
 	}
-	list_free(config->cmd_queue);
+	free_flat_list(config->cmd_queue);
 }
 
 

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -163,6 +163,16 @@ static bool handle_pointer_button(wlc_handle view, uint32_t time, const struct w
 	return true;
 }
 
+static void handle_wlc_ready(void) {
+	sway_log(L_DEBUG, "Compositor is ready, executing cmds in queue");
+	int i;
+	for (i = 0; i < config->cmd_queue->length; ++i) {
+		sway_log(L_DEBUG, "Handling command %s", config->cmd_queue->items[i]);
+		handle_command(config, config->cmd_queue->items[i]);
+	}
+	list_free(config->cmd_queue);
+}
+
 
 struct wlc_interface interface = {
 	.output = {
@@ -185,6 +195,9 @@ struct wlc_interface interface = {
 	.pointer = {
 		.motion = handle_pointer_motion,
 		.button = handle_pointer_button
+	},
+	.compositor = {
+		.ready = handle_wlc_ready 
 	}
 };
 

--- a/sway/main.c
+++ b/sway/main.c
@@ -18,16 +18,15 @@ int main(int argc, char **argv) {
 	/* Signal handling */
 	signal(SIGCHLD, sigchld_handle);
 
+	if (!load_config()) {
+		sway_abort("Unable to load config");
+	}
 
 	setenv("WLC_DIM", "0", 0);
 	if (!wlc_init(&interface, argc, argv)) {
 		return 1;
 	}
 	setenv("DISPLAY", ":1", 1);
-
-	if (!load_config()) {
-		sway_abort("Unable to load config");
-	}
 
 	wlc_run();
 	return 0;

--- a/sway/workspace.c
+++ b/sway/workspace.c
@@ -14,43 +14,46 @@ swayc_t *active_workspace = NULL;
 char *workspace_next_name(void) {
 	sway_log(L_DEBUG, "Workspace: Generating new name");
 	int i;
-    int l = 1;
-    // Scan all workspace bindings to find the next available workspace name,
-    // if none are found/available then default to a number
+	int l = 1;
+	// Scan all workspace bindings to find the next available workspace name,
+	// if none are found/available then default to a number
 	struct sway_mode *mode = config->current_mode;
 
 	for (i = 0; i < mode->bindings->length; ++i) {
 		struct sway_binding *binding = mode->bindings->items[i];
 		const char* command = binding->command;
-	    list_t *args = split_string(command, " ");
-	    sway_log(L_DEBUG, "Workspace: Checking name '%s'", command);
+		list_t *args = split_string(command, " ");
 
-        if (strcmp("workspace", args->items[0]) == 0 && args->length > 1) {
-	        sway_log(L_DEBUG, "Got valid workspace command for target: '%s'", args->items[1]);
-            const char* target = args->items[1];
+		if (strcmp("workspace", args->items[0]) == 0 && args->length > 1) {
+			sway_log(L_DEBUG, "Got valid workspace command for target: '%s'", args->items[1]);
+			const char* target = args->items[1];
 
-            while (*target == ' ' || *target == '\t')
-                target++; 
+			while (*target == ' ' || *target == '\t')
+				target++; 
 
-            // Make sure that the command references an actual workspace
-            // not a command about workspaces
-            if (strcmp(target, "next") == 0 ||
-                strcmp(target, "prev") == 0 ||
-                strcmp(target, "next_on_output") == 0 ||
-                strcmp(target, "prev_on_output") == 0 ||
-                strcmp(target, "number") == 0 ||
-                strcmp(target, "back_and_forth") == 0 ||
-                strcmp(target, "current") == 0)
-                continue;
-           
-            //Make sure that the workspace doesn't already exist 
-            if (workspace_find_by_name(args->items[1]))
-               continue; 
+			// Make sure that the command references an actual workspace
+			// not a command about workspaces
+			if (strcmp(target, "next") == 0 ||
+				strcmp(target, "prev") == 0 ||
+				strcmp(target, "next_on_output") == 0 ||
+				strcmp(target, "prev_on_output") == 0 ||
+				strcmp(target, "number") == 0 ||
+				strcmp(target, "back_and_forth") == 0 ||
+				strcmp(target, "current") == 0)
+				continue;
+		   
+			//Make sure that the workspace doesn't already exist 
+			if (workspace_find_by_name(args->items[1]))
+			   continue; 
 
-            return args->items[1];        }
-    }
-    // As a fall back, get the current number of active workspaces
-    // and return that + 1 for the next workspace's name
+			list_free(args);
+
+			sway_log(L_DEBUG, "Workspace: Found free name %s", args->items[1]);
+			return args->items[1];
+		}
+	}
+	// As a fall back, get the current number of active workspaces
+	// and return that + 1 for the next workspace's name
 	int ws_num = root_container.children->length;
 	if (ws_num >= 10) {
 		l = 2;

--- a/sway/workspace.c
+++ b/sway/workspace.c
@@ -26,8 +26,8 @@ char *workspace_next_name(void) {
 
 		if (strcmp("workspace", args->items[0]) == 0 && args->length > 1) {
 			sway_log(L_DEBUG, "Got valid workspace command for target: '%s'", args->items[1]);
-			const char* target = args->items[1];
-
+			char* target = malloc(strlen(args->items[1]) + 1);
+			strcpy(target, args->items[1]);
 			while (*target == ' ' || *target == '\t')
 				target++; 
 
@@ -43,13 +43,14 @@ char *workspace_next_name(void) {
 				continue;
 		   
 			//Make sure that the workspace doesn't already exist 
-			if (workspace_find_by_name(args->items[1]))
+			if (workspace_find_by_name(target)) {
 			   continue; 
+			}
 
 			list_free(args);
 
-			sway_log(L_DEBUG, "Workspace: Found free name %s", args->items[1]);
-			return args->items[1];
+			sway_log(L_DEBUG, "Workspace: Found free name %s", target);
+			return target;
 		}
 	}
 	// As a fall back, get the current number of active workspaces

--- a/sway/workspace.c
+++ b/sway/workspace.c
@@ -12,7 +12,42 @@ swayc_t *active_workspace = NULL;
 int ws_num = 1;
 
 char *workspace_next_name(void) {
-	int l = 1;
+	int i;
+    // Scan all workspace bindings to find the next available workspace name,
+    // if none are found/available then default to a number
+	struct sway_mode *mode = config->current_mode;
+
+	for (i = 0; i < mode->bindings->length; ++i) {
+		const char* command = *binding = mode->bindings->items[i]->command;
+	    list_t *args = split_string(command, " ");
+
+        if (strcmp("workspace", args->items[0]) == 0 && args->length > 2) {
+            const char* target = args->items[1];
+
+            while (*target == ' ' || *target == '\t')
+                target++; 
+
+            // Make sure that the command references an actual workspace
+            // not a command about workspaces
+            if (strcmp(target, "next") == 0 ||
+                strcmp(target, "prev") == 0 ||
+                strcmp(target, "next_on_output") == 0 ||
+                strcmp(target, "prev_on_output") == 0 ||
+                strcmp(target, "number") == 0 ||
+                strcmp(target, "back_and_forth") == 0 ||
+                strcmp(target, "current") == 0)
+                continue;
+           
+            //Make sure that the workspace doesn't already exist 
+            if (workspace_find_by_name(args->items[2]))
+               continue; 
+
+            return args->items[2];        
+        }
+    }
+    // As a fall back, get the current number of active workspaces
+    // and return that + 1 for the next workspace's name
+	int ws_num = root_container.children->length;
 	if (ws_num >= 10) {
 		l = 2;
 	} else if (ws_num >= 100) {

--- a/sway/workspace.c
+++ b/sway/workspace.c
@@ -6,22 +6,27 @@
 #include "list.h"
 #include "log.h"
 #include "container.h"
+#include "config.h"
+#include "stringop.h"
 
 swayc_t *active_workspace = NULL;
 
-int ws_num = 1;
-
 char *workspace_next_name(void) {
+	sway_log(L_DEBUG, "Workspace: Generating new name");
 	int i;
+    int l = 1;
     // Scan all workspace bindings to find the next available workspace name,
     // if none are found/available then default to a number
 	struct sway_mode *mode = config->current_mode;
 
 	for (i = 0; i < mode->bindings->length; ++i) {
-		const char* command = *binding = mode->bindings->items[i]->command;
+		struct sway_binding *binding = mode->bindings->items[i];
+		const char* command = binding->command;
 	    list_t *args = split_string(command, " ");
+	    sway_log(L_DEBUG, "Workspace: Checking name '%s'", command);
 
-        if (strcmp("workspace", args->items[0]) == 0 && args->length > 2) {
+        if (strcmp("workspace", args->items[0]) == 0 && args->length > 1) {
+	        sway_log(L_DEBUG, "Got valid workspace command for target: '%s'", args->items[1]);
             const char* target = args->items[1];
 
             while (*target == ' ' || *target == '\t')
@@ -39,11 +44,10 @@ char *workspace_next_name(void) {
                 continue;
            
             //Make sure that the workspace doesn't already exist 
-            if (workspace_find_by_name(args->items[2]))
+            if (workspace_find_by_name(args->items[1]))
                continue; 
 
-            return args->items[2];        
-        }
+            return args->items[1];        }
     }
     // As a fall back, get the current number of active workspaces
     // and return that + 1 for the next workspace's name


### PR DESCRIPTION
Workspace names are now generated by scanning for bindsyms which execute "workspace [workspace name]", with a fallback option to use the number of currently active workspaces + 1.
In addition, a command queue has been implemented to allow for the configuration file to be loaded prior to initializing wlc. Upon initialization, all queued commands will be executed.