### PR TITLE
#187 cleanup zombies properly

### DIFF
--- a/sway/main.c
+++ b/sway/main.c
@@ -22,8 +22,6 @@ void sway_terminate(void) {
 	wlc_terminate();
 }
 
-static void sigchld_handle(int signal);
-
 static void wlc_log_handler(enum wlc_log_type type, const char *str) {
 	if (type == WLC_LOG_ERROR) {
 		sway_log(L_ERROR, "[wlc] %s", str);
@@ -64,8 +62,8 @@ int main(int argc, char **argv) {
 		{0, 0, 0, 0}
 	};
 
-	/* Signal handling */
-	signal(SIGCHLD, sigchld_handle);
+	/* clean zombie processes */
+	signal(SIGCHLD, SIG_IGN);
 
 	setenv("WLC_DIM", "0", 0);
 
@@ -151,9 +149,4 @@ int main(int argc, char **argv) {
 	ipc_terminate();
 
 	return 0;
-}
-
-void sigchld_handle(int signal) {
-	(void) signal;
-	while (waitpid((pid_t)-1, 0, WNOHANG) > 0);
 }


### PR DESCRIPTION
this seems to work.
it seemed the sigchld handler was only called once for the first child process that it closed.
