### PR TITLE
Configure outputs during reload 

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -6,6 +6,7 @@
 #include <xkbcommon/xkbcommon.h>
 #include "list.h"
 #include "layout.h"
+#include "container.h"
 
 struct sway_variable {
 	char *name;
@@ -62,6 +63,8 @@ struct sway_config {
 bool load_config(const char *file);
 bool read_config(FILE *file, bool is_active);
 char *do_var_replacement(char *str);
+// Setup output container by applying given config
+void apply_output_config(struct output_config *oc, swayc_t *output);
 
 extern struct sway_config *config;
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -619,7 +619,7 @@ static enum cmd_status cmd_output(int argc, char **argv) {
 
 	list_add(config->output_configs, output);
 
-	sway_log(L_DEBUG, "Configured output %s to %d x %d @ %d, %d",
+	sway_log(L_DEBUG, "Config stored for output %s (%d x %d @ %d, %d)",
 			output->name, output->width, output->height, output->x, output->y);
 
 	return CMD_SUCCESS;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -622,6 +622,20 @@ static enum cmd_status cmd_output(int argc, char **argv) {
 	sway_log(L_DEBUG, "Config stored for output %s (%d x %d @ %d, %d)",
 			output->name, output->width, output->height, output->x, output->y);
 
+	if (output->name) {
+		// Try to find the output container and apply configuration now. If
+		// this is during startup then there will be no container and config
+		// will be applied during normal "new output" event from wlc.
+		swayc_t *cont = NULL;
+		for (int i = 0; i < root_container.children->length; ++i) {
+			cont = root_container.children->items[i];
+			if (cont->name && strcmp(cont->name, output->name) == 0) {
+				apply_output_config(output, cont);
+				break;
+			}
+		}
+	}
+
 	return CMD_SUCCESS;
 }
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -561,7 +561,6 @@ static enum cmd_status cmd_orientation(int argc, char **argv) {
 }
 
 static enum cmd_status cmd_output(int argc, char **argv) {
-	if (!config->reading) return CMD_FAILURE;
 	if (!checkarg(argc, "output", EXPECTED_AT_LEAST, 1)) {
 		return CMD_FAILURE;
 	}

--- a/sway/config.c
+++ b/sway/config.c
@@ -283,6 +283,35 @@ bool read_config(FILE *file, bool is_active) {
 	return success;
 }
 
+void apply_output_config(struct output_config *oc, swayc_t *output) {
+	if (oc && oc->width != -1 && oc->height != -1) {
+		output->width = oc->width;
+		output->height = oc->height;
+
+		sway_log(L_DEBUG, "Set %s size to %ix%i", oc->name, oc->width, oc->height);
+		struct wlc_size new_size = { .w = oc->width, .h = oc->height };
+		wlc_output_set_resolution(output->handle, &new_size);
+	}
+
+	// Find position for it
+	if (oc && oc->x != -1 && oc->y != -1) {
+		sway_log(L_DEBUG, "Set %s position to %d, %d", oc->name, oc->x, oc->y);
+		output->x = oc->x;
+		output->y = oc->y;
+	} else {
+		int x = 0;
+		for (int i = 0; i < root_container.children->length; ++i) {
+			swayc_t *c = root_container.children->items[i];
+			if (c->type == C_OUTPUT) {
+				if (c->width + c->x > x) {
+					x = c->width + c->x;
+				}
+			}
+		}
+		output->x = x;
+	}
+}
+
 char *do_var_replacement(char *str) {
 	int i;
 	char *find = str;

--- a/sway/config.c
+++ b/sway/config.c
@@ -284,7 +284,7 @@ bool read_config(FILE *file, bool is_active) {
 }
 
 void apply_output_config(struct output_config *oc, swayc_t *output) {
-	if (oc && oc->width != -1 && oc->height != -1) {
+	if (oc && oc->width > 0 && oc->height > 0) {
 		output->width = oc->width;
 		output->height = oc->height;
 

--- a/sway/container.c
+++ b/sway/container.c
@@ -88,36 +88,12 @@ swayc_t *new_output(wlc_handle handle) {
 	}
 
 	swayc_t *output = new_swayc(C_OUTPUT);
-	if (oc && oc->width != -1 && oc->height != -1) {
-		output->width = oc->width;
-		output->height = oc->height;
-		struct wlc_size new_size = { .w = oc->width, .h = oc->height };
-		wlc_output_set_resolution(handle, &new_size);
-	} else {
-		output->width = size->w;
-		output->height = size->h;
-	}
 	output->handle = handle;
 	output->name = name ? strdup(name) : NULL;
-	
-	// Find position for it
-	if (oc && oc->x != -1 && oc->y != -1) {
-		sway_log(L_DEBUG, "Set %s position to %d, %d", name, oc->x, oc->y);
-		output->x = oc->x;
-		output->y = oc->y;
-	} else {
-		int x = 0;
-		for (i = 0; i < root_container.children->length; ++i) {
-			swayc_t *c = root_container.children->items[i];
-			if (c->type == C_OUTPUT) {
-				if (c->width + c->x > x) {
-					x = c->width + c->x;
-				}
-			}
-		}
-		output->x = x;
-	}
+	output->width = size->w;
+	output->height = size->h;
 
+	apply_output_config(oc, output);
 	add_child(&root_container, output);
 
 	// Create workspace

--- a/sway/container.c
+++ b/sway/container.c
@@ -70,7 +70,7 @@ swayc_t *new_output(wlc_handle handle) {
 		}
 	}
 
-	sway_log(L_DEBUG, "Added output %lu:%s", handle, name);
+	sway_log(L_DEBUG, "New output %lu:%s", handle, name);
 
 	struct output_config *oc = NULL;
 	int i;


### PR DESCRIPTION
config: Apply output config also during config reload.

My biggest patch so far, this code allows sway to apply changes in outputs config after config reload.

The position data isn't used (so far), but the resolution of the different outputs can now be changed on the fly by simply reloading the config. Everything seems to be working nicely. Please review.