### PR TITLE
Added in resize locking

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -240,7 +240,24 @@ static bool cmd_floating_mod(struct sway_config *config, int argc, char **argv) 
 	if (!checkarg(argc, "floating_modifier", EXPECTED_EQUAL_TO, 1)) {
 		return false;
 	}
-	config->floating_mod = xkb_keysym_from_name(argv[0], XKB_KEYSYM_CASE_INSENSITIVE);
+	int i, j;
+	list_t *split = split_string(argv[0], "+");
+	fprintf(stderr,"%s, %d,%d\n",argv[0], split->length,split->items);
+	config->floating_mod = 0;
+
+	//set modifer keys
+	for (i = 0; i < split->length; ++i) {
+		for (j = 0; j < sizeof(modifiers) / sizeof(struct modifier_key); ++j) {
+			if (strcasecmp(modifiers[j].name, split->items[i]) == 0) {
+				config->floating_mod |= modifiers[j].mod;
+			}
+		}
+	}
+	list_free(split);
+	if (!config->floating_mod) {
+		sway_log(L_ERROR, "bindsym - unknown keys %s", argv[0]);
+		return false;
+	}
 	return true;
 }
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -242,7 +242,6 @@ static bool cmd_floating_mod(struct sway_config *config, int argc, char **argv) 
 	}
 	int i, j;
 	list_t *split = split_string(argv[0], "+");
