### PR TITLE
Implemented "move container to workspace"

### DIFF
--- a/include/container.h
+++ b/include/container.h
@@ -56,9 +56,8 @@ struct sway_container {
 	struct sway_container *focused;
 };
 
-enum view_visibility {
-	INVISIBLE = 1,
-	VISIBLE = 2
+enum visibility_mask {
+	VISIBLE = 1
 };
 
 // Container Creation

--- a/include/container.h
+++ b/include/container.h
@@ -56,6 +56,11 @@ struct sway_container {
 	struct sway_container *focused;
 };
 
+enum view_visibility {
+	INVISIBLE = 1,
+	VISIBLE = 2
+};
+
 // Container Creation
 
 swayc_t *new_output(wlc_handle handle);
@@ -105,5 +110,8 @@ void container_map(swayc_t *, void (*f)(swayc_t *, void *), void *);
 // Mappings
 void set_view_visibility(swayc_t *view, void *data);
 void reset_gaps(swayc_t *view, void *data);
+
+
+void update_visibility(swayc_t *container);
 
 #endif

--- a/include/layout.h
+++ b/include/layout.h
@@ -22,6 +22,7 @@ swayc_t *remove_child(swayc_t *child);
 void swap_container(swayc_t *a, swayc_t *b);
 
 void move_container(swayc_t* container,swayc_t* root,enum movement_direction direction);
+void move_container_to(swayc_t* container, swayc_t* destination);
 
 // Layout
 void update_geometry(swayc_t *view);

--- a/include/util.h
+++ b/include/util.h
@@ -1,4 +1,9 @@
+#ifndef _SWAY_UTIL_H
+#define _SWAY_UTIL_H
+
 /**
  * Wrap i into the range [0, max[
  */
 int wrap(int i, int max);
+
+#endif

--- a/include/util.h
+++ b/include/util.h
@@ -1,0 +1,4 @@
+/**
+ * Wrap i into the range [0, max[
+ */
+int wrap(int i, int max);

--- a/include/workspace.h
+++ b/include/workspace.h
@@ -9,9 +9,9 @@ char *workspace_next_name(void);
 swayc_t *workspace_create(const char*);
 swayc_t *workspace_by_name(const char*);
 void workspace_switch(swayc_t*);
-void workspace_output_next();
-void workspace_next();
-void workspace_output_prev();
-void workspace_prev();
+swayc_t *workspace_output_next();
+swayc_t *workspace_next();
+swayc_t *workspace_output_prev();
+swayc_t *workspace_prev();
 
 #endif

--- a/sway.5.txt
+++ b/sway.5.txt
@@ -80,6 +80,10 @@ Commands
 **move** <left|right|up|down>::
 	Moves the focused container _left_, _right_, _up_, or _down_.
 
+**move** <container|window> to workspace <name>::
+	Moves the focused container to the workspace identified by _name_.
+	_name_ may be a special workspace name. See **workspace**.
+
 **output** <name> <resolution|res WIDTHxHEIGHT> <position|pos X,Y>::
 	Configures the specified output. It will use the given resolution and be
 	arranged at the given position in the layout tree. You may omit either of
@@ -110,6 +114,10 @@ Commands
 
 **workspace** <name>::
 	Switches to the specified workspace.
+
+**workspace** <prev|next>::
+	Switches to the next workspace on the current output or on the next output
+	if currently on the last workspace.
 
 **workspace** <prev_on_output|next_on_output>::
 	Switches to the next workspace on the current output.

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -344,7 +344,7 @@ static bool cmd_focus_follows_mouse(struct sway_config *config, int argc, char *
 }
 
 static bool cmd_move(struct sway_config *config, int argc, char **argv) {
-	if (!checkarg(argc, "workspace", EXPECTED_EQUAL_TO, 1)) {
+	if (!checkarg(argc, "workspace", EXPECTED_AT_LEAST, 1)) {
 		return false;
 	}
 
@@ -358,6 +358,29 @@ static bool cmd_move(struct sway_config *config, int argc, char **argv) {
 		move_container(view,&root_container,MOVE_UP);
 	} else if (strcasecmp(argv[0], "down") == 0) {
 		move_container(view,&root_container,MOVE_DOWN);
+	} else if (strcasecmp(argv[0], "container") == 0 || strcasecmp(argv[0], "window") == 0) {
+		// "move container to workspace x"
+		if (!checkarg(argc, "move container/window", EXPECTED_EQUAL_TO, 4) ||
+			strcasecmp(argv[1], "to") != 0 ||
+			strcasecmp(argv[2], "workspace") != 0) {
+			return false;
+		}
+
+		if (view->type != C_CONTAINER && view->type != C_VIEW) {
+			return false;
+		}
+
+		const char *ws_name = argv[3];
+		if (argc == 5) {
+			// move "container to workspace number x"
+			ws_name = argv[4];
+		}
+
+		swayc_t *ws = workspace_by_name(ws_name);
+		if (ws == NULL) {
+			ws = workspace_create(ws_name);
+		}
+		move_container_to(view, ws);
 	} else {
 		return false;
 	}

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -668,23 +668,23 @@ static bool cmd_workspace(struct sway_config *config, int argc, char **argv) {
 	if (argc == 1) {
 		// Handle workspace next/prev
 		if (strcmp(argv[0], "next") == 0) {
-			workspace_next();
+			workspace_switch(workspace_next());
 			return true;
 		}
 
 		if (strcmp(argv[0], "prev") == 0) {
-			workspace_next();
+			workspace_switch(workspace_prev());
 			return true;
 		}
 
 		// Handle workspace output_next/prev
 		if (strcmp(argv[0], "next_on_output") == 0) {
-			workspace_output_next();
+			workspace_switch(workspace_output_next());
 			return true;
 		}
 
 		if (strcmp(argv[0], "prev_on_output") == 0) {
-			workspace_output_prev();
+			workspace_switch(workspace_output_prev());
 			return true;
 		}
 

--- a/sway/container.c
+++ b/sway/container.c
@@ -520,25 +520,24 @@ void set_view_visibility(swayc_t *view, void *data) {
 	if (!ASSERT_NONNULL(view)) {
 		return;
 	}
-	uint32_t mask = *(uint32_t *)data;
+	bool visible = *(bool *)data;
 	if (view->type == C_VIEW) {
-		wlc_view_set_mask(view->handle, mask);
-		if (mask & VISIBLE) {
+		wlc_view_set_mask(view->handle, visible ? VISIBLE : 0);
+		if (visible) {
 			wlc_view_bring_to_front(view->handle);
 		} else {
 			wlc_view_send_to_back(view->handle);
 		}
 	}
-	view->visible = mask & VISIBLE;
-	sway_log(L_DEBUG, "Container %p is now %s", view, view->visible ? "visible" : "invisible");
+	view->visible = visible;
+	sway_log(L_DEBUG, "Container %p is now %s", view, visible ? "visible" : "invisible");
 }
 
 void update_visibility(swayc_t *container) {
 	swayc_t *ws = swayc_active_workspace_for(container);
-	bool visible = ws->parent->focused == container;
-	uint32_t mask = visible ? VISIBLE : INVISIBLE;
+	bool visible = (ws->parent->focused == container);
 	sway_log(L_DEBUG, "Setting visibility of container %p to %s", container, visible ? "visible" : "invisible");
-	container_map(ws, set_view_visibility, &mask);
+	container_map(ws, set_view_visibility, &visible);
 }
 
 void reset_gaps(swayc_t *view, void *data) {

--- a/sway/container.c
+++ b/sway/container.c
@@ -520,16 +520,25 @@ void set_view_visibility(swayc_t *view, void *data) {
 	if (!ASSERT_NONNULL(view)) {
 		return;
 	}
-	uint32_t *p = data;
+	uint32_t mask = *(uint32_t *)data;
 	if (view->type == C_VIEW) {
-		wlc_view_set_mask(view->handle, *p);
-		if (*p == 2) {
+		wlc_view_set_mask(view->handle, mask);
+		if (mask & VISIBLE) {
 			wlc_view_bring_to_front(view->handle);
 		} else {
 			wlc_view_send_to_back(view->handle);
 		}
 	}
-	view->visible = (*p == 2);
+	view->visible = mask & VISIBLE;
+	sway_log(L_DEBUG, "Container %p is now %s", view, view->visible ? "visible" : "invisible");
+}
+
+void update_visibility(swayc_t *container) {
+	swayc_t *ws = swayc_active_workspace_for(container);
+	bool visible = ws->parent->focused == container;
+	uint32_t mask = visible ? VISIBLE : INVISIBLE;
+	sway_log(L_DEBUG, "Setting visibility of container %p to %s", container, visible ? "visible" : "invisible");
+	container_map(ws, set_view_visibility, &mask);
 }
 
 void reset_gaps(swayc_t *view, void *data) {

--- a/sway/container.c
+++ b/sway/container.c
@@ -522,6 +522,7 @@ void set_view_visibility(swayc_t *view, void *data) {
 	}
 	bool visible = *(bool *)data;
 	if (view->type == C_VIEW) {
+		wlc_view_set_output(view->handle, swayc_parent_by_type(view, C_OUTPUT)->handle);
 		wlc_view_set_mask(view->handle, visible ? VISIBLE : 0);
 		if (visible) {
 			wlc_view_bring_to_front(view->handle);
@@ -535,7 +536,7 @@ void set_view_visibility(swayc_t *view, void *data) {
 
 void update_visibility(swayc_t *container) {
 	swayc_t *ws = swayc_active_workspace_for(container);
-	bool visible = (ws->parent->focused == container);
+	bool visible = (ws->parent->focused == ws);
 	sway_log(L_DEBUG, "Setting visibility of container %p to %s", container, visible ? "visible" : "invisible");
 	container_map(ws, set_view_visibility, &visible);
 }

--- a/sway/focus.c
+++ b/sway/focus.c
@@ -28,11 +28,11 @@ static void update_focus(swayc_t *c) {
 			if (parent->focused) {
 				swayc_t *ws = parent->focused;
 				// hide visibility of old workspace
-				uint32_t mask = INVISIBLE;
-				container_map(ws, set_view_visibility, &mask);
+				bool visible = false;
+				container_map(ws, set_view_visibility, &visible);
 				// set visibility of new workspace
-				mask = VISIBLE;
-				container_map(c, set_view_visibility, &mask);
+				visible = true;
+				container_map(c, set_view_visibility, &visible);
 				destroy_workspace(ws);
 			}
 			break;

--- a/sway/focus.c
+++ b/sway/focus.c
@@ -28,12 +28,11 @@ static void update_focus(swayc_t *c) {
 			if (parent->focused) {
 				swayc_t *ws = parent->focused;
 				// hide visibility of old workspace
-				uint32_t mask = 1;
+				uint32_t mask = INVISIBLE;
 				container_map(ws, set_view_visibility, &mask);
 				// set visibility of new workspace
-				mask = 2;
+				mask = VISIBLE;
 				container_map(c, set_view_visibility, &mask);
-				wlc_output_set_mask(parent->handle, 2);
 				destroy_workspace(ws);
 			}
 			break;
@@ -45,8 +44,8 @@ static void update_focus(swayc_t *c) {
 			// for example, stacked and tabbing change stuff.
 			break;
 		}
+		c->parent->focused = c;
 	}
-	c->parent->focused = c;
 }
 
 bool move_focus(enum movement_direction direction) {

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -90,6 +90,9 @@ swayc_t *container_under_pointer(void) {
 static bool handle_output_created(wlc_handle output) {
 	swayc_t *op = new_output(output);
 
+	// Visibilty mask to be able to make view invisible
+	wlc_output_set_mask(output, VISIBLE);
+
 	if (!op) {
 		return false;
 	}

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -90,7 +90,7 @@ swayc_t *container_under_pointer(void) {
 static bool handle_output_created(wlc_handle output) {
 	swayc_t *op = new_output(output);
 
-	// Visibilty mask to be able to make view invisible
+	// Visibility mask to be able to make view invisible
 	wlc_output_set_mask(output, VISIBLE);
 
 	if (!op) {

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -203,6 +203,21 @@ void move_container(swayc_t *container,swayc_t* root,enum movement_direction dir
 
 }
 
+void move_container_to(swayc_t* container, swayc_t* destination) {
+	if (container->parent == destination) {
+		return;
+	}
+	destroy_container(remove_child(container));
+	set_focused_container(get_focused_view(&root_container));
+	if (container->is_floating) {
+		add_floating(destination, container);
+	} else {
+		add_child(destination, container);
+	}
+	update_visibility(container);
+	arrange_windows(&root_container, -1, -1);
+}
+
 void update_geometry(swayc_t *container) {
 	if (container->type != C_VIEW) {
 		return;

--- a/sway/util.c
+++ b/sway/util.c
@@ -1,0 +1,3 @@
+int wrap(int i, int max) {
+	return ((i % max) + max) % max;
+}

--- a/sway/util.c
+++ b/sway/util.c
@@ -1,3 +1,5 @@
+#include "util.h"
+
 int wrap(int i, int max) {
 	return ((i % max) + max) % max;
 }

--- a/sway/workspace.c
+++ b/sway/workspace.c
@@ -11,6 +11,7 @@
 #include "config.h"
 #include "stringop.h"
 #include "focus.h"
+#include "util.h"
 
 char *workspace_next_name(void) {
 	sway_log(L_DEBUG, "Workspace: Generating new name");
@@ -102,31 +103,27 @@ void workspace_output_next() {
 }
 
 void workspace_next() {
-	// Get the index of the workspace in the current output, and change the view to index+1 workspace.
-	// if we're currently focused on the last workspace in the output, change focus to there
-	// and call workspace_output_next(), as long as another output actually exists
+	// Get the index of the workspace in the current output, and change the focus to index+1 workspace.
+	// if we're currently focused on the last workspace in the output, change focus to the next output
+	// and call workspace_output_next()
+
 	swayc_t *current_output = swayc_active_workspace()->parent;
 	int i;
 	for (i = 0; i < current_output->children->length - 1; i++) {
-		if (strcmp((((swayc_t *)current_output->children->items[i])->name), swayc_active_workspace()->name) == 0) {
+		if (current_output->children->items[i] == swayc_active_workspace()) {
 			workspace_switch(current_output->children->items[i + 1]);
 			return;
 		}
 	}
-	if (root_container.children->length > 1) {
-		for (i = 0; i < root_container.children->length - 1; i++) {
-			if (root_container.children->items[i] == current_output) {
-				workspace_switch(((swayc_t *)root_container.children->items[i + 1])->focused);
-				workspace_output_next();
-				return;
-			}
+
+	int num_outputs = root_container.children->length;
+	for (i = 0; i < num_outputs; i++) {
+		if (root_container.children->items[i] == current_output) {
+			swayc_t *next_output = root_container.children->items[wrap(++i, num_outputs)];
+			workspace_switch(next_output->focused);
+			workspace_output_next();
+			return;
 		}
-		// If we're at the last output, then go to the first
-		workspace_switch(((swayc_t *)root_container.children->items[0])->focused);
-		workspace_output_next();
-		return;
-	} else {
-		workspace_switch(current_output->children->items[0]);
 	}
 }
 
@@ -145,34 +142,28 @@ void workspace_output_prev() {
 }
 
 void workspace_prev() {
-	// Get the index of the workspace in the current output, and change the view to index-1 workspace.
-	// if we're currently focused on the last workspace in the output, change focus to there
-	// and call workspace_output_next(), as long as another output actually exists
+	// Get the index of the workspace in the current output, and change the focus to index-1 workspace.
+	// if we're currently focused on the first workspace in the output, change focus to the previous output
+	// and call workspace_output_prev()
 
 	swayc_t *current_output = swayc_active_workspace()->parent;
 	int i;
 	for (i = 1; i < current_output->children->length; i++) {
-		if (strcmp((((swayc_t *)current_output->children->items[i])->name), swayc_active_workspace()->name) == 0) {
+		if (current_output->children->items[i] == swayc_active_workspace()) {
 			workspace_switch(current_output->children->items[i - 1]);
 			return;
 		}
 	}
-	if (root_container.children->length > 1) {
-		for (i = 1; i < root_container.children->length; i++) {
-			if (root_container.children->items[i] == current_output) {
-				workspace_switch(((swayc_t *)root_container.children->items[i - 1])->focused);
-				workspace_output_next();
-				return;
-			}
-		}
-		// If we're at the first output, then go to the last
-		workspace_switch(((swayc_t *)root_container.children->items[root_container.children->length-1])->focused);
-		workspace_output_next();
-		return;
-	} else {
-		workspace_switch(current_output->children->items[current_output->children->length - 1]);
-	}
 
+	int num_outputs = root_container.children->length;
+	for (i = 0; i < num_outputs; i++) {
+		if (root_container.children->items[i] == current_output) {
+			swayc_t *prev_output = root_container.children->items[wrap(--i, num_outputs)];
+			workspace_switch(prev_output->focused);
+			workspace_output_prev();
+			return;
+		}
+	}
 }
 
 void workspace_switch(swayc_t *workspace) {

--- a/sway/workspace.c
+++ b/sway/workspace.c
@@ -85,85 +85,95 @@ static bool _workspace_by_name(swayc_t *view, void *data) {
 }
 
 swayc_t *workspace_by_name(const char* name) {
-	return swayc_by_test(&root_container, _workspace_by_name, (void *) name);
+	if (strcmp(name, "prev") == 0) {
+		return workspace_prev();
+	}
+	else if (strcmp(name, "prev_on_output") == 0) {
+		return workspace_output_prev();
+	}
+	else if (strcmp(name, "next") == 0) {
+		return workspace_next();
+	}
+	else if (strcmp(name, "next_on_output") == 0) {
+		return workspace_output_next();
+	}
+	else if (strcmp(name, "current") == 0) {
+		return swayc_active_workspace();
+	}
+	else {
+		return swayc_by_test(&root_container, _workspace_by_name, (void *) name);
+	}
 }
 
-void workspace_output_next() {
-	// Get the index of the workspace in the current output, and change the view to index+1 workspace.
-	// if we're currently focused on the last workspace in the output, switch to the first
-	swayc_t *current_output = swayc_active_workspace()->parent;
+/**
+ * Get the previous or next workspace on the specified output.
+ * Wraps around at the end and beginning.
+ * If next is false, the previous workspace is returned, otherwise the next one is returned.
+ */
+swayc_t *workspace_output_prev_next_impl(swayc_t *output, bool next) {
+	if (!sway_assert(output->type == C_OUTPUT, "Argument must be an output, is %d", output->type)) {
+		return NULL;
+	}
+
 	int i;
-	for (i = 0; i < current_output->children->length - 1; i++) {
-		if (strcmp((((swayc_t *)current_output->children->items[i])->name), swayc_active_workspace()->name) == 0) {
-			workspace_switch(current_output->children->items[i + 1]);
-			return;
+	for (i = 0; i < output->children->length; i++) {
+		if (output->children->items[i] == output->focused) {
+			return output->children->items[wrap(i + (next ? 1 : -1), output->children->length)];
 		}
 	}
-	workspace_switch(current_output->children->items[0]);
+
+	// Doesn't happen, at worst the for loop returns the previously active workspace
+	return NULL;
 }
 
-void workspace_next() {
-	// Get the index of the workspace in the current output, and change the focus to index+1 workspace.
-	// if we're currently focused on the last workspace in the output, change focus to the next output
-	// and call workspace_output_next()
+/**
+ * Get the previous or next workspace. If the first/last workspace on an output is active,
+ * proceed to the previous/next output's previous/next workspace.
+ * If next is false, the previous workspace is returned, otherwise the next one is returned.
+ */
+swayc_t *workspace_prev_next_impl(swayc_t *workspace, bool next) {
+	if (!sway_assert(workspace->type == C_WORKSPACE, "Argument must be a workspace, is %d", workspace->type)) {
+		return NULL;
+	}
 
-	swayc_t *current_output = swayc_active_workspace()->parent;
+	swayc_t *current_output = workspace->parent;
+	int offset = next ? 1 : -1;
+	int start = next ? 0 : 1;
+	int end = next ? (current_output->children->length) - 1 : current_output->children->length;
 	int i;
-	for (i = 0; i < current_output->children->length - 1; i++) {
-		if (current_output->children->items[i] == swayc_active_workspace()) {
-			workspace_switch(current_output->children->items[i + 1]);
-			return;
+	for (i = start; i < end; i++) {
+		if (current_output->children->items[i] == workspace) {
+			return current_output->children->items[i + offset];
 		}
 	}
 
+	// Given workspace is the first/last on the output, jump to the previous/next output
 	int num_outputs = root_container.children->length;
 	for (i = 0; i < num_outputs; i++) {
 		if (root_container.children->items[i] == current_output) {
-			swayc_t *next_output = root_container.children->items[wrap(++i, num_outputs)];
-			workspace_switch(next_output->focused);
-			workspace_output_next();
-			return;
+			swayc_t *next_output = root_container.children->items[wrap(i + offset, num_outputs)];
+			return workspace_output_prev_next_impl(next_output, next);
 		}
 	}
+
+	// Doesn't happen, at worst the for loop returns the previously active workspace on the active output
+	return NULL;
 }
 
-void workspace_output_prev() {
-	// Get the index of the workspace in the current output, and change the view to index+1 workspace
-	// if we're currently focused on the first workspace in the output, do nothing and return false
-	swayc_t *current_output = swayc_active_workspace()->parent;
-	int i;
-	for (i = 1; i < current_output->children->length; i++) {
-		if (strcmp((((swayc_t *)current_output->children->items[i])->name), swayc_active_workspace()->name) == 0) {
-			workspace_switch(current_output->children->items[i - 1]);
-			return;
-		}
-	}
-	workspace_switch(current_output->children->items[current_output->children->length - 1]);
+swayc_t *workspace_output_next() {
+	return workspace_output_prev_next_impl(swayc_active_output(), true);
 }
 
-void workspace_prev() {
-	// Get the index of the workspace in the current output, and change the focus to index-1 workspace.
-	// if we're currently focused on the first workspace in the output, change focus to the previous output
-	// and call workspace_output_prev()
+swayc_t *workspace_next() {
+	return workspace_prev_next_impl(swayc_active_workspace(), true);
+}
 
-	swayc_t *current_output = swayc_active_workspace()->parent;
-	int i;
-	for (i = 1; i < current_output->children->length; i++) {
-		if (current_output->children->items[i] == swayc_active_workspace()) {
-			workspace_switch(current_output->children->items[i - 1]);
-			return;
-		}
-	}
+swayc_t *workspace_output_prev() {
+	return workspace_output_prev_next_impl(swayc_active_output(), false);
+}
 
-	int num_outputs = root_container.children->length;
-	for (i = 0; i < num_outputs; i++) {
-		if (root_container.children->items[i] == current_output) {
-			swayc_t *prev_output = root_container.children->items[wrap(--i, num_outputs)];
-			workspace_switch(prev_output->focused);
-			workspace_output_prev();
-			return;
-		}
-	}
+swayc_t *workspace_prev() {
+	return workspace_prev_next_impl(swayc_active_workspace(), false);
 }
 
 void workspace_switch(swayc_t *workspace) {


### PR DESCRIPTION
- Fixes to the visibility of views
- `move container to workspace <name>`
- rewrote `workspace{,_output}_{prev,next}` and patched that into `workspace_by_name` so it works with the move command