### PR TITLE
added sway_assert function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ project(sway C)
 set(CMAKE_C_FLAGS "-g")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "bin/")
 add_definitions("-Wall")
-set(CMAKE_BUILD_TYPE Debug)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/CMake)
 
 find_package(XKBCommon REQUIRED)

--- a/include/log.h
+++ b/include/log.h
@@ -1,5 +1,6 @@
 #ifndef _SWAY_LOG_H
 #define _SWAY_LOG_H
+#include <stdbool.h>
 
 typedef enum {
 	L_SILENT = 0,
@@ -10,7 +11,8 @@ typedef enum {
 
 void init_log(int verbosity);
 void sway_log_colors(int mode);
-void sway_log(int verbosity, char* format, ...) __attribute__((format(printf,2,3)));
-void sway_abort(char* format, ...)__attribute__((format(printf,1,2)));
+void sway_log(int verbosity, const char* format, ...) __attribute__((format(printf,2,3)));
+void sway_abort(const char* format, ...) __attribute__((format(printf,1,2)));
+bool sway_assert(bool condition, const char* format, ...) __attribute__((format(printf,2,3)));
 
 #endif

--- a/sway/log.c
+++ b/sway/log.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <signal.h>
 
 int colored = 1;
 int v = 0;
@@ -32,7 +33,7 @@ void sway_log_colors(int mode) {
 	colored = (mode == 1) ? 1 : 0;
 }
 
-void sway_abort(char *format, ...) {
+void sway_abort(const char *format, ...) {
 	fprintf(stderr, "ERROR: ");
 	va_list args;
 	va_start(args, format);
@@ -42,7 +43,7 @@ void sway_abort(char *format, ...) {
 	exit(1);
 }
 
-void sway_log(int verbosity, char* format, ...) {
+void sway_log(int verbosity, const char* format, ...) {
 	if (verbosity <= v) {
 		int c = verbosity;
 		if (c > sizeof(verbosity_colors) / sizeof(char *)) {
@@ -63,4 +64,21 @@ void sway_log(int verbosity, char* format, ...) {
 		}
 		fprintf(stderr, "\n");
 	}
+}
+
+bool sway_assert(bool condition, const char* format, ...) {
+	if (condition) {
+		return true;
+	}
+
+#ifndef NDEBUG
+	raise(SIGABRT);
+#endif
+
+	va_list args;
+	va_start(args, format);
+	sway_log(L_ERROR, format, args);
+	va_end(args);
+
+	return false;
 }


### PR DESCRIPTION
sway_assert returns false on a failed assertion in release mode and raises SIGABRT in debug mode

printing a backtrace in debug mode is unnecessary, expecting it to run in a debugger anyway.

also removed the static build type config from CMakeLists.txt because it prevents building in release mode.