### PR TITLE
resize gap

### DIFF
--- a/include/container.h
+++ b/include/container.h
@@ -116,7 +116,9 @@ void container_map(swayc_t *, void (*f)(swayc_t *, void *), void *);
 
 // Mappings
 void set_view_visibility(swayc_t *view, void *data);
-void reset_gaps(swayc_t *view, void *data);
+// Set or add to gaps
+void set_gaps(swayc_t *view, void *amount);
+void add_gaps(swayc_t *view, void *amount);
 
 void update_visibility(swayc_t *container);
 

--- a/sway.5.txt
+++ b/sway.5.txt
@@ -64,11 +64,19 @@ Commands
 	Toggles fullscreen status for the focused view.
 
 **gaps** <amount>::
-	Adds _amount_ pixels between each view, and around each output.
+	Sets _amount_ pixels as the gap between each view, and around each
+	workspace.
 
 **gaps** <inner|outer> <amount>::
-	Adds _amount_ pixels as an _inner_ or _outer_ gap, where the former affects
-	spacing between views and the latter affects the space around each output.
+	Sets _amount_ pixels as the _inner_ or _outer_ gap, where the former affects
+	spacing between views and the latter affects the space around each
+	workspace.
+
+**gaps** <inner|outer> <all|workspace|current> <set|plus|minus> <amount>::
+	Changes the gaps for the _inner_ or _outer_ gap. _all_ changes the gaps for
+	all views or workspace, _workspace_ changes gaps for all views in current
+	workspace, or current workspace, and _current_ changes gaps for the current
+	view or workspace.
 
 **kill**::
 	Closes the currently focused view.

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -570,7 +570,7 @@ static bool cmd_gaps(struct sway_config *config, int argc, char **argv) {
 		target = CURRENT;
 	} else if (strcasecmp(target_str, "all") == 0) {
 		target = ALL;
-	} else if (strcasecmp(target_str, "workspace") == 0){
+	} else if (strcasecmp(target_str, "workspace") == 0) {
 		if (inout == OUTER) {
 			target = CURRENT;
 		} else {

--- a/sway/config.c
+++ b/sway/config.c
@@ -246,7 +246,6 @@ _continue:
 
 	if (is_active) {
 		temp_config->reloading = false;
-		container_map(&root_container, reset_gaps, NULL);
 		arrange_windows(&root_container, -1, -1);
 	}
 	config = temp_config;

--- a/sway/container.c
+++ b/sway/container.c
@@ -653,15 +653,24 @@ void update_visibility(swayc_t *container) {
 	}
 }
 
-void reset_gaps(swayc_t *view, void *data) {
-	(void) data;
+void set_gaps(swayc_t *view, void *_data) {
+	int *data = _data;
 	if (!ASSERT_NONNULL(view)) {
 		return;
 	}
-	if (view->type == C_WORKSPACE) {
-		view->gaps = -1;
+	if (view->type == C_WORKSPACE || view->type == C_VIEW) {
+		view->gaps = *data;
 	}
-	if (view->type == C_VIEW) {
-		view->gaps = -1;
+}
+
+void add_gaps(swayc_t *view, void *_data) {
+	int *data = _data;
+	if (!ASSERT_NONNULL(view)) {
+		return;
+	}
+	if (view->type == C_WORKSPACE || view->type == C_VIEW) {
+		if ((view->gaps += *data) < 0) {
+			view->gaps = 0;
+		}
 	}
 }

--- a/sway/log.c
+++ b/sway/log.c
@@ -159,8 +159,9 @@ static void container_log(const swayc_t *c) {
 			c->layout == L_STACKED  ? "Stacked|":
 			c->layout == L_FLOATING ? "Floating|":
 			"Unknown|");
-	fprintf(stderr, "w:%f|h:%f|", c->width, c->height);
-	fprintf(stderr, "x:%f|y:%f|", c->x, c->y);
+	fprintf(stderr, "w:%.f|h:%.f|", c->width, c->height);
+	fprintf(stderr, "x:%.f|y:%.f|", c->x, c->y);
+	fprintf(stderr, "g:%d|",c->gaps);
 	fprintf(stderr, "vis:%c|", c->visible?'t':'f');
 	fprintf(stderr, "name:%.16s|", c->name);
 	fprintf(stderr, "children:%d\n",c->children?c->children->length:0);


### PR DESCRIPTION
resize gaps for workspace, views via the following commands.
`gaps inner|outer all|current|workspace set|plus|minus nnn`
one difference in the `inner current|workspace`
airbladers `inner current` changes all view gaps for a workspace, while this sets it for the focused view.
and newly added `inner workspace` changes all view gaps for a workspace.

i could change `inner workspace` to `inner view` so the `inner current` is the same as airbladers, but it was a bit neater this way.