### PR TITLE
default gap value.

### DIFF
--- a/include/container.h
+++ b/include/container.h
@@ -107,6 +107,8 @@ bool swayc_is_active(swayc_t *view);
 bool swayc_is_parent_of(swayc_t *parent, swayc_t *child);
 // Is `child` a child of `parent`
 bool swayc_is_child_of(swayc_t *child, swayc_t *parent);
+// Return gap of specified container
+int swayc_gap(swayc_t *container);
 
 // Mapping functions
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -519,8 +519,7 @@ static bool cmd_gaps(struct sway_config *config, int argc, char **argv) {
 	}
 
 	if (argc == 1) {
-		char *end;
-		int amount = (int)strtol(argv[0], &end, 10);
+		int amount = (int)strtol(argv[0], NULL, 10);
 		if (errno == ERANGE || amount == 0) {
 			errno = 0;
 			return false;
@@ -532,8 +531,7 @@ static bool cmd_gaps(struct sway_config *config, int argc, char **argv) {
 			config->gaps_outer = amount;
 		}
 	} else if (argc == 2) {
-		char *end;
-		int amount = (int)strtol(argv[1], &end, 10);
+		int amount = (int)strtol(argv[1], NULL, 10);
 		if (errno == ERANGE || amount == 0) {
 			errno = 0;
 			return false;
@@ -548,6 +546,7 @@ static bool cmd_gaps(struct sway_config *config, int argc, char **argv) {
 	} else {
 		return false;
 	}
+	arrange_windows(&root_container, -1, -1);
 	return true;
 }
 

--- a/sway/container.c
+++ b/sway/container.c
@@ -14,6 +14,7 @@
 static swayc_t *new_swayc(enum swayc_types type) {
 	swayc_t *c = calloc(1, sizeof(swayc_t));
 	c->handle = -1;
+	c->gaps = -1;
 	c->layout = L_NONE;
 	c->type = type;
 	if (type != C_VIEW) {
@@ -96,7 +97,6 @@ swayc_t *new_output(wlc_handle handle) {
 	}
 	output->handle = handle;
 	output->name = name ? strdup(name) : NULL;
-	output->gaps = config->gaps_outer;
 	
 	// Find position for it
 	if (oc && oc->x != -1 && oc->y != -1) {
@@ -243,8 +243,6 @@ swayc_t *new_view(swayc_t *sibling, wlc_handle handle) {
 	view->height = 0;
 	view->desired_width = geometry->size.w;
 	view->desired_height = geometry->size.h;
-
-	view->gaps = config->gaps_inner;
 
 	view->is_floating = false;
 
@@ -556,6 +554,16 @@ bool swayc_is_child_of(swayc_t *child, swayc_t *parent) {
 	return swayc_is_parent_of(parent, child);
 }
 
+int swayc_gap(swayc_t *container) {
+	if (container->type == C_VIEW) {
+		return container->gaps >= 0 ? container->gaps : config->gaps_inner;
+	} else if (container->type == C_WORKSPACE) {
+		return container->gaps >= 0 ? container->gaps : config->gaps_outer;
+	} else {
+		return 0;
+	}
+}
+
 // Mapping
 
 void container_map(swayc_t *container, void (*f)(swayc_t *view, void *data), void *data) {
@@ -650,10 +658,10 @@ void reset_gaps(swayc_t *view, void *data) {
 	if (!ASSERT_NONNULL(view)) {
 		return;
 	}
-	if (view->type == C_OUTPUT) {
-		view->gaps = config->gaps_outer;
+	if (view->type == C_WORKSPACE) {
+		view->gaps = -1;
 	}
 	if (view->type == C_VIEW) {
-		view->gaps = config->gaps_inner;
+		view->gaps = -1;
 	}
 }

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -319,14 +319,15 @@ void update_geometry(swayc_t *container) {
 	if (container->type != C_VIEW) {
 		return;
 	}
+	int gap = swayc_gap(container);
 	struct wlc_geometry geometry = {
 		.origin = {
-			.x = container->x + (container->is_floating ? 0 : container->gaps / 2),
-			.y = container->y + (container->is_floating ? 0 : container->gaps / 2)
+			.x = container->x + (container->is_floating ? 0 : gap / 2),
+			.y = container->y + (container->is_floating ? 0 : gap / 2)
 		},
 		.size = {
-			.w = container->width - (container->is_floating ? 0 : container->gaps),
-			.h = container->height - (container->is_floating ? 0 : container->gaps)
+			.w = container->width - (container->is_floating ? 0 : gap),
+			.h = container->height - (container->is_floating ? 0 : gap)
 		}
 	};
 	if (swayc_is_fullscreen(container)) {
@@ -364,10 +365,11 @@ void arrange_windows(swayc_t *container, double width, double height) {
 		x = 0, y = 0;
 		for (i = 0; i < container->children->length; ++i) {
 			swayc_t *child = container->children->items[i];
-			child->x = x + container->gaps;
-			child->y = y + container->gaps;
-			child->width = width - container->gaps * 2;
-			child->height = height - container->gaps * 2;
+			int gap = swayc_gap(child);
+			child->x = x + gap;
+			child->y = y + gap;
+			child->width = width - gap * 2;
+			child->height = height - gap * 2;
 			sway_log(L_DEBUG, "Arranging workspace #%d at %f, %f", i, child->x, child->y);
 			arrange_windows(child, -1, -1);
 		}
@@ -582,17 +584,7 @@ void recursive_resize(swayc_t *container, double amount, enum wlc_resize_edge ed
 		layout_match = container->layout == L_VERT;
 	}
 	if (container->type == C_VIEW) {
-		struct wlc_geometry geometry = {
-			.origin = {
-				.x = container->x + container->gaps / 2,
-				.y = container->y + container->gaps / 2
-			},
-			.size = {
-				.w = container->width - container->gaps,
-				.h = container->height - container->gaps
-			}
-		};
-		wlc_view_set_geometry(container->handle, edge, &geometry);
+		update_geometry(container);
 		return;
 	}
 	if (layout_match) {


### PR DESCRIPTION
if in the future, we add a command for setting gaps of a window individually, this will help.
default value of `swayc_t.gap` is -1, in this case it gets the value to use from the `config->gaps_xxx`.
when `swayc_t.gap` is nonnegative it will use that instead.

also some minor changes.