### PR TITLE
cmd status + workspace ws output op

### DIFF
--- a/include/commands.h
+++ b/include/commands.h
@@ -5,17 +5,16 @@
 
 struct cmd_handler {
 	char *command;
-	bool (*handle)(int argc, char **argv);
-	enum {
-		CMD_COMPOSITOR_READY,
-		CMD_KEYBIND,
-		CMD_ANYTIME
-	} config_type;
+	enum  cmd_status {
+		CMD_SUCCESS,
+		CMD_FAILURE,
+		CMD_DEFER,
+	} (*handle)(int argc, char **argv);
 };
 
-bool handle_command(char *command);
+enum cmd_status handle_command(char *command);
 // Handles commands during config
-bool config_command(char *command);
+enum cmd_status config_command(char *command);
 
 void remove_view_from_scratchpad();
 

--- a/include/config.h
+++ b/include/config.h
@@ -52,6 +52,7 @@ struct sway_config {
 	bool active;
 	bool failed;
 	bool reloading;
+	bool reading;
 	bool auto_back_and_forth;
 
 	int gaps_inner;

--- a/sway/config.c
+++ b/sway/config.c
@@ -102,6 +102,7 @@ static void config_defaults(struct sway_config *config) {
 	config->active = false;
 	config->failed = false;
 	config->auto_back_and_forth = false;
+	config->reading = false;
 
 	config->gaps_inner = 0;
 	config->gaps_outer = 0;
@@ -217,6 +218,7 @@ bool read_config(FILE *file, bool is_active) {
 	config = malloc(sizeof(struct sway_config));
 
 	config_defaults(config);
+	config->reading = true;
 	if (is_active) {
 		sway_log(L_DEBUG, "Performing configuration file reload");
 		config->reloading = true;
@@ -228,7 +230,8 @@ bool read_config(FILE *file, bool is_active) {
 	while (!feof(file)) {
 		line = read_line(file);
 		line = strip_comments(line);
-		if (!config_command(line)) {
+		if (config_command(line) == CMD_FAILURE) {
+			sway_log(L_ERROR, "Error on line '%s'", line);
 			success = false;
 		}
 		free(line);
@@ -242,6 +245,7 @@ bool read_config(FILE *file, bool is_active) {
 		free_config(old_config);
 	}
 
+	config->reading = false;
 	return success;
 }
 

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -478,12 +478,12 @@ static bool handle_pointer_button(wlc_handle view, uint32_t time, const struct w
 static void handle_wlc_ready(void) {
 	sway_log(L_DEBUG, "Compositor is ready, executing cmds in queue");
 	// Execute commands until there are none left
+	config->active = true;
 	while (config->cmd_queue->length) {
 		handle_command(config->cmd_queue->items[0]);
 		free(config->cmd_queue->items[0]);
 		list_del(config->cmd_queue, 0);
 	}
-	config->active = true;
 }
 
 struct wlc_interface interface = {

--- a/sway/stringop.c
+++ b/sway/stringop.c
@@ -145,7 +145,7 @@ char **split_args(const char *start, int *argc) {
 }
 
 void free_argv(int argc, char **argv) {
-	while (--argc) {
+	while (--argc > 0) {
 		free(argv[argc]);
 	}
 	free(argv);

--- a/sway/workspace.c
+++ b/sway/workspace.c
@@ -76,7 +76,26 @@ char *workspace_next_name(void) {
 }
 
 swayc_t *workspace_create(const char* name) {
-	swayc_t *parent = get_focused_container(&root_container);
+	swayc_t *parent;
+	// Search for workspace<->output pair
+	int i, e = config->workspace_outputs->length;
+	for (i = 0; i < e; ++i) {
+		struct workspace_output *wso = config->workspace_outputs->items[i];
+		if (strcasecmp(wso->workspace, name) == 0)
+		{
+			// Find output to use if it exists
+			e = root_container.children->length;
+			for (i = 0; i < e; ++i) {
+				parent = root_container.children->items[i];
+				if (strcmp(parent->name, wso->output) == 0) {
+					return new_workspace(parent, name);
+				}
+			}
+			break;
+		}
+	}
+	// Otherwise create a new one
+	parent = get_focused_container(&root_container);
 	parent = swayc_parent_by_type(parent, C_OUTPUT);
 	return new_workspace(parent, name);
 }


### PR DESCRIPTION
commands now return a status instead of boolean.
it now returns if it should defer the command, which only happens when !config->active

it now checks if its calling the command from a config or keybind and returns failure/success accordingly

ans workspace output behavior is fixed.
it wont move any already created workspaces but it will search for the output to use when creating workspace.