### PR TITLE
Added in proper focus handling for floating containers.

### DIFF
--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -60,9 +60,7 @@ swayc_t *container_under_pointer(void) {
 			i = len = lookup->floating->length;
 			bool got_floating = false;
 			while (--i > -1) {
-				sway_log(L_DEBUG, "Checking index %d of floating items", i);
 				if (pointer_test(lookup->floating->items[i], &mouse_origin)) {
-					sway_log(L_DEBUG, "Got hit for floatin on %d", i);
 					lookup = lookup->floating->items[i];
 					got_floating = true;
 					break;
@@ -75,7 +73,6 @@ swayc_t *container_under_pointer(void) {
 		// search children
 		len = lookup->children->length;
 		for (i = 0; i < len; ++i) {
-			sway_log(L_DEBUG, "Checking index %d of standard children", i);
 			if (pointer_test(lookup->children->items[i], &mouse_origin)) {
 				lookup = lookup->children->items[i];
 				break;


### PR DESCRIPTION
The change to `container_under_pointer` reverses the order in which the floating list is traversed so that focus order is preserved. The change to `handle_pointer_button` makes it so that if a user clicks on a floating window, it's brought above all other floating windows.