### PR TITLE
Focus floating window, if any, when the last tiling window has been closed

### DIFF
--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -230,9 +230,7 @@ static void handle_view_destroyed(wlc_handle handle) {
 
     swayc_t *focused_view = get_focused_view(&root_container);
     if(focused_view->type == C_WORKSPACE && focused_view->children->length == 0){
-        sway_log(L_DEBUG, "we are here first");
         if(focused_view->floating->length > 0){
-            sway_log(L_DEBUG, "we are here %d", focused_view->floating->length);
             focused_view = focused_view->floating->items[focused_view->floating->length-1];
             focused_view = get_focused_view(focused_view);
         }

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -228,13 +228,13 @@ static void handle_view_destroyed(wlc_handle handle) {
 		break;
 	}
 
-    swayc_t *focused_view = get_focused_view(&root_container);
-    if(focused_view->type == C_WORKSPACE && focused_view->children->length == 0){
-        if(focused_view->floating->length > 0){
-            focused_view = focused_view->floating->items[focused_view->floating->length-1];
-            focused_view = get_focused_view(focused_view);
-        }
-    }
+	swayc_t *focused_view = get_focused_view(&root_container);
+	if (focused_view->type == C_WORKSPACE && focused_view->children->length == 0) {
+		if (focused_view->floating->length > 0) {
+			focused_view = focused_view->floating->items[focused_view->floating->length-1];
+			focused_view = get_focused_view(focused_view);
+		}
+	}
 	set_focused_container(focused_view);
 }
 

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -227,7 +227,17 @@ static void handle_view_destroyed(wlc_handle handle) {
 		locked_container_focus = false;
 		break;
 	}
-	set_focused_container(get_focused_view(&root_container));
+
+    swayc_t *focused_view = get_focused_view(&root_container);
+    if(focused_view->type == C_WORKSPACE && focused_view->children->length == 0){
+        sway_log(L_DEBUG, "we are here first");
+        if(focused_view->floating->length > 0){
+            sway_log(L_DEBUG, "we are here %d", focused_view->floating->length);
+            focused_view = focused_view->floating->items[focused_view->floating->length-1];
+            focused_view = get_focused_view(focused_view);
+        }
+    }
+	set_focused_container(focused_view);
 }
 
 static void handle_view_focus(wlc_handle view, bool focus) {


### PR DESCRIPTION
Addresses issue #126:
The fix doesn't exactly replicate I3wm's behavior, mostly because I3wm's behavior is counter intuitive.