### PR TITLE
Multi user

### DIFF
--- a/sway/ipc.c
+++ b/sway/ipc.c
@@ -82,8 +82,8 @@ void ipc_terminate(void) {
 
 struct sockaddr_un *ipc_user_sockaddr(void) {
 	struct sockaddr_un *ipc_sockaddr = malloc(sizeof(struct sockaddr_un));
-	if (!sway_assert(ipc_sockaddr != NULL, "can't malloc ipc_sockaddr")) {
-		return NULL;
+	if (ipc_sockaddr == NULL) {
+		sway_abort("can't malloc ipc_sockaddr");
 	}
 
 	ipc_sockaddr->sun_family = AF_UNIX;
@@ -93,8 +93,8 @@ struct sockaddr_un *ipc_user_sockaddr(void) {
 	// Without logind:
 	int allocating_path_size = snprintf(ipc_sockaddr->sun_path, path_size, "/tmp/sway-ipc.%i.sock", getuid());
 
-	if (!sway_assert(allocating_path_size < path_size, "socket path won't fit into ipc_sockaddr->sun_path")) {
-		return NULL;
+	if (allocating_path_size >= path_size) {
+		sway_abort("socket path won't fit into ipc_sockaddr->sun_path");
 	}
 
 	return ipc_sockaddr;

--- a/sway/ipc.c
+++ b/sway/ipc.c
@@ -81,7 +81,11 @@ struct sockaddr_un *ipc_user_sockaddr(void) {
   assert(ipc_sockaddr != NULL);
 
   ipc_sockaddr->sun_family = AF_UNIX;
-  strcpy(ipc_sockaddr->sun_path, "/tmp/sway-ipc.sock");
+
+  int path_size = sizeof(ipc_sockaddr->sun_path);
+
+  // Without logind:
+  assert(snprintf(ipc_sockaddr->sun_path, path_size, "/tmp/sway-ipc.%i.sock", getuid()) < path_size);
 
   return ipc_sockaddr;
 }

--- a/sway/ipc.c
+++ b/sway/ipc.c
@@ -74,6 +74,10 @@ void ipc_terminate(void) {
 	}
 	close(ipc_socket);
 	unlink(ipc_sockaddr->sun_path);
+
+	if (ipc_sockaddr) {
+		free(ipc_sockaddr);
+	}
 }
 
 struct sockaddr_un *ipc_user_sockaddr(void) {

--- a/sway/ipc.c
+++ b/sway/ipc.c
@@ -81,17 +81,17 @@ void ipc_terminate(void) {
 }
 
 struct sockaddr_un *ipc_user_sockaddr(void) {
-  struct sockaddr_un *ipc_sockaddr = malloc(sizeof(struct sockaddr_un));
-  assert(ipc_sockaddr != NULL);
+	struct sockaddr_un *ipc_sockaddr = malloc(sizeof(struct sockaddr_un));
+	assert(ipc_sockaddr != NULL);
 
-  ipc_sockaddr->sun_family = AF_UNIX;
+	ipc_sockaddr->sun_family = AF_UNIX;
 
-  int path_size = sizeof(ipc_sockaddr->sun_path);
+	int path_size = sizeof(ipc_sockaddr->sun_path);
 
-  // Without logind:
-  assert(snprintf(ipc_sockaddr->sun_path, path_size, "/tmp/sway-ipc.%i.sock", getuid()) < path_size);
+	// Without logind:
+	assert(snprintf(ipc_sockaddr->sun_path, path_size, "/tmp/sway-ipc.%i.sock", getuid()) < path_size);
 
-  return ipc_sockaddr;
+	return ipc_sockaddr;
 }
 
 int ipc_handle_connection(int fd, uint32_t mask, void *data) {

--- a/sway/ipc.c
+++ b/sway/ipc.c
@@ -82,14 +82,20 @@ void ipc_terminate(void) {
 
 struct sockaddr_un *ipc_user_sockaddr(void) {
 	struct sockaddr_un *ipc_sockaddr = malloc(sizeof(struct sockaddr_un));
-	assert(ipc_sockaddr != NULL);
+	if (!sway_assert(ipc_sockaddr != NULL, "can't malloc ipc_sockaddr")) {
+		return NULL;
+	}
 
 	ipc_sockaddr->sun_family = AF_UNIX;
 
 	int path_size = sizeof(ipc_sockaddr->sun_path);
 
 	// Without logind:
-	assert(snprintf(ipc_sockaddr->sun_path, path_size, "/tmp/sway-ipc.%i.sock", getuid()) < path_size);
+	int allocating_path_size = snprintf(ipc_sockaddr->sun_path, path_size, "/tmp/sway-ipc.%i.sock", getuid());
+
+	if (!sway_assert(allocating_path_size < path_size, "socket path won't fit into ipc_sockaddr->sun_path")) {
+		return NULL;
+	}
 
 	return ipc_sockaddr;
 }

--- a/sway/ipc.c
+++ b/sway/ipc.c
@@ -21,10 +21,7 @@
 
 static int ipc_socket = -1;
 static struct wlc_event_source *ipc_event_source =  NULL;
-static struct sockaddr_un ipc_sockaddr = {
-	.sun_family = AF_UNIX,
-	.sun_path = "/tmp/sway-ipc.sock"
-};
+static struct sockaddr_un *ipc_sockaddr = NULL;
 
 static const char ipc_magic[] = {'i', '3', '-', 'i', 'p', 'c'};
 
@@ -35,6 +32,7 @@ struct ipc_client {
 	enum ipc_command_type current_command;
 };
 
+struct sockaddr_un *ipc_user_sockaddr(void);
 int ipc_handle_connection(int fd, uint32_t mask, void *data);
 int ipc_client_handle_readable(int client_fd, uint32_t mask, void *data);
 void ipc_client_disconnect(struct ipc_client *client);
@@ -49,12 +47,14 @@ void ipc_init(void) {
 		sway_abort("Unable to create IPC socket");
 	}
 
+	ipc_sockaddr = ipc_user_sockaddr();
+
 	if (getenv("SWAYSOCK") != NULL) {
-		strncpy(ipc_sockaddr.sun_path, getenv("SWAYSOCK"), sizeof(ipc_sockaddr.sun_path));
+		strncpy(ipc_sockaddr->sun_path, getenv("SWAYSOCK"), sizeof(ipc_sockaddr->sun_path));
 	}
 
-	unlink(ipc_sockaddr.sun_path);
-	if (bind(ipc_socket, (struct sockaddr *)&ipc_sockaddr, sizeof(ipc_sockaddr)) == -1) {
+	unlink(ipc_sockaddr->sun_path);
+	if (bind(ipc_socket, (struct sockaddr *)ipc_sockaddr, sizeof(*ipc_sockaddr)) == -1) {
 		sway_abort("Unable to bind IPC socket");
 	}
 
@@ -63,7 +63,7 @@ void ipc_init(void) {
 	}
 
 	// Set i3 IPC socket path so that i3-msg works out of the box
-	setenv("I3SOCK", ipc_sockaddr.sun_path, 1);
+	setenv("I3SOCK", ipc_sockaddr->sun_path, 1);
 
 	ipc_event_source = wlc_event_loop_add_fd(ipc_socket, WLC_EVENT_READABLE, ipc_handle_connection, NULL);
 }
@@ -73,7 +73,17 @@ void ipc_terminate(void) {
 		wlc_event_source_remove(ipc_event_source);
 	}
 	close(ipc_socket);
-	unlink(ipc_sockaddr.sun_path);
+	unlink(ipc_sockaddr->sun_path);
+}
+
+struct sockaddr_un *ipc_user_sockaddr(void) {
+  struct sockaddr_un *ipc_sockaddr = malloc(sizeof(struct sockaddr_un));
+  assert(ipc_sockaddr != NULL);
+
+  ipc_sockaddr->sun_family = AF_UNIX;
+  strcpy(ipc_sockaddr->sun_path, "/tmp/sway-ipc.sock");
+
+  return ipc_sockaddr;
 }
 
 int ipc_handle_connection(int fd, uint32_t mask, void *data) {


### PR DESCRIPTION
If multiple users try to use sway at the same time the identically named ipc socket will prevent anyone other than the first user to actually run sway.

This patch fixes that by adding the user id to the socket path.

Note: I have no idea what I'm actually doing, please review carefully before pulling and please excuse any obvious errors I might have made ...

(Also, when using logind the path should actually be something like `/var/run/user/<id>/sway-ipc.socket`, but this patch is anyway an improvement.)