### PR TITLE
Add CI support

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -7,11 +7,10 @@ git submodule update --init --recursive # - initialize and fetch submodules
 mkdir target && cd target               # - create build target directory
 cmake -DCMAKE_BUILD_TYPE=Upstream ..    # - run CMake
 make                                    # - compile
+sudo make install                       # - install
 
 cd ../..
 
 # build sway
-cmake \
-    -DWLC_LIBRARIES=wlc/target/src/libwlc.so \
-    -DWLC_INCLUDE_DIRS=wlc/include .
+cmake .
 make

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# clone and build wlc
+git clone https://github.com/Cloudef/wlc.git
+cd wlc
+git submodule update --init --recursive # - initialize and fetch submodules
+mkdir target && cd target               # - create build target directory
+cmake -DCMAKE_BUILD_TYPE=Upstream ..    # - run CMake
+make                                    # - compile
+
+cd ../..
+
+# build sway
+cmake \
+    -DWLC_LIBRARIES=wlc/target/src/libwlc.so \
+    -DWLC_INCLUDE_DIRS=wlc/include .
+make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+sudo: required
+
+arch:
+  packages:
+    - cmake
+    - xorg-server-xwayland
+    - asciidoc
+    - pcre
+    - json-c
+    # aur
+    - wlc-git
+  script:
+    - "cmake ."
+    - "make"
+
+script:
+  - "curl -s https://raw.githubusercontent.com/mikkeloscar/arch-travis/master/arch-travis.sh | bash"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,16 @@ arch:
     - asciidoc
     - pcre
     - json-c
-    # aur
-    - wlc-git
+    - pixman
+    - wayland
+    - libxkbcommon
+    - libinput
+    - libx11
+    - libxcb
+    - libgl
+    - mesa
   script:
-    - "cmake ."
-    - "make"
+    - "bash .ci/build.sh"
 
 script:
   - "curl -s https://raw.githubusercontent.com/mikkeloscar/arch-travis/master/arch-travis.sh | bash"


### PR DESCRIPTION
As discussed in #20 this adds support for travis-ci builds based on [arch-travis](https://github.com/mikkeloscar/arch-travis).

I have added `make install` for wlc as suggested by @Luminarys 