### PR TITLE
Fix inline comments in the config file.

### DIFF
--- a/sway/config.c
+++ b/sway/config.c
@@ -190,6 +190,7 @@ bool read_config(FILE *file, bool is_active) {
 		char *line = read_line(file);
 		line = strip_whitespace(line, &_);
 		line = strip_comments(line);
+		line = strip_whitespace(line, &_);
 		if (!line[0]) {
 			goto _continue;
 		}

--- a/sway/stringop.c
+++ b/sway/stringop.c
@@ -40,7 +40,7 @@ char *strip_comments(char *str) {
 		} else if (str[i] == '\'' && !in_string) {
 			in_character = !in_character;
 		} else if (!in_character && !in_string) {
-			if (str[i] == '#' && i == 0) {
+			if (str[i] == '#') {
 				str[i] = '\0';
 				break;
 			}


### PR DESCRIPTION
This fixes inline comments in the config file.

These are present in the default /etc/sway/config:

```
set $mod Mod4       # Logo key. Use Mod1 for Alt.
```

Which breaks all shortcuts

See issue #60 