### PR TITLE
move_container_to fixup

### DIFF
--- a/include/container.h
+++ b/include/container.h
@@ -101,6 +101,7 @@ swayc_t *swayc_active_workspace_for(swayc_t *view);
 // Container information
 
 bool swayc_is_fullscreen(swayc_t *view);
+bool swayc_is_active(swayc_t *view);
 
 // Mapping functions
 
@@ -109,7 +110,6 @@ void container_map(swayc_t *, void (*f)(swayc_t *, void *), void *);
 // Mappings
 void set_view_visibility(swayc_t *view, void *data);
 void reset_gaps(swayc_t *view, void *data);
-
 
 void update_visibility(swayc_t *container);
 

--- a/include/log.h
+++ b/include/log.h
@@ -15,7 +15,11 @@ void sway_log_colors(int mode);
 void sway_log(log_importance_t verbosity, const char* format, ...) __attribute__((format(printf,2,3)));
 void sway_log_errno(log_importance_t verbosity, char* format, ...) __attribute__((format(printf,2,3)));
 void sway_abort(const char* format, ...) __attribute__((format(printf,1,2)));
-bool sway_assert(bool condition, const char* format, ...) __attribute__((format(printf,2,3)));
+
+bool _sway_assert(bool condition, const char* format, ...) __attribute__((format(printf,2,3)));
+#define sway_assert(COND, FMT, ...) \
+	_sway_assert(COND, "%s:" FMT, __PRETTY_FUNCTION__, ##__VA_ARGS__)
+
 void error_handler(int sig);
 
 void layout_log(const swayc_t *c, int depth);

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -380,7 +380,7 @@ static bool cmd_move(struct sway_config *config, int argc, char **argv) {
 		if (ws == NULL) {
 			ws = workspace_create(ws_name);
 		}
-		move_container_to(view, ws);
+		move_container_to(view, get_focused_container(ws));
 	} else {
 		return false;
 	}

--- a/sway/container.c
+++ b/sway/container.c
@@ -9,7 +9,7 @@
 #include "log.h"
 
 #define ASSERT_NONNULL(PTR) \
-	sway_assert (PTR, "%s: " #PTR "must be non-null", __func__)
+	sway_assert (PTR, #PTR "must be non-null")
 
 static swayc_t *new_swayc(enum swayc_types type) {
 	swayc_t *c = calloc(1, sizeof(swayc_t));
@@ -305,7 +305,7 @@ swayc_t *destroy_workspace(swayc_t *workspace) {
 
 	// Do not destroy if there are children
 	if (workspace->children->length == 0 && workspace->floating->length == 0) {
-		sway_log(L_DEBUG, "%s: '%s'", __func__, workspace->name);
+		sway_log(L_DEBUG, "'%s'", workspace->name);
 		swayc_t *parent = workspace->parent;
 		free_swayc(workspace);
 		return parent;
@@ -376,7 +376,7 @@ swayc_t *swayc_parent_by_type(swayc_t *container, enum swayc_types type) {
 	if (!ASSERT_NONNULL(container)) {
 		return NULL;
 	}
-	if (!sway_assert(type < C_TYPES && type >= C_ROOT, "%s: invalid type", __func__)) {
+	if (!sway_assert(type < C_TYPES && type >= C_ROOT, "invalid type")) {
 		return NULL;
 	}
 	do {
@@ -389,7 +389,7 @@ swayc_t *swayc_parent_by_layout(swayc_t *container, enum swayc_layouts layout) {
 	if (!ASSERT_NONNULL(container)) {
 		return NULL;
 	}
-	if (!sway_assert(layout < L_LAYOUTS && layout >= L_NONE, "%s: invalid layout", __func__)) {
+	if (!sway_assert(layout < L_LAYOUTS && layout >= L_NONE, "invalid layout")) {
 		return NULL;
 	}
 	do {
@@ -402,7 +402,7 @@ swayc_t *swayc_focus_by_type(swayc_t *container, enum swayc_types type) {
 	if (!ASSERT_NONNULL(container)) {
 		return NULL;
 	}
-	if (!sway_assert(type < C_TYPES && type >= C_ROOT, "%s: invalid type", __func__)) {
+	if (!sway_assert(type < C_TYPES && type >= C_ROOT, "invalid type")) {
 		return NULL;
 	}
 	do {
@@ -410,11 +410,12 @@ swayc_t *swayc_focus_by_type(swayc_t *container, enum swayc_types type) {
 	} while (container && container->type != type);
 	return container;
 }
+
 swayc_t *swayc_focus_by_layout(swayc_t *container, enum swayc_layouts layout) {
 	if (!ASSERT_NONNULL(container)) {
 		return NULL;
 	}
-	if (!sway_assert(layout < L_LAYOUTS && layout >= L_NONE, "%s: invalid layout", __func__)) {
+	if (!sway_assert(layout < L_LAYOUTS && layout >= L_NONE, "invalid layout")) {
 		return NULL;
 	}
 	do {
@@ -494,6 +495,10 @@ bool swayc_is_fullscreen(swayc_t *view) {
 	return view && view->type == C_VIEW && (wlc_view_get_state(view->handle) & WLC_BIT_FULLSCREEN);
 }
 
+bool swayc_is_active(swayc_t *view) {
+	return view && view->type == C_VIEW && (wlc_view_get_state(view->handle) & WLC_BIT_ACTIVATED);
+}
+
 // Mapping
 
 void container_map(swayc_t *container, void (*f)(swayc_t *view, void *data), void *data) {
@@ -536,6 +541,7 @@ void set_view_visibility(swayc_t *view, void *data) {
 
 void update_visibility(swayc_t *container) {
 	swayc_t *ws = swayc_active_workspace_for(container);
+	// TODO better visibility setting
 	bool visible = (ws->parent->focused == ws);
 	sway_log(L_DEBUG, "Setting visibility of container %p to %s", container, visible ? "visible" : "invisible");
 	container_map(ws, set_view_visibility, &visible);

--- a/sway/log.c
+++ b/sway/log.c
@@ -100,7 +100,7 @@ void sway_log_errno(log_importance_t verbosity, char* format, ...) {
 	}
 }
 
-bool sway_assert(bool condition, const char* format, ...) {
+bool _sway_assert(bool condition, const char* format, ...) {
 	if (condition) {
 		return true;
 	}

--- a/sway/main.c
+++ b/sway/main.c
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {
 		{"version", no_argument, NULL, 'v'},
 		{"verbose", no_argument, &verbose, 1},
 		{"get-socketpath", no_argument, NULL, 'p'},
-		{0,0,0,0}
+		{0, 0, 0, 0}
 	};
 
 	/* Signal handling */
@@ -127,7 +127,7 @@ int main(int argc, char **argv) {
 	return 0;
 }
 
-static void sigchld_handle(int signal) {
+void sigchld_handle(int signal) {
 	(void) signal;
 	while (waitpid((pid_t)-1, 0, WNOHANG) > 0);
 }


### PR DESCRIPTION
`move container to workspace %s` has more proper behavior.
changed `sway_assert` to a macro that calls `_sway_assert` with `__PRETTY_FUNCTION__:` prepended.