### PR TITLE
A couple of cppcheck issues

### DIFF
--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -290,8 +290,8 @@ static void handle_view_state_request(wlc_handle view, enum wlc_view_state_bit s
 		// i3 just lets it become fullscreen
 		wlc_view_set_state(view, state, toggle);
 		c = get_swayc_for_handle(view, &root_container);
-		sway_log(L_DEBUG, "setting view %ld %s, fullscreen %d", view, c->name, toggle);
 		if (c) {
+			sway_log(L_DEBUG, "setting view %ld %s, fullscreen %d", view, c->name, toggle);
 			arrange_windows(c->parent, -1, -1);
 			// Set it as focused window for that workspace if its going fullscreen
 			if (toggle) {

--- a/sway/log.c
+++ b/sway/log.c
@@ -19,10 +19,10 @@ static const char *verbosity_colors[] = {
 void init_log(int verbosity) {
 	v = verbosity;
 	/* set FD_CLOEXEC flag to prevent programs called with exec to write into logs */
-	int i, flag;
+	int i;
 	int fd[] = { STDOUT_FILENO, STDIN_FILENO, STDERR_FILENO };
 	for (i = 0; i < 3; ++i) {
-		flag = fcntl(fd[i], F_GETFD);
+		int flag = fcntl(fd[i], F_GETFD);
 		if (flag != -1) {
 			fcntl(fd[i], F_SETFD, flag | FD_CLOEXEC);
 		}

--- a/sway/readline.c
+++ b/sway/readline.c
@@ -17,18 +17,22 @@ char *read_line(FILE *file) {
 			continue;
 		}
 		if (length == size) {
-			string = realloc(string, size *= 2);
-			if (!string) {
+			char *new_string = realloc(string, size *= 2);
+			if (!new_string) {
+				free(string);
 				return NULL;
 			}
+			string = new_string;
 		}
 		string[length++] = c;
 	}
 	if (length + 1 == size) {
-		string = realloc(string, length + 1);
-		if (!string) {
+		char *new_string = realloc(string, length + 1);
+		if (!new_string) {
+			free(string);
 			return NULL;
 		}
+		string = new_string;
 	}
 	string[length] = '\0';
 	return string;


### PR DESCRIPTION
Most of the issues in #58 seem to not be present anymore; at least my version of cppcheck (1.69) doesn't find any more (with `--enable=all --inconclusive`), except an issue with the format specifier for wlc_handle being for signed numbers and some unused functions.

For the former I've opened a ticket for wlc, Cloudef/wlc#53, and the latter is not a concern I think.

The memory leak commit is an interesting one though; read_line.c seems to be the only fire where `malloc` and `realloc` is checked for failure. Maybe the checks should be removed and these functions are expected to never fail, or checks should be inserted everywhere else.