### PR TITLE
get/set_userdata stores swayc_t *, fixed memory leak, minor changes.

### DIFF
--- a/sway/container.c
+++ b/sway/container.c
@@ -54,8 +54,10 @@ swayc_t *new_output(wlc_handle handle) {
 	output->height = size->h;
 	output->handle = handle;
 
-	add_child(&root_container, output);
+	//link this to handler
+	wlc_handle_set_user_data(handle, output);
 
+	add_child(&root_container, output);
 	//TODO something with this
 	int total_width = 0;
 	container_map(&root_container, add_output_widths, &total_width);
@@ -138,6 +140,8 @@ swayc_t *new_view(swayc_t *sibling, wlc_handle handle) {
 	view->name = strdup(title);
 	view->visible = true;
 
+	//Link view to handle
+	wlc_handle_set_user_data(handle, view);
 	//Case of focused workspace, just create as child of it
 	if (sibling->type == C_WORKSPACE) {
 		add_child(sibling, view);

--- a/sway/container.c
+++ b/sway/container.c
@@ -31,6 +31,9 @@ static void free_swayc(swayc_t *c) {
 		}
 		remove_child(c->parent, c);
 	}
+	if (c->name) {
+		free(c->name);
+	}
 	free(c);
 }
 

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -88,21 +88,21 @@ static void handle_output_focused(wlc_handle output, bool focus) {
 static bool handle_view_created(wlc_handle handle) {
 	swayc_t *focused = get_focused_container(&root_container);
 	swayc_t *view = new_view(focused, handle);
+	//Leave unamanaged windows alone
 	if (view) {
-		//Set maximize flag for windows.
-		//TODO: floating windows have this unset
-		wlc_view_set_state(handle, WLC_BIT_MAXIMIZED, true);
-		unfocus_all(&root_container);
-		focus_view(view);
 		arrange_windows(view->parent, -1, -1);
-	} else { //Unmanaged view
+		wlc_view_set_state(handle, WLC_BIT_MAXIMIZED, true);
+		if (!(wlc_view_get_state(focused->handle) & WLC_BIT_FULLSCREEN)) {
+			unfocus_all(&root_container);
+			focus_view(view);
+		}
+		else {
+			wlc_view_set_state(handle, WLC_BIT_ACTIVATED, true);
+			wlc_view_focus(handle);
+		}
+	} else {
 		wlc_view_set_state(handle, WLC_BIT_ACTIVATED, true);
 		wlc_view_focus(handle);
-	}
-	if (wlc_view_get_state(focused->handle) & WLC_BIT_FULLSCREEN) {
-		unfocus_all(&root_container);
-		focus_view(focused);
-		arrange_windows(focused, -1, -1);
 	}
 	return true;
 }

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -69,7 +69,7 @@ static void handle_output_destroyed(wlc_handle output) {
 
 static void handle_output_resolution_change(wlc_handle output, const struct wlc_size *from, const struct wlc_size *to) {
 	sway_log(L_DEBUG, "Output %d resolution changed to %d x %d", output, to->w, to->h);
-	swayc_t *c = get_swayc_for_handle(output, &root_container);
+	swayc_t *c = wlc_handle_get_user_data(output);
 	if (!c) return;
 	c->width = to->w;
 	c->height = to->h;
@@ -77,7 +77,7 @@ static void handle_output_resolution_change(wlc_handle output, const struct wlc_
 }
 
 static void handle_output_focused(wlc_handle output, bool focus) {
-	swayc_t *c = get_swayc_for_handle(output, &root_container);
+	swayc_t *c = wlc_handle_get_user_data(output);
 	if (!c) return;
 	if (focus) {
 		unfocus_all(&root_container);
@@ -109,7 +109,7 @@ static bool handle_view_created(wlc_handle handle) {
 
 static void handle_view_destroyed(wlc_handle handle) {
 	sway_log(L_DEBUG, "Destroying window %d", handle);
-	swayc_t *view = get_swayc_for_handle(handle, &root_container);
+	swayc_t *view = wlc_handle_get_user_data(handle);
 	swayc_t *parent;
 	swayc_t *focused = get_focused_container(&root_container);
 

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -215,10 +215,10 @@ swayc_t *get_swayc_for_handle(wlc_handle handle, swayc_t *parent) {
 }
 
 swayc_t *get_focused_container(swayc_t *parent) {
-	if (parent->focused == NULL) {
-		return parent;
+	while (parent->focused) {
+		parent = parent->focused;
 	}
-	return get_focused_container(parent->focused);
+	return parent;
 }
 
 void unfocus_all(swayc_t *container) {

--- a/sway/log.h
+++ b/sway/log.h
@@ -1,6 +1,10 @@
 #ifndef _SWAY_LOG_H
 #define _SWAY_LOG_H
 
+#ifndef __GNUC__
+#  define  __attribute__(x)
+#endif
+
 typedef enum {
 	L_SILENT = 0,
 	L_ERROR = 1,
@@ -8,9 +12,10 @@ typedef enum {
 	L_DEBUG = 3,
 } log_importance_t;
 
+
 void init_log(int verbosity);
 void sway_log_colors(int mode);
-void sway_log(int verbosity, char* format, ...);
-void sway_abort(char* format, ...);
+void sway_log(int verbosity, char* format, ...)__attribute__((format (printf,2,3)));
+void sway_abort(char* format, ...) __attribute__((format (printf,1,2)));
 
 #endif

--- a/sway/stringop.c
+++ b/sway/stringop.c
@@ -68,7 +68,6 @@ list_t *split_string(const char *str, const char *delims) {
 				j++;
 				i++;
 			}
-			free(left);
 		}
 	}
 	return res;

--- a/sway/stringop.c
+++ b/sway/stringop.c
@@ -67,6 +67,7 @@ list_t *split_string(const char *str, const char *delims) {
 				j++;
 				i++;
 			}
+			free(left);
 		}
 	}
 	return res;

--- a/sway/stringop.c
+++ b/sway/stringop.c
@@ -53,8 +53,9 @@ char *strip_comments(char *str) {
 list_t *split_string(const char *str, const char *delims) {
 	list_t *res = create_list();
 	int i, j;
-	for (i = 0, j = 0; i < strlen(str) + 1; ++i) {
-		if (strchr(delims, str[i]) || i == strlen(str)) {
+	int len = strlen(str);
+	for (i = 0, j = 0; i < len + 1; ++i) {
+		if (strchr(delims, str[i]) || i == len) {
 			if (i - j == 0) {
 				continue;
 			}
@@ -63,7 +64,7 @@ list_t *split_string(const char *str, const char *delims) {
 			left[i - j] = 0;
 			list_add(res, left);
 			j = i + 1;
-			while (j <= strlen(str) && str[j] && strchr(delims, str[j])) {
+			while (j <= len && str[j] && strchr(delims, str[j])) {
 				j++;
 				i++;
 			}
@@ -111,39 +112,43 @@ int unescape_string(char *string) {
 	for (i = 0; string[i]; ++i) {
 		if (string[i] == '\\') {
 			--len;
+			int shift = 0;
 			switch (string[++i]) {
 			case '0':
 				string[i - 1] = '\0';
-				memmove(string + i, string + i + 1, len - i);
+				shift = 1;
 				break;
 			case 'a':
 				string[i - 1] = '\a';
-				memmove(string + i, string + i + 1, len - i);
+				shift = 1;
 				break;
 			case 'b':
 				string[i - 1] = '\b';
-				memmove(string + i, string + i + 1, len - i);
+				shift = 1;
 				break;
 			case 't':
 				string[i - 1] = '\t';
-				memmove(string + i, string + i + 1, len - i);
+				shift = 1;
 				break;
 			case 'n':
 				string[i - 1] = '\n';
-				memmove(string + i, string + i + 1, len - i);
+				shift = 1;
 				break;
 			case 'v':
 				string[i - 1] = '\v';
-				memmove(string + i, string + i + 1, len - i);
+				shift = 1;
 				break;
 			case 'f':
 				string[i - 1] = '\f';
-				memmove(string + i, string + i + 1, len - i);
+				shift = 1;
 				break;
 			case 'r':
 				string[i - 1] = '\r';
-				memmove(string + i, string + i + 1, len - i);
+				shift = 1;
 				break;
+			}
+			if (shift) {
+				memmove(string + i, string + i + shift, len - i);
 			}
 		}
 	}

--- a/sway/workspace.c
+++ b/sway/workspace.c
@@ -26,7 +26,7 @@ char *workspace_next_name(void) {
 		list_t *args = split_string(command, " ");
 
 		if (strcmp("workspace", args->items[0]) == 0 && args->length > 1) {
-			sway_log(L_DEBUG, "Got valid workspace command for target: '%s'", args->items[1]);
+			sway_log(L_DEBUG, "Got valid workspace command for target: '%s'", (char *)args->items[1]);
 			char* target = malloc(strlen(args->items[1]) + 1);
 			strcpy(target, args->items[1]);
 			while (*target == ' ' || *target == '\t')


### PR DESCRIPTION
using `get/set_userdata` to store swayc_t * container for handle.
fixed leaking container names.
`get_focused` is now iterative insteda of recursive
added format attributes to logs, 
reduced code duplication in `unescape_strings` and can more easily add fancy escape codes.
in `split_string` strlen is now only called once instead of all over the place.