### PR TITLE
fixed split [vh], small memory leak, unescape_strings handle \xnn

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -285,9 +285,9 @@ static bool cmd_split(struct sway_config *config, int argc, char **argv) {
 		return false;
 	}
 	if (strcasecmp(argv[0], "v") == 0 || strcasecmp(argv[0], "vertical") == 0) {
-		_do_split(config, argc, argv, L_VERT);
+		_do_split(config, argc - 1, argv + 1, L_VERT);
 	} else if (strcasecmp(argv[0], "h") == 0 || strcasecmp(argv[0], "horizontal") == 0) {
-		_do_split(config, argc, argv, L_HORIZ);
+		_do_split(config, argc - 1, argv + 1, L_HORIZ);
 	} else {
 		sway_log(L_ERROR, "Invalid split command (expected either horiziontal or vertical).");
 		return false;

--- a/sway/container.c
+++ b/sway/container.c
@@ -31,6 +31,9 @@ static void free_swayc(swayc_t *c) {
 		}
 		remove_child(c->parent, c);
 	}
+	if (c->name) {
+		free(c->name);
+	}
 	free(c);
 }
 

--- a/sway/stringop.c
+++ b/sway/stringop.c
@@ -53,8 +53,9 @@ char *strip_comments(char *str) {
 list_t *split_string(const char *str, const char *delims) {
 	list_t *res = create_list();
 	int i, j;
-	for (i = 0, j = 0; i < strlen(str) + 1; ++i) {
-		if (strchr(delims, str[i]) || i == strlen(str)) {
+	int len = strlen(str);
+	for (i = 0, j = 0; i < len + 1; ++i) {
+		if (strchr(delims, str[i]) || i == len) {
 			if (i - j == 0) {
 				continue;
 			}
@@ -63,7 +64,7 @@ list_t *split_string(const char *str, const char *delims) {
 			left[i - j] = 0;
 			list_add(res, left);
 			j = i + 1;
-			while (j <= strlen(str) && str[j] && strchr(delims, str[j])) {
+			while (j <= len && str[j] && strchr(delims, str[j])) {
 				j++;
 				i++;
 			}
@@ -110,40 +111,72 @@ int unescape_string(char *string) {
 	for (i = 0; string[i]; ++i) {
 		if (string[i] == '\\') {
 			--len;
+			int shift = 0;
 			switch (string[++i]) {
 			case '0':
 				string[i - 1] = '\0';
-				memmove(string + i, string + i + 1, len - i);
+				shift = 1;
 				break;
 			case 'a':
 				string[i - 1] = '\a';
-				memmove(string + i, string + i + 1, len - i);
+				shift = 1;
 				break;
 			case 'b':
 				string[i - 1] = '\b';
-				memmove(string + i, string + i + 1, len - i);
-				break;
-			case 't':
-				string[i - 1] = '\t';
-				memmove(string + i, string + i + 1, len - i);
-				break;
-			case 'n':
-				string[i - 1] = '\n';
-				memmove(string + i, string + i + 1, len - i);
-				break;
-			case 'v':
-				string[i - 1] = '\v';
-				memmove(string + i, string + i + 1, len - i);
+				shift = 1;
 				break;
 			case 'f':
 				string[i - 1] = '\f';
-				memmove(string + i, string + i + 1, len - i);
+				shift = 1;
+				break;
+			case 'n':
+				string[i - 1] = '\n';
+				shift = 1;
 				break;
 			case 'r':
 				string[i - 1] = '\r';
-				memmove(string + i, string + i + 1, len - i);
+				shift = 1;
 				break;
+			case 't':
+				string[i - 1] = '\t';
+				shift = 1;
+				break;
+			case 'v':
+				string[i - 1] = '\v';
+				shift = 1;
+				break;
+			case '\\':
+				shift = 1;
+				break;
+			case '\'':
+				string[i - 1] = '\'';
+				shift = 1;
+				break;
+			case '\"':
+				string[i - 1] = '\"';
+				shift = 1;
+				break;
+			case '?':
+				string[i - 1] = '?';
+				shift = 1;
+				break;
+			case 'x':
+				{
+					unsigned char c = 0;
+					shift = 1;
+					if (string[i+1] >= '0' && string[i+1] <= '9') {
+						shift = 2;
+						c = string[i+1] - '0';
+						if (string[i+2] >= '0' && string[i+2] <= '9') {
+							shift = 3;
+							c *= 0x10;
+							c += string[i+2] - '0';
+						}
+					}
+					string[i - 1] = c;
+				}
 			}
+			memmove(string + i, string + i + shift, len - i);
 		}
 	}
 	return len;


### PR DESCRIPTION
split vh was passing unaltered arugments into _do_split which wanted no arguments.
frees container names now.
unescape handles a few more things `\'` `\"` `\xnn` `\\`