### PR TITLE
Added in backtrace printing

### DIFF
--- a/include/log.h
+++ b/include/log.h
@@ -16,6 +16,7 @@ void sway_log(log_importance_t verbosity, const char* format, ...) __attribute__
 void sway_log_errno(log_importance_t verbosity, char* format, ...) __attribute__((format(printf,2,3)));
 void sway_abort(const char* format, ...) __attribute__((format(printf,1,2)));
 bool sway_assert(bool condition, const char* format, ...) __attribute__((format(printf,2,3)));
+void error_handler(int sig);
 
 void layout_log(const swayc_t *c, int depth);
 #endif


### PR DESCRIPTION
I've added in backtrace printing as referenced in #66. SIGABRT is handled in addition to SIGEGV because that can also be called when sway_assert fails.