### PR TITLE
find_parent_by_type

### DIFF
--- a/include/container.h
+++ b/include/container.h
@@ -55,6 +55,7 @@ struct sway_container {
 	struct sway_container *focused;
 };
 
+// Container Creation
 
 swayc_t *new_output(wlc_handle handle);
 swayc_t *new_workspace(swayc_t *output, const char *name);
@@ -65,12 +66,22 @@ swayc_t *new_view(swayc_t *sibling, wlc_handle handle);
 // Creates view as a new floating view which is in the active workspace
 swayc_t *new_floating_view(wlc_handle handle);
 
+// Container Destroying
 
 swayc_t *destroy_output(swayc_t *output);
 // Destroys workspace if empty and returns parent pointer, else returns NULL
 swayc_t *destroy_workspace(swayc_t *workspace);
+// Destroyes container and all parent container if they are empty, returns
+// topmost non-empty parent. returns NULL otherwise
 swayc_t *destroy_container(swayc_t *container);
+// Destroys view and all empty parent containers. return topmost non-empty
+// parent
 swayc_t *destroy_view(swayc_t *view);
+
+// Container Lookup
+
+swayc_t *swayc_parent_by_type(swayc_t *container, enum swayc_types);
+swayc_t *swayc_parent_by_layout(swayc_t *container, enum swayc_layouts);
 
 swayc_t *find_container(swayc_t *container, bool (*test)(swayc_t *view, void *data), void *data);
 void container_map(swayc_t *, void (*f)(swayc_t *, void *), void *);

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -390,7 +390,6 @@ static bool cmd_layout(struct sway_config *config, int argc, char **argv) {
 		return false;
 	}
 	swayc_t *parent = get_focused_container(&root_container);
-
 	while (parent->type == C_VIEW) {
 		parent = parent->parent;
 	}
@@ -512,9 +511,7 @@ static bool cmd_fullscreen(struct sway_config *config, int argc, char **argv) {
 	// Resize workspace if going from  fullscreen -> notfullscreen
 	// otherwise just resize container
 	if (current) {
-		while (container->type != C_WORKSPACE) {
-			container = container->parent;
-		}
+		container = swayc_parent_by_type(container, C_WORKSPACE);
 	}
 	// Only resize container when going into fullscreen
 	arrange_windows(container, -1, -1);

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -20,10 +20,7 @@ static struct wlc_origin mouse_origin;
 static bool pointer_test(swayc_t *view, void *_origin) {
 	const struct wlc_origin *origin = _origin;
 	// Determine the output that the view is under
-	swayc_t *parent = view;
-	while (parent->type != C_OUTPUT) {
-		parent = parent->parent;
-	}
+	swayc_t *parent = swayc_parent_by_type(view, C_OUTPUT);
 	if (origin->x >= view->x && origin->y >= view->y
 		&& origin->x < view->x + view->width && origin->y < view->y + view->height
 		&& view->visible && parent == root_container.focused) {
@@ -191,10 +188,7 @@ static bool handle_view_created(wlc_handle handle) {
 
 	if (newview) {
 		set_focused_container(newview);
-		swayc_t *output = newview->parent;
-		while (output && output->type != C_OUTPUT) {
-			output = output->parent;
-		}
+		swayc_t *output = swayc_parent_by_type(newview, C_OUTPUT);
 		arrange_windows(output, -1, -1);
 	}
 	return true;
@@ -262,10 +256,7 @@ static void handle_view_state_request(wlc_handle view, enum wlc_view_state_bit s
 			arrange_windows(c->parent, -1, -1);
 			// Set it as focused window for that workspace if its going fullscreen
 			if (toggle) {
-				swayc_t *ws = c;
-				while (ws->type != C_WORKSPACE) {
-					ws = ws->parent;
-				}
+				swayc_t *ws = swayc_parent_by_type(c, C_WORKSPACE);
 				// Set ws focus to c
 				set_focused_container_for(ws, c);
 			}

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -161,10 +161,7 @@ void arrange_windows(swayc_t *container, int width, int height) {
 				}
 			};
 			if (wlc_view_get_state(container->handle) & WLC_BIT_FULLSCREEN) {
-				swayc_t *parent = container;
-				while (parent->type != C_OUTPUT) {
-					parent = parent->parent;
-				}
+				swayc_t *parent = swayc_parent_by_type(container, C_OUTPUT);
 				geometry.origin.x = 0;
 				geometry.origin.y = 0;
 				geometry.size.w = parent->width;
@@ -263,10 +260,7 @@ void arrange_windows(swayc_t *container, int width, int height) {
 					}
 				};
 				if (wlc_view_get_state(view->handle) & WLC_BIT_FULLSCREEN) {
-					swayc_t *parent = view;
-					while (parent->type != C_OUTPUT) {
-						parent = parent->parent;
-					}
+					swayc_t *parent = swayc_parent_by_type(view, C_OUTPUT);
 					geometry.origin.x = 0;
 					geometry.origin.y = 0;
 					geometry.size.w = parent->width;

--- a/sway/workspace.c
+++ b/sway/workspace.c
@@ -75,9 +75,7 @@ char *workspace_next_name(void) {
 
 swayc_t *workspace_create(const char* name) {
 	swayc_t *parent = get_focused_container(&root_container);
-	while (parent->type != C_OUTPUT) {
-		parent = parent->parent;
-	}
+	parent = swayc_parent_by_type(parent, C_OUTPUT);
 	return new_workspace(parent, name);
 }
 


### PR DESCRIPTION
replaced all instance of
```
while (container->type != C_WORKSPACE) {
	container = container->parent;
}
```
with
`container = swayc_parent_by_type(container, C_WORKSPACE);`
theres also a `swayc_parent_by_layout` too.

also added sway_asserts to destroy/create functions.

ill try to find more things to clean up