### PR TITLE
setup for resizable windows, drop weight

### DIFF
--- a/include/container.h
+++ b/include/container.h
@@ -44,8 +44,6 @@ struct sway_container {
 	bool is_floating;
 	bool is_focused;
 
-	int weight;
-
 	char *name;
 
 	int gaps;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -242,6 +242,7 @@ static bool cmd_floating(struct sway_config *config, int argc, char **argv) {
 				add_sibling(focused, view);
 			}
 			// Refocus on the view once its been put back into the layout
+			view->width = view->height = 0;
 			arrange_windows(active_workspace, -1, -1);
 		}
 		set_focused_container(view);

--- a/sway/container.c
+++ b/sway/container.c
@@ -172,13 +172,8 @@ swayc_t *new_view(swayc_t *sibling, wlc_handle handle) {
 	view->visible = true;
 	view->is_focused = true;
 	//Setup geometry
-	view->width = sibling->parent->width;
-	view->height = sibling->parent->height;
-	if (sibling->parent->layout == L_HORIZ) {
-		view->width /= sibling->parent->children->length;
-	} else {
-		view->height /= sibling->parent->children->length;
-	}
+	view->width = 0;
+	view->height = 0;
 
 	view->gaps = config->gaps_inner;
 

--- a/sway/container.c
+++ b/sway/container.c
@@ -14,7 +14,6 @@ static swayc_t *new_swayc(enum swayc_types type) {
 	c->handle = -1;
 	c->layout = L_NONE;
 	c->type = type;
-	c->weight  = 1;
 	if (type != C_VIEW) {
 		c->children = create_list();
 	}
@@ -172,6 +171,14 @@ swayc_t *new_view(swayc_t *sibling, wlc_handle handle) {
 	view->name = title ? strdup(title) : NULL;
 	view->visible = true;
 	view->is_focused = true;
+	//Setup geometry
+	view->width = sibling->parent->width;
+	view->height = sibling->parent->height;
+	if (sibling->parent->layout == L_HORIZ) {
+		view->width /= sibling->parent->children->length;
+	} else {
+		view->height /= sibling->parent->children->length;
+	}
 
 	view->gaps = config->gaps_inner;
 

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -200,7 +200,6 @@ void arrange_windows(swayc_t *container, int width, int height) {
 				} else {
 					*old_width = width;
 				}
-				sway_log(L_DEBUG,"setting width as %d",*old_width);
 			}
 			scale += *old_width;
 		}

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -194,7 +194,7 @@ void arrange_windows(swayc_t *container, int width, int height) {
 		//Calculate total width
 		for (i = 0; i < container->children->length; ++i) {
 			int *old_width = &((swayc_t *)container->children->items[i])->width;
-			if (*old_width == 0) {
+			if (*old_width <= 0) {
 				if (container->children->length > 1) {
 					*old_width = width / (container->children->length - 1);
 				} else {
@@ -221,12 +221,12 @@ void arrange_windows(swayc_t *container, int width, int height) {
 		//Calculate total height
 		for (i = 0; i < container->children->length; ++i) {
 			int *old_height = &((swayc_t *)container->children->items[i])->height;
+			if (*old_height <= 0) {
 				if (container->children->length > 1) {
 					*old_height = height / (container->children->length - 1);
 				} else {
 					*old_height = height;
 				}
-			if (*old_height == 0) {
 			}
 			scale += *old_height;
 		}

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -186,40 +186,63 @@ void arrange_windows(swayc_t *container, int width, int height) {
 		break;
 	}
 
-	double total_weight = 0;
-	for (i = 0; i < container->children->length; ++i) {
-		swayc_t *child = container->children->items[i];
-		total_weight += child->weight;
-	}
-
+	x = y = 0;
+	double scale = 0;
 	switch (container->layout) {
 	case L_HORIZ:
 	default:
-		sway_log(L_DEBUG, "Arranging %p horizontally", container);
+		//Calculate total width
 		for (i = 0; i < container->children->length; ++i) {
-			swayc_t *child = container->children->items[i];
-			double percent = child->weight / total_weight;
-			sway_log(L_DEBUG, "Calculating arrangement for %p:%d (will receive %.2f of %d)", child, child->type, percent, width);
-			child->x = x + container->x;
-			child->y = y + container->y;
-			int w = width * percent;
-			int h = height;
-			arrange_windows(child, w, h);
-			x += w;
+			int *old_width = &((swayc_t *)container->children->items[i])->width;
+			if (*old_width == 0) {
+				if (container->children->length > 1) {
+					*old_width = width / (container->children->length - 1);
+				} else {
+					*old_width = width;
+				}
+				sway_log(L_DEBUG,"setting width as %d",*old_width);
+			}
+			scale += *old_width;
+		}
+		//Resize windows
+		if (scale > 0.1) {
+			scale = width / scale;
+			sway_log(L_DEBUG, "Arranging %p horizontally", container);
+			for (i = 0; i < container->children->length; ++i) {
+				swayc_t *child = container->children->items[i];
+				sway_log(L_DEBUG, "Calculating arrangement for %p:%d (will scale %d by %f)", child, child->type, width, scale);
+				child->x = x + container->x;
+				child->y = y + container->y;
+				arrange_windows(child, child->width * scale, height);
+				x += child->width;
+			}
 		}
 		break;
 	case L_VERT:
-		sway_log(L_DEBUG, "Arranging %p vertically", container);
+		//Calculate total height
 		for (i = 0; i < container->children->length; ++i) {
-			swayc_t *child = container->children->items[i];
-			double percent = child->weight / total_weight;
-			sway_log(L_DEBUG, "Calculating arrangement for %p:%d (will receive %.2f of %d)", child, child->type, percent, width);
-			child->x = x + container->x;
-			child->y = y + container->y;
-			int w = width;
-			int h = height * percent;
-			arrange_windows(child, w, h);
-			y += h;
+			int *old_height = &((swayc_t *)container->children->items[i])->height;
+				if (container->children->length > 1) {
+					*old_height = height / (container->children->length - 1);
+				} else {
+					*old_height = height;
+				}
+			if (*old_height == 0) {
+			}
+			scale += *old_height;
+		}
+		//Resize
+		if (scale > 0.1) {
+			scale = height / scale;
+			sway_log(L_DEBUG, "Arranging %p vertically", container);
+			for (i = 0; i < container->children->length; ++i) {
+				swayc_t *child = container->children->items[i];
+				sway_log(L_DEBUG, "Calculating arrangement for %p:%d (will scale %d by %f)", child, child->type, height, scale);
+				child->x = x + container->x;
+				child->y = y + container->y;
+				arrange_windows(child, width, child->height * scale);
+				y += child->height;
+			}
 		}
 		break;
 	}

--- a/sway/log.c
+++ b/sway/log.c
@@ -114,7 +114,6 @@ static void container_log(const swayc_t *c) {
 	fprintf(stderr, "w:%d|h:%d|", c->width, c->height);
 	fprintf(stderr, "x:%d|y:%d|", c->x, c->y);
 	fprintf(stderr, "vis:%c|", c->visible?'t':'f');
-	fprintf(stderr, "wgt:%d|", c->weight);
 	fprintf(stderr, "name:%.16s|", c->name);
 	fprintf(stderr, "children:%d\n",c->children?c->children->length:0);
 }


### PR DESCRIPTION
as it says, it drops the weight method for calculating size,
and instead uses previous width/height.
