### PR TITLE
bugfixes, renames, and other things.

### DIFF
--- a/include/container.h
+++ b/include/container.h
@@ -81,12 +81,21 @@ swayc_t *destroy_view(swayc_t *view);
 
 // Container Lookup
 
+swayc_t *swayc_by_test(swayc_t *container, bool (*test)(swayc_t *view, void *data), void *data);
 swayc_t *swayc_parent_by_type(swayc_t *container, enum swayc_types);
 swayc_t *swayc_parent_by_layout(swayc_t *container, enum swayc_layouts);
+swayc_t *swayc_by_handle(wlc_handle handle);
+swayc_t *swayc_active_output(void);
+swayc_t *swayc_active_workspace(void);
+swayc_t *swayc_active_workspace_for(swayc_t *view);
 
-swayc_t *find_container(swayc_t *container, bool (*test)(swayc_t *view, void *data), void *data);
+// Container information
+
+bool swayc_is_fullscreen(swayc_t *view);
+
+// Mapping functions
+
 void container_map(swayc_t *, void (*f)(swayc_t *, void *), void *);
-
 
 // Mappings
 void set_view_visibility(swayc_t *view, void *data);

--- a/include/layout.h
+++ b/include/layout.h
@@ -19,17 +19,10 @@ swayc_t *remove_child(swayc_t *child);
 
 void move_container(swayc_t* container,swayc_t* root,enum movement_direction direction);
 
-
 // Layout
 void arrange_windows(swayc_t *container, double width, double height);
 
-// Focus
-void unfocus_all(swayc_t *container);
-void focus_view(swayc_t *view);
-void focus_view_for(swayc_t *ancestor, swayc_t *container);
-
 swayc_t *get_focused_container(swayc_t *parent);
-swayc_t *get_swayc_for_handle(wlc_handle handle, swayc_t *parent);
 swayc_t *get_swayc_in_direction(swayc_t *container, enum movement_direction dir);
 
 void recursive_resize(swayc_t *container, double amount, enum wlc_resize_edge edge);

--- a/include/workspace.h
+++ b/include/workspace.h
@@ -5,11 +5,9 @@
 #include "list.h"
 #include "layout.h"
 
-extern swayc_t *active_workspace;
-
 char *workspace_next_name(void);
 swayc_t *workspace_create(const char*);
-swayc_t *workspace_find_by_name(const char*);
+swayc_t *workspace_by_name(const char*);
 void workspace_switch(swayc_t*);
 void workspace_output_next();
 void workspace_next();

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -684,7 +684,7 @@ static bool cmd_fullscreen(struct sway_config *config, int argc, char **argv) {
 	}
 
 	swayc_t *container = get_focused_view(&root_container);
-	bool current = (wlc_view_get_state(container->handle) & WLC_BIT_FULLSCREEN) > 0;
+	bool current = swayc_is_fullscreen(container);
 	wlc_view_set_state(container->handle, WLC_BIT_FULLSCREEN, !current);
 	// Resize workspace if going from  fullscreen -> notfullscreen
 	// otherwise just resize container

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -208,16 +208,16 @@ static bool cmd_floating(struct sway_config *config, int argc, char **argv) {
 			destroy_container(remove_child(view));
 
 			// and move it into workspace floating
-			add_floating(active_workspace,view);
-			view->x = (active_workspace->width - view->width)/2;
-			view->y = (active_workspace->height - view->height)/2;
+			add_floating(swayc_active_workspace(),view);
+			view->x = (swayc_active_workspace()->width - view->width)/2;
+			view->y = (swayc_active_workspace()->height - view->height)/2;
 			if (view->desired_width != -1) {
 				view->width = view->desired_width;
 			}
 			if (view->desired_height != -1) {
 				view->height = view->desired_height;
 			}
-			arrange_windows(active_workspace, -1, -1);
+			arrange_windows(swayc_active_workspace(), -1, -1);
 		} else {
 			// Delete the view from the floating list and unset its is_floating flag
 			// Using length-1 as the index is safe because the view must be the currently
@@ -228,7 +228,7 @@ static bool cmd_floating(struct sway_config *config, int argc, char **argv) {
 			swayc_t *focused = container_under_pointer();
 			// If focused is null, it's because the currently focused container is a workspace
 			if (focused == NULL) {
-				focused = active_workspace;
+				focused = swayc_active_workspace();
 			}
 			set_focused_container(focused);
 
@@ -244,7 +244,7 @@ static bool cmd_floating(struct sway_config *config, int argc, char **argv) {
 			}
 			// Refocus on the view once its been put back into the layout
 			view->width = view->height = 0;
-			arrange_windows(active_workspace, -1, -1);
+			arrange_windows(swayc_active_workspace(), -1, -1);
 		}
 		set_focused_container(view);
 	}
