### PR TITLE
Fixed config path

### DIFF
--- a/sway/config.c
+++ b/sway/config.c
@@ -63,7 +63,7 @@ void free_config(struct sway_config *config) {
 
 static const char *search_paths[] = {
 	"$home/.sway/config",
-	"$config/.sway/config",
+	"$config/sway/config",
 	"/etc/sway/config",
 	"$home/.i3/config",
 	"$config/.i3/config",


### PR DESCRIPTION
This extra period stopped sway from loading the user config file at ~/.config/sway/config. Instead the default file at /etc/sway/config was being loaded.