### PR TITLE
split workspace bug

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -237,7 +237,7 @@ static bool _do_split(struct sway_config *config, int argc, char **argv, int lay
 	swayc_t *focused = get_focused_container(&root_container);
 	if (focused->type == C_WORKSPACE) {
 		sway_log(L_DEBUG, "Dont split workspaces");
-		if(focused->children->length == 0) {
+		if (focused->children->length == 0) {
 			focused->layout = layout;
 		}
 		return true;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -235,6 +235,10 @@ static bool _do_split(struct sway_config *config, int argc, char **argv, int lay
 		return false;
 	}
 	swayc_t *focused = get_focused_container(&root_container);
+	if (focused->type == C_WORKSPACE) {
+		sway_log(L_DEBUG, "Dont split workspaces");
+		return true;
+	}
 	swayc_t *parent = focused->parent;
 	sway_log(L_DEBUG, "Splitting %p vertically with %p", parent, focused);
 	int index = remove_container_from_parent(parent, focused);

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -237,6 +237,9 @@ static bool _do_split(struct sway_config *config, int argc, char **argv, int lay
 	swayc_t *focused = get_focused_container(&root_container);
 	if (focused->type == C_WORKSPACE) {
 		sway_log(L_DEBUG, "Dont split workspaces");
+		if(focused->children->length == 0) {
+			focused->layout = layout;
+		}
 		return true;
 	}
 	swayc_t *parent = focused->parent;


### PR DESCRIPTION
splitting a empty workspace would put it in a container which we dont want,
now changes layout of workspace.

splitting would do this `(Root (Output (container (... (workspace (...)))))`

hope this merges with the other pr, if it doesnt ill just wait and re add it.