### PR TITLE
set maximize flag for handled views

### DIFF
--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -86,7 +86,6 @@ static void handle_output_focused(wlc_handle output, bool focus) {
 }
 
 static bool handle_view_created(wlc_handle handle) {
-
 	swayc_t *focused = get_focused_container(&root_container);
 	swayc_t *view = new_view(focused, handle);
 	if (view) {

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -86,9 +86,13 @@ static void handle_output_focused(wlc_handle output, bool focus) {
 }
 
 static bool handle_view_created(wlc_handle handle) {
+
 	swayc_t *focused = get_focused_container(&root_container);
 	swayc_t *view = new_view(focused, handle);
 	if (view) {
+		//Set maximize flag for windows.
+		//TODO: floating windows have this unset
+		wlc_view_set_state(handle, WLC_BIT_MAXIMIZED, true);
 		unfocus_all(&root_container);
 		focus_view(view);
 		arrange_windows(view->parent, -1, -1);


### PR DESCRIPTION
very small update.

as i used weston-terminal to test, the gaps were bothering me, and i thought of this.
when implementing floating windows later this should be unset for them.