### PR TITLE
fixed when views dont have names.

### DIFF
--- a/sway/container.c
+++ b/sway/container.c
@@ -54,9 +54,7 @@ swayc_t *new_output(wlc_handle handle) {
 	output->width = size->w;
 	output->height = size->h;
 	output->handle = handle;
-	if (name) {
-		output->name = strdup(name);
-	}
+	output->name = name ? strdup(name) : NULL;
 
 	add_child(&root_container, output);
 
@@ -95,7 +93,7 @@ swayc_t *new_container(swayc_t *child, enum swayc_layouts layout) {
 	cont->layout = layout;
 	cont->width = child->width;
 	cont->height = child->height;
-	cont->x	= child->x;
+	cont->x = child->x;
 	cont->y = child->y;
 	cont->visible = child->visible;
 
@@ -132,7 +130,7 @@ swayc_t *new_view(swayc_t *sibling, wlc_handle handle) {
 		(unsigned int)handle, title, sibling, sibling?sibling->type:0);
 	//Setup values
 	view->handle = handle;
-	view->name = strdup(title);
+	view->name = title ? strdup(title) : NULL;
 	view->visible = true;
 
 	view->desired_width = -1;
@@ -159,7 +157,7 @@ swayc_t *new_floating_view(wlc_handle handle) {
 		(unsigned int)handle, title);
 	//Setup values
 	view->handle = handle;
-	view->name = strdup(title);
+	view->name = title ? strdup(title) : NULL;
 	view->visible = true;
 
 	// Set the geometry of the floating view

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -104,6 +104,7 @@ static bool handle_view_created(wlc_handle handle) {
 		// Float popups
 		if (type & WLC_BIT_POPUP) {
 			swayc_t *view = new_floating_view(handle);
+			wlc_view_set_state(handle, WLC_BIT_MAXIMIZED, false);
 			focus_view(view);
 			arrange_windows(active_workspace, -1, -1);
 		}
@@ -136,12 +137,16 @@ static void handle_view_destroyed(wlc_handle handle) {
 			focus_view(focus_pointer());
 			arrange_windows(active_workspace, -1, -1);
 			return;
-		} 
+		}
 
 		if (type & WLC_BIT_OVERRIDE_REDIRECT) {
 			focus_view(focus_pointer());
 			arrange_windows(active_workspace, -1, -1);
 			return;
+		}
+		if (type & WLC_BIT_POPUP) {
+			swayc_t *view = get_swayc_for_handle(handle, &root_container);
+			destroy_view(view);
 		}
 	}
 	swayc_t *view = get_swayc_for_handle(handle, &root_container);


### PR DESCRIPTION
would try to duplicate windows with no name, and crash it. (context menus and whatnot)
theres probably a lot more to fix and change, ill look through it some more later.

but for now, a quick fix.