### PR TITLE
Added in proper resize locking

### DIFF
--- a/include/input_state.h
+++ b/include/input_state.h
@@ -37,13 +37,19 @@ extern struct pointer_state {
 	struct pointer_tiling {
 		bool resize;
 		swayc_t *init_view;
-		struct wlc_origin *lock_pos;
+		struct wlc_origin lock_pos;
 	} tiling;
 	struct pointer_lock {
+		// Lock movement for certain edges
 		bool left;
 		bool right;
 		bool top;
 		bool bottom;
+		// Lock movement in certain directions
+		bool temp_left;
+		bool temp_right;
+		bool temp_up;
+		bool temp_down;
 	} lock;
 } pointer_state;
 

--- a/sway/input_state.c
+++ b/sway/input_state.c
@@ -48,7 +48,7 @@ void release_key(keycode key) {
 	}
 }
 
-struct pointer_state pointer_state = {0, 0, {0, 0}, {0, 0, 0}, {0, 0, 0, 0}};
+struct pointer_state pointer_state = {0, 0, {0, 0}, {0, 0, {0, 0}}, {0, 0, 0, 0, 0, 0, 0, 0}};
 
 static struct wlc_geometry saved_floating;
 


### PR DESCRIPTION
Resize now locks properly if you over-resize a container and make it smaller than the mininimum width/height. Some unnecessary debugging was also removed.