-	fprintf(stderr,"%s, %d,%d\n",argv[0], split->length,split->items);
 	config->floating_mod = 0;
 
 	//set modifer keys

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -388,15 +388,13 @@ static bool handle_pointer_motion(wlc_handle handle, uint32_t time, const struct
 			int midway_x = view->x + view->width/2;
 			int midway_y = view->y + view->height/2;
 			if (dx < 0) {
-				if (mouse_origin.x > midway_x && !lock_right) {
+				if (!lock_right) {
 					if (view->width > min_sane_w) {
-						lock_left = true;
 						changed_floating = true;
 						view->width += dx;
 						edge += WLC_RESIZE_EDGE_RIGHT;
 					}
 				} else if (mouse_origin.x < midway_x && !lock_left) {
-					lock_right = true;
 					changed_floating = true;
 					view->x += dx;
 					view->width -= dx;
@@ -404,16 +402,11 @@ static bool handle_pointer_motion(wlc_handle handle, uint32_t time, const struct
 				}
 			} else if (dx > 0){
 				if (mouse_origin.x > midway_x && !lock_right) {
-					lock_left = true;
 					changed_floating = true;
 					view->width += dx;
 					edge += WLC_RESIZE_EDGE_RIGHT;
+				} else if (!lock_left) {
 					if (view->width > min_sane_w) {
-						lock_left = false;
-					}
-				} else if (mouse_origin.x < midway_x && !lock_left) {
-					if (view->width > min_sane_w) {
-						lock_right = true;
 						changed_floating = true;
 						view->x += dx;
 						view->width -= dx;
@@ -423,15 +416,13 @@ static bool handle_pointer_motion(wlc_handle handle, uint32_t time, const struct
 			}
 
 			if (dy < 0) {
-				if (mouse_origin.y > midway_y && !lock_bottom) {
+				if (!lock_bottom) {
 					if (view->height > min_sane_h) {
-						lock_top = true;
 						changed_floating = true;
 						view->height += dy;
 						edge += WLC_RESIZE_EDGE_BOTTOM;
 					}
 				} else if (mouse_origin.y < midway_y && !lock_top) {
-					lock_bottom = true;
 					changed_floating = true;
 					view->y += dy;
 					view->height -= dy;
@@ -439,13 +430,11 @@ static bool handle_pointer_motion(wlc_handle handle, uint32_t time, const struct
 				}
 			} else if (dy > 0) {
 				if (mouse_origin.y > midway_y && !lock_bottom) {
-					lock_top = true;
 					changed_floating = true;
 					view->height += dy;
 					edge += WLC_RESIZE_EDGE_BOTTOM;
-				} else if (mouse_origin.y < midway_y && !lock_top) {
+				} else if (!lock_top) {
 					if (view->height > min_sane_h) {
-						lock_bottom = true;
 						changed_floating = true;
 						view->y += dy;
 						view->height -= dy;
@@ -511,6 +500,12 @@ static bool handle_pointer_button(wlc_handle view, uint32_t time, const struct w
 			if (floating_mod_pressed()) {
 				dragging = m1_held;
 				resizing = m2_held;
+				int midway_x = pointer->x + pointer->width/2;
+				int midway_y = pointer->y + pointer->height/2;
+				lock_bottom = origin->y < midway_y;
+				lock_top = !lock_bottom;
+				lock_right = origin->x < midway_x;
+				lock_left = !lock_right;
 			}
 			//Dont want pointer sent to window while dragging or resizing
 			return (dragging || resizing);

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -15,7 +15,9 @@
 #include "focus.h"
 
 uint32_t keys_pressed[32];
+uint32_t key_modifiers;
 int keys_pressed_length = 0;
+
 
 static struct wlc_origin mouse_origin;
 
@@ -25,12 +27,7 @@ static bool m2_held = false;
 static bool resizing = false;
 
 static bool floating_mod_pressed(void) {
-	int i = 0;
-	while (i < keys_pressed_length) {
-		if (keys_pressed[i++] == config->floating_mod)
-			return true;
-	}
-	return false;
+	return key_modifiers & config->floating_mod;
 }
 
 static bool pointer_test(swayc_t *view, void *_origin) {
@@ -297,6 +294,7 @@ static bool handle_key(wlc_handle view, uint32_t time, const struct wlc_modifier
 		return false;
 	}
 	bool cmd_success = false;
+	key_modifiers = modifiers->mods;
 
 	struct sway_mode *mode = config->current_mode;
 	// Lowercase if necessary

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -25,6 +25,7 @@ static bool m1_held = false;
 static bool dragging = false;
 static bool m2_held = false;
 static bool resizing = false;
+static bool lock_left, lock_right, lock_top, lock_bottom = false;
 
 static bool floating_mod_pressed(void) {
 	return key_modifiers & config->floating_mod;
@@ -368,61 +369,89 @@ static bool handle_pointer_motion(wlc_handle handle, uint32_t time, const struct
 	// Do checks to determine if proper keys are being held
 	swayc_t *view = get_focused_view(active_workspace);
 	uint32_t edge = 0;
-	if (dragging && view && view->is_floating) {
-		int dx = mouse_origin.x - prev_pos.x;
-		int dy = mouse_origin.y - prev_pos.y;
-		view->x += dx;
-		view->y += dy;
-		changed_floating = true;
-	} else if (resizing && view && view->is_floating) {
-		int dx = mouse_origin.x - prev_pos.x;
-		int dy = mouse_origin.y - prev_pos.y;
-
-		// Move and resize the view based on the dx/dy and mouse position
-		int midway_x = view->x + view->width/2;
-		int midway_y = view->y + view->height/2;
-		if (dx < 0) {
+	if (dragging && view) {
+		if (view->is_floating) {
+			int dx = mouse_origin.x - prev_pos.x;
+			int dy = mouse_origin.y - prev_pos.y;
+			view->x += dx;
+			view->y += dy;
 			changed_floating = true;
-			if (mouse_origin.x > midway_x) {
-				view->width += dx;
-				edge += WLC_RESIZE_EDGE_RIGHT;
-			} else {
-				view->x += dx;
-				view->width -= dx;
-				edge += WLC_RESIZE_EDGE_LEFT;
-			}
-		} else if (dx > 0){
-			changed_floating = true;
-			if (mouse_origin.x > midway_x) {
-				view->width += dx;
-				edge += WLC_RESIZE_EDGE_RIGHT;
-			} else {
-				view->x += dx;
-				view->width -= dx;
-				edge += WLC_RESIZE_EDGE_LEFT;
-			}
 		}
+	} else if (resizing && view) {
+		if (view->is_floating) {
+			int dx = mouse_origin.x - prev_pos.x;
+			int dy = mouse_origin.y - prev_pos.y;
+			int min_sane_w = 100;
+			int min_sane_h = 60;
 
-		if (dy < 0) {
-			changed_floating = true;
-			if (mouse_origin.y > midway_y) {
-				view->height += dy;
-				edge += WLC_RESIZE_EDGE_BOTTOM;
-			} else {
-				view->y += dy;
-				view->height -= dy;
-				edge += WLC_RESIZE_EDGE_TOP;
+			// Move and resize the view based on the dx/dy and mouse position
+			int midway_x = view->x + view->width/2;
+			int midway_y = view->y + view->height/2;
+			if (dx < 0) {
+				if (mouse_origin.x > midway_x && !lock_right) {
+					if (view->width > min_sane_w) {
+						lock_left = true;
+						changed_floating = true;
+						view->width += dx;
+						edge += WLC_RESIZE_EDGE_RIGHT;
+					}
+				} else if (mouse_origin.x < midway_x && !lock_left) {
+					lock_right = true;
+					changed_floating = true;
+					view->x += dx;
+					view->width -= dx;
+					edge += WLC_RESIZE_EDGE_LEFT;
+				}
+			} else if (dx > 0){
+				if (mouse_origin.x > midway_x && !lock_right) {
+					lock_left = true;
+					changed_floating = true;
+					view->width += dx;
+					edge += WLC_RESIZE_EDGE_RIGHT;
+					if (view->width > min_sane_w) {
+						lock_left = false;
+					}
+				} else if (mouse_origin.x < midway_x && !lock_left) {
+					if (view->width > min_sane_w) {
+						lock_right = true;
+						changed_floating = true;
+						view->x += dx;
+						view->width -= dx;
+						edge += WLC_RESIZE_EDGE_LEFT;
+					}
+				}
 			}
-		} else if (dy > 0) {
-			changed_floating = true;
-			if (mouse_origin.y > midway_y) {
-				view->height += dy;
-				edge += WLC_RESIZE_EDGE_BOTTOM;
-			} else {
-				edge = WLC_RESIZE_EDGE_BOTTOM;
-				view->y += dy;
-				view->height -= dy;
-				edge += WLC_RESIZE_EDGE_TOP;
+
+			if (dy < 0) {
+				if (mouse_origin.y > midway_y && !lock_bottom) {
+					if (view->height > min_sane_h) {
+						lock_top = true;
+						changed_floating = true;
+						view->height += dy;
+						edge += WLC_RESIZE_EDGE_BOTTOM;
+					}
+				} else if (mouse_origin.y < midway_y && !lock_top) {
+					lock_bottom = true;
+					changed_floating = true;
+					view->y += dy;
+					view->height -= dy;
+					edge += WLC_RESIZE_EDGE_TOP;
+				}
+			} else if (dy > 0) {
+				if (mouse_origin.y > midway_y && !lock_bottom) {
+					lock_top = true;
+					changed_floating = true;
+					view->height += dy;
+					edge += WLC_RESIZE_EDGE_BOTTOM;
+				} else if (mouse_origin.y < midway_y && !lock_top) {
+					if (view->height > min_sane_h) {
+						lock_bottom = true;
+						changed_floating = true;
+						view->y += dy;
+						view->height -= dy;
+						edge += WLC_RESIZE_EDGE_TOP;
+					}
+				}
 			}
 		}
 	}
@@ -492,10 +521,12 @@ static bool handle_pointer_button(wlc_handle view, uint32_t time, const struct w
 		if (button == 272) {
 			m1_held = false;
 			dragging = false;
+			lock_top = lock_bottom = lock_left = lock_right = false;
 		}
 		if (button == 273) {
 			m2_held = false;
 			resizing = false;
+			lock_top = lock_bottom = lock_left = lock_right = false;
 		}
 	}
 	return false;


### PR DESCRIPTION
This adds in resize locks so that resizing functions more similarly to i3. Currently, if you shrink a window and move past the midway point, the window will begin to grow in the opposite direction. This is not how i3 works, so I've added in locks which prevent windows from having their opposite edge from being resized once one of the edges is changed. I've also established minimum sane height/width so to make sure that windows don't get too small when being resized.