### PR TITLE
tell where openSUSE packages lives as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ available for you to install:
 
 * [Arch Linux](https://aur.archlinux.org/packages/sway-git/)
 * [Gentoo Linux](https://github.com/zetok/zetok-overlay/)
+* [openSUSE](https://build.opensuse.org/project/show/X11:Wayland)
 
 ### Compiling from Source
 


### PR DESCRIPTION
It seems to be good idea to add location for openSUSE packages as well.