@@ -293,37 +293,38 @@ static bool cmd_focus(struct sway_config *config, int argc, char **argv) {
 		return move_focus(MOVE_PARENT);
 	} else if (strcasecmp(argv[0], "mode_toggle") == 0) {
 		int i;
-		swayc_t *focused = get_focused_view(active_workspace);
+		swayc_t *workspace = swayc_active_workspace();
+		swayc_t *focused = get_focused_view(workspace);
 		if (focused->is_floating) {
-			if (active_workspace->children->length > 0) {
-				for (i = 0;i < active_workspace->floating->length; i++) {
-					if (active_workspace->floating->items[i] == focused) {
+			if (workspace->children->length > 0) {
+				for (i = 0;i < workspace->floating->length; i++) {
+					if (workspace->floating->items[i] == focused) {
 						floating_toggled_index = i;
 						break;
 					}
 				}
-				if (active_workspace->children->length > tiled_toggled_index) {
-					set_focused_container(get_focused_view(active_workspace->children->items[tiled_toggled_index]));
+				if (workspace->children->length > tiled_toggled_index) {
+					set_focused_container(get_focused_view(workspace->children->items[tiled_toggled_index]));
 				} else {
-					set_focused_container(get_focused_view(active_workspace->children->items[0]));
+					set_focused_container(get_focused_view(workspace->children->items[0]));
 					tiled_toggled_index = 0;
 				}
 			}
 		} else {
-			if (active_workspace->floating->length > 0) {
-				for (i = 0;i < active_workspace->children->length; i++) {
-					if (active_workspace->children->items[i] == focused) {
+			if (workspace->floating->length > 0) {
+				for (i = 0;i < workspace->children->length; i++) {
+					if (workspace->children->items[i] == focused) {
 						tiled_toggled_index = i;
 						break;
 					}
 				}
-				if (active_workspace->floating->length > floating_toggled_index) {
-					swayc_t *floating = active_workspace->floating->items[floating_toggled_index];
+				if (workspace->floating->length > floating_toggled_index) {
+					swayc_t *floating = workspace->floating->items[floating_toggled_index];
 					set_focused_container(get_focused_view(floating));
 				} else {
-					swayc_t *floating = active_workspace->floating->items[active_workspace->floating->length - 1];
+					swayc_t *floating = workspace->floating->items[workspace->floating->length - 1];
 					set_focused_container(get_focused_view(floating));
-					tiled_toggled_index = active_workspace->floating->length - 1;
+					tiled_toggled_index = workspace->floating->length - 1;
 				}
 			}
 		}
@@ -459,7 +460,7 @@ static bool cmd_resize(struct sway_config *config, int argc, char **argv) {
 		amount *= -1;
 	}
 
-	swayc_t *parent = get_focused_view(active_workspace);
+	swayc_t *parent = get_focused_view(swayc_active_workspace());
 	swayc_t *focused = parent;
 	swayc_t *sibling;
 	if (!parent) {
@@ -529,7 +530,7 @@ static bool cmd_resize(struct sway_config *config, int argc, char **argv) {
 		}
 		// Recursive resize does not handle positions, let arrange_windows
 		// take care of that.
-		arrange_windows(active_workspace, -1, -1);
+		arrange_windows(swayc_active_workspace(), -1, -1);
 		return true;
 	} else if (strcmp(argv[1], "height") == 0) {
 		int tnumber = 0;
@@ -589,7 +590,7 @@ static bool cmd_resize(struct sway_config *config, int argc, char **argv) {
 				}
 			}
 		}
-		arrange_windows(active_workspace, -1, -1);
+		arrange_windows(swayc_active_workspace(), -1, -1);
 		return true;
 	}
 	return true;
@@ -616,8 +617,12 @@ static bool _do_split(struct sway_config *config, int argc, char **argv, int lay
 	}
 	swayc_t *focused = get_focused_container(&root_container);
 
+	// Case of floating window, dont split
+	if (focused->is_floating) {
+		return true;
+	}
+	/* Case that focus is on an workspace with 0/1 children.change its layout */
 	if (focused->type == C_WORKSPACE && focused->children->length <= 1) {
-		/* Case that focus is on an workspace with 0/1 children.change its layout */
 		sway_log(L_DEBUG, "changing workspace layout");
 		focused->layout = layout;
 	} else if (focused->type != C_WORKSPACE && focused->parent->children->length == 1) {
@@ -632,7 +637,6 @@ static bool _do_split(struct sway_config *config, int argc, char **argv, int lay
 		set_focused_container(focused);
 		arrange_windows(parent, -1, -1);
 	}
-
 	return true;
 }
 
@@ -721,7 +725,7 @@ static bool cmd_workspace(struct sway_config *config, int argc, char **argv) {
 			return true;
 		}
 
-		swayc_t *workspace = workspace_find_by_name(argv[0]);
+		swayc_t *workspace = workspace_by_name(argv[0]);
 		if (!workspace) {
 			workspace = workspace_create(argv[0]);
 		}

--- a/sway/container.c
+++ b/sway/container.c
@@ -341,7 +341,7 @@ swayc_t *swayc_parent_by_type(swayc_t *container, enum swayc_types type) {
 	}
 	do {
 		container = container->parent;
-	} while(container && container->type != type);
+	} while (container && container->type != type);
 	return container;
 }
 
@@ -402,18 +402,23 @@ swayc_t *swayc_active_workspace(void) {
 }
 
 swayc_t *swayc_active_workspace_for(swayc_t *cont) {
-	if (! cont) {
+	if (!cont) {
 		return NULL;
 	}
 	switch (cont->type) {
-		/* set root -> output */
-	case C_ROOT: cont = cont->focused;
-		/* set output -> workspace  */
-	case C_OUTPUT: cont = cont->focused;
-		/* return workspace */
-	case C_WORKSPACE: return cont;
-		/* Find parent workspace */
-	default: return swayc_parent_by_type(cont, C_WORKSPACE);
+	case C_ROOT:
+		cont = cont->focused;
+		/* Fallthrough */
+
+	case C_OUTPUT:
+		cont = cont->focused;
+		/* Fallthrough */
+
+	case C_WORKSPACE:
+		return cont;
+
+	default:
+		return swayc_parent_by_type(cont, C_WORKSPACE);
 	}
 }
 

--- a/sway/container.c
+++ b/sway/container.c
@@ -26,14 +26,11 @@ static void free_swayc(swayc_t *cont) {
 	if (!ASSERT_NONNULL(cont)) {
 		return;
 	}
-	// TODO does not properly handle containers with children,
-	// TODO but functions that call this usually check for that
 	if (cont->children) {
-		if (cont->children->length) {
-			int i;
-			for (i = 0; i < cont->children->length; ++i) {
-				free_swayc(cont->children->items[i]);
-			}
+		// remove children until there are no more, free_swayc calls
+		// remove_child, which removes child from this container
+		while (cont->children->length) {
+			free_swayc(cont->children->items[0]);
 		}
 		list_free(cont->children);
 	}
@@ -409,9 +406,13 @@ swayc_t *swayc_active_workspace_for(swayc_t *cont) {
 		return NULL;
 	}
 	switch (cont->type) {
+		/* set root -> output */
 	case C_ROOT: cont = cont->focused;
+		/* set output -> workspace  */
 	case C_OUTPUT: cont = cont->focused;
+		/* return workspace */
 	case C_WORKSPACE: return cont;
+		/* Find parent workspace */
 	default: return swayc_parent_by_type(cont, C_WORKSPACE);
 	}
 }

--- a/sway/focus.c
+++ b/sway/focus.c
@@ -21,8 +21,6 @@ static void update_focus(swayc_t *c) {
 		// Case where output changes
 		case C_OUTPUT:
 			wlc_output_focus(c->handle);
-			// Set new workspace to the outputs focused workspace
-			active_workspace = c->focused;
 			break;
 
 		// Case where workspace changes
@@ -39,7 +37,6 @@ static void update_focus(swayc_t *c) {
 				c->parent->focused = c;
 				destroy_workspace(ws);
 			}
-			active_workspace = c;
 			break;
 
 		default:
@@ -54,8 +51,8 @@ static void update_focus(swayc_t *c) {
 }
 
 bool move_focus(enum movement_direction direction) {
-	swayc_t *view = get_swayc_in_direction(
-			get_focused_container(&root_container), direction);
+	swayc_t *view = get_focused_container(&root_container);
+	view = get_swayc_in_direction(view, direction);
 	if (view) {
 		if (direction == MOVE_PARENT) {
 			set_focused_container(view);
@@ -68,13 +65,12 @@ bool move_focus(enum movement_direction direction) {
 }
 
 swayc_t *get_focused_container(swayc_t *parent) {
-	while (parent && !parent->is_focused) {
-		parent = parent->focused;
+	if (!parent) {
+		return swayc_active_workspace();
 	}
-	// just incase
-	if (parent == NULL) {
-		sway_log(L_DEBUG, "get_focused_container unable to find container");
-		return active_workspace;
+	// get focusde container
+	while (!parent->is_focused && parent->focused) {
+		parent = parent->focused;
 	}
 	return parent;
 }
@@ -85,9 +81,13 @@ void set_focused_container(swayc_t *c) {
 	}
 	sway_log(L_DEBUG, "Setting focus to %p:%ld", c, c->handle);
 
-	// Find previous focused view, and the new focused view, if they are the same return
-	swayc_t *focused = get_focused_view(&root_container);
-	swayc_t *workspace = active_workspace;
+	// Get workspace for c, get that workspaces current focused container.
+	swayc_t *workspace = swayc_active_workspace_for(c);
+	swayc_t *focused = get_focused_view(workspace);
+	// if the workspace we are changing focus to has a fullscreen view return
+	if (swayc_is_fullscreen(focused) && focused != c) {
+		return;
+	}
 
 	// update container focus from here to root, making necessary changes along
 	// the way
@@ -99,13 +99,6 @@ void set_focused_container(swayc_t *c) {
 		update_focus(p);
 		p = p->parent;
 		p->is_focused = false;
-	}
-
-	// if the workspace is the same, and previous focus is fullscreen, dont
-	// change focus
-	if (workspace == active_workspace
-		&& wlc_view_get_state(focused->handle) & WLC_BIT_FULLSCREEN) {
-		return;
 	}
 
 	// get new focused view and set focus to it.
@@ -137,6 +130,15 @@ void set_focused_container_for(swayc_t *a, swayc_t *c) {
 			return;
 		}
 	}
+
+	// Get workspace for c, get that workspaces current focused container.
+	swayc_t *workspace = swayc_active_workspace_for(c);
+	swayc_t *focused = get_focused_view(workspace);
+	// if the workspace we are changing focus to has a fullscreen view return
+	if (swayc_is_fullscreen(focused) && c != focused) {
+		return;
+	}
+
 	// Check if we changing a parent container that will see chnage
 	bool effective = true;
 	while (find != &root_container) {
@@ -171,7 +173,7 @@ swayc_t *get_focused_view(swayc_t *parent) {
 		parent = parent->focused;
 	}
 	if (parent == NULL) {
-		return active_workspace;
+		return swayc_active_workspace_for(parent);
 	}
 	return parent;
 }

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -640,8 +640,12 @@ static bool handle_pointer_button(wlc_handle view, uint32_t time, const struct w
 			// Dont want pointer sent to window while dragging or resizing
 			return (pointer_state.floating.drag || pointer_state.floating.resize);
 		} else {
-			pointer_state.tiling.resize = pointer_state.r_held;
-			pointer_state.tiling.init_view = pointer;
+			if (modifiers->mods & config->floating_mod) {
+				pointer_state.tiling.resize = pointer_state.r_held;
+				pointer_state.tiling.init_view = pointer;
+				// Dont want pointer sent when resizing
+				return (pointer_state.tiling.resize);
+			}
 		}
 		return (pointer && pointer != focused);
 	} else {

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -568,7 +568,7 @@ static bool handle_pointer_motion(wlc_handle handle, uint32_t time, const struct
 	if (config->focus_follows_mouse && prev_handle != handle) {
 		// Dont change focus if fullscreen
 		swayc_t *focused = get_focused_view(view);
-		if (!(focused->type == C_VIEW && wlc_view_get_state(focused->handle) & WLC_BIT_FULLSCREEN)
+		if (!swayc_is_fullscreen(focused)
 				&& !(pointer_state.l_held || pointer_state.r_held)) {
 			set_focused_container(container_under_pointer());
 		}
@@ -600,7 +600,7 @@ static bool handle_pointer_button(wlc_handle view, uint32_t time, const struct w
 		uint32_t button, enum wlc_button_state state, const struct wlc_origin *origin) {
 	swayc_t *focused = get_focused_container(&root_container);
 	// dont change focus if fullscreen
-	if (focused->type == C_VIEW && wlc_view_get_state(focused->handle) & WLC_BIT_FULLSCREEN) {
+	if (swayc_is_fullscreen(focused)) {
 		return false;
 	}
 	if (state == WLC_BUTTON_STATE_PRESSED) {

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -204,7 +204,7 @@ void arrange_windows(swayc_t *container, double width, double height) {
 					.h = height - container->gaps
 				}
 			};
-			if (wlc_view_get_state(container->handle) & WLC_BIT_FULLSCREEN) {
+			if (swayc_is_fullscreen(container)) {
 				swayc_t *parent = swayc_parent_by_type(container, C_OUTPUT);
 				geometry.origin.x = 0;
 				geometry.origin.y = 0;
@@ -303,7 +303,7 @@ void arrange_windows(swayc_t *container, double width, double height) {
 						.h = view->height
 					}
 				};
-				if (wlc_view_get_state(view->handle) & WLC_BIT_FULLSCREEN) {
+				if (swayc_is_fullscreen(view)) {
 					swayc_t *parent = swayc_parent_by_type(view, C_OUTPUT);
 					geometry.origin.x = 0;
 					geometry.origin.y = 0;
@@ -318,7 +318,7 @@ void arrange_windows(swayc_t *container, double width, double height) {
 					// have higher indexes
 					// This is conditional on there not being a fullscreen view in the workspace
 					if (!container->focused
-							|| !(wlc_view_get_state(container->focused->handle) & WLC_BIT_FULLSCREEN)) {
+							|| !swayc_is_fullscreen(container->focused)) {
 						wlc_view_bring_to_front(view->handle);
 					}
 				}

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -35,7 +35,7 @@ void add_child(swayc_t *parent, swayc_t *child) {
 	child->parent = parent;
 	// set focus for this container
 	if (parent->children->length == 1) {
-		set_focused_container_for(parent, child);
+		parent->focused = child;
 	}
 }
 
@@ -46,7 +46,7 @@ void add_floating(swayc_t *ws, swayc_t *child) {
 	child->parent = ws;
 	child->is_floating = true;
 	if (!ws->focused) {
-		set_focused_container_for(ws, child);
+		ws->focused = child;
 	}
 }
 
@@ -71,7 +71,7 @@ swayc_t *replace_child(swayc_t *child, swayc_t *new_child) {
 	new_child->parent = child->parent;
 
 	if (child->parent->focused == child) {
-		set_focused_container_for(child->parent, new_child);
+		child->parent->focused = new_child;
 	}
 	child->parent = NULL;
 	return parent;
@@ -100,7 +100,7 @@ swayc_t *remove_child(swayc_t *child) {
 	// Set focused to new container
 	if (parent->focused == child) {
 		if (parent->children->length > 0) {
-			set_focused_container_for(parent, parent->children->items[i?i-1:0]);
+			parent->focused = parent->children->items[i?i-1:0];
 		} else {
 			parent->focused = NULL;
 		}
@@ -328,35 +328,6 @@ void arrange_windows(swayc_t *container, double width, double height) {
 	layout_log(&root_container, 0);
 }
 
-swayc_t *get_swayc_for_handle(wlc_handle handle, swayc_t *parent) {
-	if (parent->children == NULL) {
-		return NULL;
-	}
-
-	// Search for floating workspaces
-	int i;
-	if (parent->type == C_WORKSPACE) {
-		for (i = 0; i < parent->floating->length; ++i) {
-			swayc_t *child = parent->floating->items[i];
-			if (child->handle == handle) {
-				return child;
-			}
-		}
-	}
-
-	for (i = 0; i < parent->children->length; ++i) {
-		swayc_t *child = parent->children->items[i];
-		if (child->handle == handle) {
-			return child;
-		} else {
-			swayc_t *res;
-			if ((res = get_swayc_for_handle(handle, child))) {
-				return res;
-			}
-		}
-	}
-	return NULL;
-}
 
 swayc_t *get_swayc_in_direction(swayc_t *container, enum movement_direction dir) {
 	swayc_t *parent = container->parent;

--- a/sway/log.c
+++ b/sway/log.c
@@ -119,8 +119,9 @@ bool sway_assert(bool condition, const char* format, ...) {
 /* XXX:DEBUG:XXX */
 static void container_log(const swayc_t *c) {
 	fprintf(stderr, "focus:%c|",
-			c->is_focused ? 'F' : // Focused
-			c == active_workspace ? 'W' : // active workspace
+			c == get_focused_view(&root_container) ? 'K':
+			c == get_focused_container(&root_container) ? 'F' : // Focused
+			c == swayc_active_workspace() ? 'W' : // active workspace
 			c == &root_container  ? 'R' : // root
 			'X');// not any others
 	fprintf(stderr,"(%p)",c);

--- a/sway/workspace.c
+++ b/sway/workspace.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <wlc/wlc.h>
+#include <string.h>
 #include "workspace.h"
 #include "layout.h"
 #include "list.h"
@@ -10,8 +11,6 @@
 #include "config.h"
 #include "stringop.h"
 #include "focus.h"
-
-swayc_t *active_workspace = NULL;
 
 char *workspace_next_name(void) {
 	sway_log(L_DEBUG, "Workspace: Generating new name");
@@ -48,7 +47,7 @@ char *workspace_next_name(void) {
 			}
 
 			// Make sure that the workspace doesn't already exist
-			if (workspace_find_by_name(target)) {
+			if (workspace_by_name(target)) {
 				list_free(args);
 				continue;
 			}
@@ -79,22 +78,22 @@ swayc_t *workspace_create(const char* name) {
 	return new_workspace(parent, name);
 }
 
-bool workspace_by_name(swayc_t *view, void *data) {
+static bool _workspace_by_name(swayc_t *view, void *data) {
 	return (view->type == C_WORKSPACE) &&
 		   (strcasecmp(view->name, (char *) data) == 0);
 }
 
-swayc_t *workspace_find_by_name(const char* name) {
-	return find_container(&root_container, workspace_by_name, (void *) name);
+swayc_t *workspace_by_name(const char* name) {
+	return swayc_by_test(&root_container, _workspace_by_name, (void *) name);
 }
 
 void workspace_output_next() {
 	// Get the index of the workspace in the current output, and change the view to index+1 workspace.
 	// if we're currently focused on the last workspace in the output, switch to the first
-	swayc_t *current_output = active_workspace->parent;
+	swayc_t *current_output = swayc_active_workspace()->parent;
 	int i;
 	for (i = 0; i < current_output->children->length - 1; i++) {
-		if (strcmp((((swayc_t *)current_output->children->items[i])->name), active_workspace->name) == 0) {
+		if (strcmp((((swayc_t *)current_output->children->items[i])->name), swayc_active_workspace()->name) == 0) {
 			workspace_switch(current_output->children->items[i + 1]);
 			return;
 		}
@@ -106,10 +105,10 @@ void workspace_next() {
 	// Get the index of the workspace in the current output, and change the view to index+1 workspace.
 	// if we're currently focused on the last workspace in the output, change focus to there
 	// and call workspace_output_next(), as long as another output actually exists
-	swayc_t *current_output = active_workspace->parent;
+	swayc_t *current_output = swayc_active_workspace()->parent;
 	int i;
 	for (i = 0; i < current_output->children->length - 1; i++) {
-		if (strcmp((((swayc_t *)current_output->children->items[i])->name), active_workspace->name) == 0) {
+		if (strcmp((((swayc_t *)current_output->children->items[i])->name), swayc_active_workspace()->name) == 0) {
 			workspace_switch(current_output->children->items[i + 1]);
 			return;
 		}
@@ -134,10 +133,10 @@ void workspace_next() {
 void workspace_output_prev() {
 	// Get the index of the workspace in the current output, and change the view to index+1 workspace
 	// if we're currently focused on the first workspace in the output, do nothing and return false
-	swayc_t *current_output = active_workspace->parent;
+	swayc_t *current_output = swayc_active_workspace()->parent;
 	int i;
 	for (i = 1; i < current_output->children->length; i++) {
-		if (strcmp((((swayc_t *)current_output->children->items[i])->name), active_workspace->name) == 0) {
+		if (strcmp((((swayc_t *)current_output->children->items[i])->name), swayc_active_workspace()->name) == 0) {
 			workspace_switch(current_output->children->items[i - 1]);
 			return;
 		}
@@ -150,10 +149,10 @@ void workspace_prev() {
 	// if we're currently focused on the last workspace in the output, change focus to there
 	// and call workspace_output_next(), as long as another output actually exists
 
-	swayc_t *current_output = active_workspace->parent;
+	swayc_t *current_output = swayc_active_workspace()->parent;
 	int i;
 	for (i = 1; i < current_output->children->length; i++) {
-		if (strcmp((((swayc_t *)current_output->children->items[i])->name), active_workspace->name) == 0) {
+		if (strcmp((((swayc_t *)current_output->children->items[i])->name), swayc_active_workspace()->name) == 0) {
 			workspace_switch(current_output->children->items[i - 1]);
 			return;
 		}


### PR DESCRIPTION
first the few bugfixes, the same ones i fixed in my view_ordering pr.
splithv on floating windows, set_focused behavior for fullscreen windows.

next change is `active_workspace` -> `swayc_active_workspace()` function and other related functions such as `swayc_active_workspace_for(view)` `swayc_active_output()`
since active workspace should always be `root->focused->focused` its better to use that instead of updating active_workspace all the time.

also some name changes. `swayc_by_test()` replaces `find_container`, `sway_by_handle()` replaces `get_swayc_for_handle`

replaced the fullscreen checking with `swayc_is_fullscreen(view)` 

as for the window resizing with rightclick, i made it check for floating_modifier, and behave the same for resizing floating windows (no rightclick when resizing)

we could probably add a resizing_modifier or something, 