### PR TITLE
Add link to travis-ci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# sway ![](https://api.travis-ci.org/SirCmpwn/sway.svg)
+# sway [![](https://api.travis-ci.org/SirCmpwn/sway.svg)](https://travis-ci.org/SirCmpwn/sway)
 
 "**S**irCmpwn's **Way**land window manager" is a **work in progress**
 i3-compatible window manager for [Wayland](http://wayland.freedesktop.org/).


### PR DESCRIPTION
Make the travis badge a link for easy access to the travis build page.