### PR TITLE
use previous output containers

### DIFF
--- a/include/container.h
+++ b/include/container.h
@@ -94,6 +94,7 @@ swayc_t *swayc_focus_by_layout(swayc_t *container, enum swayc_layouts);
 
 
 swayc_t *swayc_by_handle(wlc_handle handle);
+swayc_t *swayc_by_name(const char *name);
 swayc_t *swayc_active_output(void);
 swayc_t *swayc_active_workspace(void);
 swayc_t *swayc_active_workspace_for(swayc_t *view);

--- a/include/container.h
+++ b/include/container.h
@@ -103,6 +103,10 @@ swayc_t *swayc_active_workspace_for(swayc_t *view);
 
 bool swayc_is_fullscreen(swayc_t *view);
 bool swayc_is_active(swayc_t *view);
+// Is `parent` the parent of `child`
+bool swayc_is_parent_of(swayc_t *parent, swayc_t *child);
+// Is `child` a child of `parent`
+bool swayc_is_child_of(swayc_t *child, swayc_t *parent);
 
 // Mapping functions
 

--- a/sway/container.c
+++ b/sway/container.c
@@ -603,10 +603,18 @@ void update_visibility_output(swayc_t *container, wlc_handle output) {
 		}
 	}
 	// Update visibility for children
