### PR TITLE
Change gap behaviour to more closely match i3-gaps

### DIFF
--- a/sway/container.c
+++ b/sway/container.c
@@ -67,7 +67,7 @@ swayc_t *new_output(wlc_handle handle) {
 	output->height = size->h;
 	output->handle = handle;
 	output->name = name ? strdup(name) : NULL;
-	output->gaps = config->gaps_outer;
+	output->gaps = config->gaps_outer + config->gaps_inner / 2;
 
 	add_child(&root_container, output);
 

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -152,12 +152,12 @@ void arrange_windows(swayc_t *container, int width, int height) {
 		{
 			struct wlc_geometry geometry = {
 				.origin = {
-					.x = container->x + container->gaps,
-					.y = container->y + container->gaps
+					.x = container->x + container->gaps / 2,
+					.y = container->y + container->gaps / 2
 				},
 				.size = {
-					.w = width - container->gaps * 2,
-					.h = height - container->gaps * 2
+					.w = width - container->gaps,
+					.h = height - container->gaps
 				}
 			};
 			if (wlc_view_get_state(container->handle) & WLC_BIT_FULLSCREEN) {


### PR DESCRIPTION
Previously, when only using inner gaps, the gap between a window at the
edge of the output was only half the size of the gaps between views.

Additionally, the gaps between the actual windows was twice as wide as
it was on i3-gaps.