### PR TITLE
Add missing wlc dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ arch:
     - libinput
     - libx11
     - libxcb
+    - xcb-util-image
     - libgl
     - mesa
   script:


### PR DESCRIPTION
wlc now depends on `xcb-util-image` Cloudef@eecbeccf96dfea1f05c1ad89bb08f6cfd68be73d.