-	else if (container->children) {
-		int i, len = container->children->length;
-		for (i = 0; i < len; ++i) {
-			update_visibility_output(container->children->items[i], output);
+	else {
+		if (container->children) {
+			int i, len = container->children->length;
+			for (i = 0; i < len; ++i) {
+				update_visibility_output(container->children->items[i], output);
+			}
+		}
+		if (container->floating) {
+			int i, len = container->floating->length;
+			for (i = 0; i < len; ++i) {
+				update_visibility_output(container->floating->items[i], output);
+			}
 		}
 	}
 }

--- a/sway/container.c
+++ b/sway/container.c
@@ -547,6 +547,20 @@ bool swayc_is_active(swayc_t *view) {
 	return view && view->type == C_VIEW && (wlc_view_get_state(view->handle) & WLC_BIT_ACTIVATED);
 }
 
+bool swayc_is_parent_of(swayc_t *parent, swayc_t *child) {
+	while (child != &root_container) {
+		child = child->parent;
+		if (child == parent) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool swayc_is_child_of(swayc_t *child, swayc_t *parent) {
+	return swayc_is_parent_of(parent, child);
+}
+
 // Mapping
 
 void container_map(swayc_t *container, void (*f)(swayc_t *view, void *data), void *data) {
@@ -568,58 +582,64 @@ void container_map(swayc_t *container, void (*f)(swayc_t *view, void *data), voi
 	}
 }
 
-void set_view_visibility(swayc_t *view, void *data) {
-	if (!ASSERT_NONNULL(view)) {
-		return;
+void update_visibility_output(swayc_t *container, wlc_handle output) {
+	// Inherit visibility
+	swayc_t *parent = container->parent;
+	container->visible = parent->visible;
+	// special cases where visibility depends on focus
+	if (parent->type == C_OUTPUT
+			|| parent->layout == L_TABBED
+			|| parent->layout == L_STACKED) {
+		container->visible = parent->focused == container;
 	}
-	// TODO add something like this.
-//	if (container->type == C_ROOT) {
-//		container->visible = true;
-//	} else {
-//		// Inherit visibility
-//		swayc_t *parent = container->parent;
-//		container->visible = parent->visible;
-//		// special cases where visibility depends on focus
-//		if (parent->type == C_OUTPUT || parent->layout == L_TABBED ||
-//				parent->layout == L_STACKED) {
-//			container->visible = parent->focused == container;
-//		}
-//	}
-	bool visible = *(bool *)data;
-	if (view->type == C_VIEW) {
-		wlc_view_set_output(view->handle, swayc_parent_by_type(view, C_OUTPUT)->handle);
-		wlc_view_set_mask(view->handle, visible ? VISIBLE : 0);
-		if (visible) {
-			wlc_view_bring_to_front(view->handle);
+	// Set visibility and output for view
+	if (container->type == C_VIEW) {
+		wlc_view_set_output(container->handle, output);
+		wlc_view_set_mask(container->handle, container->visible ? VISIBLE : 0);
+		if (container->visible) {
+			wlc_view_bring_to_front(container->handle);
 		} else {
-			wlc_view_send_to_back(view->handle);
+			wlc_view_send_to_back(container->handle);
 		}
 	}
-	view->visible = visible;
-	sway_log(L_DEBUG, "Container %p is now %s", view, visible ? "visible" : "invisible");
+	// Update visibility for children
+	else if (container->children) {
+		int i, len = container->children->length;
+		for (i = 0; i < len; ++i) {
+			update_visibility_output(container->children->items[i], output);
+		}
+	}
 }
 
 void update_visibility(swayc_t *container) {
-	if (!container) {
-		return;
-	}
-	swayc_t *ws;
-	if (container->type == C_ROOT || container->type == C_OUTPUT) {
-		int i, len = container->children->length;
-		for (i = 0; i < len; ++i) {
-			update_visibility(container->children->items[i]);
+	if (!container) return;
+	switch (container->type) {
+	case C_ROOT:
+		container->visible = true;
+		if (container->children) {
+			int i, len = container->children->length;
+			for (i = 0; i < len; ++i) {
+				update_visibility(container->children->items[i]);
+			}
 		}
 		return;
-	} else if (container->type == C_WORKSPACE) {
-		container->visible = container->parent->focused == container;
-		ws = container;
-	} else {
-		ws = swayc_active_workspace_for(container);
+
+	case C_OUTPUT:
+		container->visible = true;
+		if (container->children) {
+			int i, len = container->children->length;
+			for (i = 0; i < len; ++i) {
+				update_visibility_output(container->children->items[i], container->handle);
+			}
+		}
+		return;
+
+	default:
+		{
+			swayc_t *op = swayc_parent_by_type(container, C_OUTPUT);
+			update_visibility_output(container, op->handle);
+		}
 	}
-	// TODO better visibility setting
-	bool visible = (ws->parent->focused == ws);
-	sway_log(L_DEBUG, "Setting visibility of container %p to %s", container, visible ? "visible" : "invisible");
-	container_map(ws, set_view_visibility, &visible);
 }
 
 void reset_gaps(swayc_t *view, void *data) {

--- a/sway/container.c
+++ b/sway/container.c
@@ -342,7 +342,7 @@ swayc_t *destroy_workspace(swayc_t *workspace) {
 
 	// Do not destroy if there are children
 	if (workspace->children->length == 0 && workspace->floating->length == 0) {
-		sway_log(L_DEBUG, "destroying '%s'", workspace->name);
+		sway_log(L_DEBUG, "destroying workspace '%s'", workspace->name);
 		swayc_t *parent = workspace->parent;
 		free_swayc(workspace);
 		return parent;
@@ -600,7 +600,22 @@ void set_view_visibility(swayc_t *view, void *data) {
 }
 
 void update_visibility(swayc_t *container) {
-	swayc_t *ws = swayc_active_workspace_for(container);
+	if (!container) {
+		return;
+	}
+	swayc_t *ws;
+	if (container->type == C_ROOT || container->type == C_OUTPUT) {
+		int i, len = container->children->length;
+		for (i = 0; i < len; ++i) {
+			update_visibility(container->children->items[i]);
+		}
+		return;
+	} else if (container->type == C_WORKSPACE) {
+		container->visible = container->parent->focused == container;
+		ws = container;
+	} else {
+		ws = swayc_active_workspace_for(container);
+	}
 	// TODO better visibility setting
 	bool visible = (ws->parent->focused == ws);
 	sway_log(L_DEBUG, "Setting visibility of container %p to %s", container, visible ? "visible" : "invisible");

--- a/sway/focus.c
+++ b/sway/focus.c
@@ -14,6 +14,10 @@ static void update_focus(swayc_t *c) {
 	// Handle if focus switches
 	swayc_t *parent = c->parent;
 	if (parent->focused != c) {
+		// Get previous focus
+		swayc_t *prev = parent->focused;
+		// Set new focus
+		parent->focused = c;
 		switch (c->type) {
 		// Shouldnt happen
 		case C_ROOT: return;
@@ -25,16 +29,13 @@ static void update_focus(swayc_t *c) {
 
 		// Case where workspace changes
 		case C_WORKSPACE:
-			if (parent->focused) {
-				swayc_t *ws = parent->focused;
-				// hide visibility of old workspace
-				bool visible = false;
-				container_map(ws, set_view_visibility, &visible);
-				// set visibility of new workspace
-				visible = true;
-				container_map(c, set_view_visibility, &visible);
-				destroy_workspace(ws);
+			if (prev) {
+				// update visibility of old workspace
+				update_visibility(prev);
+				destroy_workspace(prev);
 			}
+			// Update visibility of newly focused workspace
+			update_visibility(c);
 			break;
 
 		default:
@@ -44,7 +45,6 @@ static void update_focus(swayc_t *c) {
 			// for example, stacked and tabbing change stuff.
 			break;
 		}
-		c->parent->focused = c;
 	}
 }
 

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -221,7 +221,7 @@ void move_container(swayc_t *container,swayc_t* root,enum movement_direction dir
 }
 
 void move_container_to(swayc_t* container, swayc_t* destination) {
-	if (container == destination) {
+	if (container == destination && swayc_is_parent_of(container, destination)) {
 		return;
 	}
 	swayc_t *parent = remove_child(container);


### PR DESCRIPTION
after testing out tty switching, i noticed that it creates duplicate outputs.
also unlike the log in #141 it doesnt destroy outputs when switching, i dont know why though.
though it does attempt to recreate them when switching back.

welp, went and redid the `update_visibility`,
also added some helper functions and cleaned up `update_focus`