### PR TITLE
disable tilde subscripting to fix manpage

### DIFF
--- a/sway.1.txt
+++ b/sway.1.txt
@@ -1,6 +1,8 @@
 /////
 vim:set ts=4 sw=4 tw=82 noet:
 /////
+:quotes.~:
+
 sway (1)
 ========
 


### PR DESCRIPTION
Asciidoc uses tildes to subscript and carets to superscript text.
The first tilde can be escaped to fix this, but looks weird because
the second tilde may not be escaped.

It doesn't seem like subscripting will be used in the man page so it
makes sense to disable it altogether.