### PR TITLE
restored fullscreen/focus behavior

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -408,7 +408,7 @@ static bool cmd_fullscreen(struct sway_config *config, int argc, char **argv) {
 		return false;
 	}
 
-	swayc_t *container = get_focused_container(&root_container);
+	swayc_t *container = get_focused_view(&root_container);
 	bool current = (wlc_view_get_state(container->handle) & WLC_BIT_FULLSCREEN) > 0;
 	wlc_view_set_state(container->handle, WLC_BIT_FULLSCREEN, !current);
 	//Resize workspace if going from  fullscreen -> notfullscreen

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -1,11 +1,12 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <wlc/wlc.h>
-#include "list.h"
-#include "log.h"
 #include "layout.h"
+#include "log.h"
+#include "list.h"
 #include "container.h"
 #include "workspace.h"
+#include "focus.h"
 
 swayc_t root_container;
 
@@ -79,9 +80,10 @@ swayc_t *remove_child(swayc_t *child) {
 			}
 		}
 	}
+	//Set focused to new container
 	if (parent->focused == child) {
 		if (parent->children->length > 0) {
-			parent->focused = parent->children->items[i?i-1:0];
+			set_focused_container_for(parent, parent->children->items[i?i-1:0]);
 		} else {
 			parent->focused = NULL;
 		}
@@ -209,26 +211,42 @@ void arrange_windows(swayc_t *container, int width, int height) {
 	if (container->type == C_WORKSPACE) {
 		for (i = 0; i < container->floating->length; ++i) {
 			swayc_t *view = container->floating->items[i];
-			// Set the geometry
-			struct wlc_geometry geometry = {
-				.origin = {
-					.x = view->x,
-					.y = view->y
-				},
-				.size = {
-					.w = view->width,
-					.h = view->height
+			if (view->type == C_VIEW) {
+				// Set the geometry
+				struct wlc_geometry geometry = {
+					.origin = {
+						.x = view->x,
+						.y = view->y
+					},
+					.size = {
+						.w = view->width,
+						.h = view->height
+					}
+				};
+				if (wlc_view_get_state(view->handle) & WLC_BIT_FULLSCREEN) {
+					swayc_t *parent = view;
+					while (parent->type != C_OUTPUT) {
+						parent = parent->parent;
+					}
+					geometry.origin.x = 0;
+					geometry.origin.y = 0;
+					geometry.size.w = parent->width;
+					geometry.size.h = parent->height;
+					wlc_view_set_geometry(view->handle, &geometry);
+					wlc_view_bring_to_front(view->handle);
+				} else {
+					wlc_view_set_geometry(view->handle, &geometry);
+					view->width = width;
+					view->height = height;
+					// Bring the views to the front in order of the list, the list
+					// will be kept up to date so that more recently focused views
+					// have higher indexes
+					// This is conditional on there not being a fullscreen view in the workspace
+					if (!container->focused
+							|| !(wlc_view_get_state(container->focused->handle) & WLC_BIT_FULLSCREEN)) {
+						wlc_view_bring_to_front(view->handle);
+					}
 				}
-			};
-			wlc_view_set_geometry(view->handle, &geometry);
-
-			// Bring the views to the front in order of the list, the list
-			// will be kept up to date so that more recently focused views
-			// have higher indexes
-			// This is conditional on there not being a fullscreen view in the workspace
-			if (!container->focused
-				|| !(wlc_view_get_state(container->focused->handle) & WLC_BIT_FULLSCREEN)) {
-				wlc_view_bring_to_front(view->handle);
 			}
 		}
 	}

--- a/sway/workspace.c
+++ b/sway/workspace.c
@@ -178,43 +178,37 @@ void workspace_switch(swayc_t *workspace) {
 		return;
 	}
 	sway_log(L_DEBUG, "Switching to workspace %p:%s", workspace, workspace->name);
-
-	// Remove focus from current view
-	swayc_t *current = get_focused_view(&root_container);
-	if (current && current->type == C_VIEW) {
-		wlc_view_set_state(current->handle, WLC_BIT_ACTIVATED, false);
-	}
-
-	set_focused_container(workspace);
+	set_focused_container(get_focused_view(workspace));
+	arrange_windows(workspace, -1, -1);
 	active_workspace = workspace;
 }
 
 /* XXX:DEBUG:XXX */
 static void container_log(const swayc_t *c) {
 	fprintf(stderr, "focus:%c|",
-		c->is_focused ? 'F' : //Focused
-		c == active_workspace ? 'W' : //active workspace
-		c == &root_container  ? 'R' : //root
-		'X');//not any others
+			c->is_focused ? 'F' : //Focused
+			c == active_workspace ? 'W' : //active workspace
+			c == &root_container  ? 'R' : //root
+			'X');//not any others
 	fprintf(stderr,"(%p)",c);
 	fprintf(stderr,"(p:%p)",c->parent);
 	fprintf(stderr,"(f:%p)",c->focused);
 	fprintf(stderr,"(h:%ld)",c->handle);
 	fprintf(stderr,"Type:");
 	fprintf(stderr,
-		c->type == C_ROOT   ? "Root|" :
-		c->type == C_OUTPUT ? "Output|" :
-		c->type == C_WORKSPACE ? "Workspace|" :
-		c->type == C_CONTAINER ? "Container|" :
-		c->type == C_VIEW   ? "View|" : "Unknown|");
+			c->type == C_ROOT   ? "Root|" :
+			c->type == C_OUTPUT ? "Output|" :
+			c->type == C_WORKSPACE ? "Workspace|" :
+			c->type == C_CONTAINER ? "Container|" :
+			c->type == C_VIEW   ? "View|" : "Unknown|");
 	fprintf(stderr,"layout:");
 	fprintf(stderr,
-		c->layout == L_NONE ? "NONE|" :
-		c->layout == L_HORIZ ? "Horiz|":
-		c->layout == L_VERT ? "Vert|":
-		c->layout == L_STACKED  ? "Stacked|":
-		c->layout == L_FLOATING ? "Floating|":
-								  "Unknown|");
+			c->layout == L_NONE ? "NONE|" :
+			c->layout == L_HORIZ ? "Horiz|":
+			c->layout == L_VERT ? "Vert|":
+			c->layout == L_STACKED  ? "Stacked|":
+			c->layout == L_FLOATING ? "Floating|":
+			"Unknown|");
 	fprintf(stderr, "w:%d|h:%d|", c->width, c->height);
 	fprintf(stderr, "x:%d|y:%d|", c->x, c->y);
 	fprintf(stderr, "vis:%c|", c->visible?'t':'f');
@@ -223,30 +217,24 @@ static void container_log(const swayc_t *c) {
 	fprintf(stderr, "children:%d\n",c->children?c->children->length:0);
 }
 void layout_log(const swayc_t *c, int depth) {
-	int i;
-	int e = c->children?c->children->length:0;
-	for (i = 0; i < depth; ++i) fputc(' ', stderr);
+	int i, d;
+	int e = c->children ? c->children->length : 0;
 	container_log(c);
 	if (e) {
-		for (i = 0; i < depth; ++i) fputc(' ', stderr);
-		fprintf(stderr,"(\n");
 		for (i = 0; i < e; ++i) {
+			fputc('|',stderr);
+			for (d = 0; d < depth; ++d) fputc('-', stderr);
 			layout_log(c->children->items[i], depth + 1);
 		}
-		for (i = 0; i < depth; ++i) fputc(' ', stderr);
-		fprintf(stderr,")\n");
 	}
 	if (c->type == C_WORKSPACE) {
 		e = c->floating?c->floating->length:0;
-		for (i = 0; i < depth; ++i) fputc(' ', stderr);
 		if (e) {
-			for (i = 0; i < depth; ++i) fputc(' ', stderr);
-			fprintf(stderr,"(\n");
 			for (i = 0; i < e; ++i) {
+				fputc('|',stderr);
+				for (d = 0; d < depth; ++d) fputc('-', stderr);
 				layout_log(c->floating->items[i], depth + 1);
 			}
-			for (i = 0; i < depth; ++i) fputc(' ', stderr);
-			fprintf(stderr,")\n");
 		}
 	}
 }


### PR DESCRIPTION
fullscreen behaviour is restored.
wont change focus randomly, keeps view set to fullscreen when switching workspaces and back.

floating windows behave properly with fullscreen now.

also changed layout_log, its neater now.
