### PR TITLE
Seamless mouse adjustments

### DIFF
--- a/include/focus.h
+++ b/include/focus.h
@@ -21,8 +21,8 @@ swayc_t *get_focused_container(swayc_t *parent);
 swayc_t *get_focused_view(swayc_t *parent);
 swayc_t *get_focused_float(swayc_t *ws);
 
-void set_focused_container(swayc_t *container);
-void set_focused_container_for(swayc_t *ancestor, swayc_t *container);
+bool set_focused_container(swayc_t *container);
+bool set_focused_container_for(swayc_t *ancestor, swayc_t *container);
 
 // lock focused container/view. locked by windows with OVERRIDE attribute
 // and unlocked when they are destroyed

--- a/include/workspace.h
+++ b/include/workspace.h
@@ -10,7 +10,7 @@ extern char *prev_workspace_name;
 char *workspace_next_name(void);
 swayc_t *workspace_create(const char*);
 swayc_t *workspace_by_name(const char*);
-void workspace_switch(swayc_t*);
+bool workspace_switch(swayc_t*);
 swayc_t *workspace_output_next();
 swayc_t *workspace_next();
 swayc_t *workspace_output_prev();

--- a/sway/focus.c
+++ b/sway/focus.c
@@ -53,11 +53,10 @@ bool move_focus(enum movement_direction direction) {
 	view = get_swayc_in_direction(view, direction);
 	if (view) {
 		if (direction == MOVE_PARENT) {
-			set_focused_container(view);
+			return set_focused_container(view);
 		} else {
-			set_focused_container(get_focused_view(view));
+			return set_focused_container(get_focused_view(view));
 		}
-		return true;
 	}
 	return false;
 }
@@ -73,9 +72,9 @@ swayc_t *get_focused_container(swayc_t *parent) {
 	return parent;
 }
 
-void set_focused_container(swayc_t *c) {
+bool set_focused_container(swayc_t *c) {
 	if (locked_container_focus || !c) {
-		return;
+		return false;
 	}
 	sway_log(L_DEBUG, "Setting focus to %p:%ld", c, c->handle);
 
@@ -84,7 +83,7 @@ void set_focused_container(swayc_t *c) {
 	swayc_t *focused = get_focused_view(workspace);
 	// if the workspace we are changing focus to has a fullscreen view return
 	if (swayc_is_fullscreen(focused) && focused != c) {
-		return;
+		return false;
 	}
 
 	// update container focus from here to root, making necessary changes along
@@ -115,17 +114,18 @@ void set_focused_container(swayc_t *c) {
 			}
 		}
 	}
+	return true;
 }
 
-void set_focused_container_for(swayc_t *a, swayc_t *c) {
+bool set_focused_container_for(swayc_t *a, swayc_t *c) {
 	if (locked_container_focus || !c) {
-		return;
+		return false;
 	}
 	swayc_t *find = c;
 	// Ensure that a is an ancestor of c
 	while (find != a && (find = find->parent)) {
 		if (find == &root_container) {
-			return;
+			return false;
 		}
 	}
 
@@ -134,7 +134,7 @@ void set_focused_container_for(swayc_t *a, swayc_t *c) {
 	swayc_t *focused = get_focused_view(workspace);
 	// if the workspace we are changing focus to has a fullscreen view return
 	if (swayc_is_fullscreen(focused) && c != focused) {
-		return;
+		return false;
 	}
 
 	// Check if we changing a parent container that will see chnage
@@ -147,8 +147,7 @@ void set_focused_container_for(swayc_t *a, swayc_t *c) {
 	}
 	if (effective) {
 		// Go to set_focused_container
-		set_focused_container(c);
-		return;
+		return set_focused_container(c);
 	}
 
 	sway_log(L_DEBUG, "Setting focus for %p:%ld to %p:%ld",
@@ -161,6 +160,7 @@ void set_focused_container_for(swayc_t *a, swayc_t *c) {
 		p = p->parent;
 		p->is_focused = false;
 	}
+	return true;
 }
 
 swayc_t *get_focused_view(swayc_t *parent) {

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -377,8 +377,9 @@ static bool handle_pointer_motion(wlc_handle handle, uint32_t time, const struct
 				}
 				if (c->y == output->y && c->x + c->width == output->x) {
 					sway_log(L_DEBUG, "%s is right of %s", output->name, c->name);
-					workspace_switch(c);
-					new_origin.x = c->width;
+					if (workspace_switch(c)) {
+						new_origin.x = c->width;
+					}
 				}
 			}
 		} else if ((double)origin->x == output->width) { // Right edge
@@ -389,8 +390,9 @@ static bool handle_pointer_motion(wlc_handle handle, uint32_t time, const struct
 				}
 				if (c->y == output->y && output->x + output->width == c->x) {
 					sway_log(L_DEBUG, "%s is left of %s", output->name, c->name);
-					workspace_switch(c);
-					new_origin.x = 0;
+					if (workspace_switch(c)) {
+						new_origin.x = 0;
+					}
 				}
 			}
 		}
@@ -402,8 +404,9 @@ static bool handle_pointer_motion(wlc_handle handle, uint32_t time, const struct
 				}
 				if (output->x == c->x && c->y + c->height == output->y) {
 					sway_log(L_DEBUG, "%s is below %s", output->name, c->name);
-					workspace_switch(c);
-					new_origin.y = c->height;
+					if (workspace_switch(c)) {
+						new_origin.y = c->height;
+					}
 				}
 			}
 		} else if ((double)origin->y == output->height) { // Bottom edge
@@ -414,8 +417,9 @@ static bool handle_pointer_motion(wlc_handle handle, uint32_t time, const struct
 				}
 				if (output->x == c->x && output->y + output->height == c->y) {
 					sway_log(L_DEBUG, "%s is above %s", output->name, c->name);
-					workspace_switch(c);
-					new_origin.y = 0;
+					if (workspace_switch(c)) {
+						new_origin.y = 0;
+					}
 				}
 			}
 		}

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -362,7 +362,8 @@ static bool handle_pointer_motion(wlc_handle handle, uint32_t time, const struct
 	//
 	// Since this doesn't currently support moving windows between outputs we
 	// don't do the switch if the pointer is in a mode.
-	if (config->seamless_mouse && !pointer_state.mode) {
+	if (config->seamless_mouse && !pointer_state.mode &&
+			!pointer_state.left.held && !pointer_state.right.held && !pointer_state.scroll.held) {
 		swayc_t *output = swayc_active_output();
 
 		// TODO: This implementation is naïve: We assume all outputs are

--- a/sway/workspace.c
+++ b/sway/workspace.c
@@ -198,9 +198,9 @@ swayc_t *workspace_prev() {
 	return workspace_prev_next_impl(swayc_active_workspace(), false);
 }
 
-void workspace_switch(swayc_t *workspace) {
+bool workspace_switch(swayc_t *workspace) {
 	if (!workspace) {
-		return;
+		return false;
 	}
 	swayc_t *active_ws = swayc_active_workspace();
 	if (config->auto_back_and_forth && active_ws == workspace && prev_workspace_name) {
@@ -217,6 +217,9 @@ void workspace_switch(swayc_t *workspace) {
 	}
 
 	sway_log(L_DEBUG, "Switching to workspace %p:%s", workspace, workspace->name);
-	set_focused_container(get_focused_view(workspace));
+	if (!set_focused_container(get_focused_view(workspace))) {
+		return false;
+	}
 	arrange_windows(workspace, -1, -1);
+	return true;
 }


### PR DESCRIPTION
1) If you're using a scrollbar at the edge of the screen you don't want to accidentally switch workspace (as that cancels the scrolling).

2) When using e.g. firefox, if you right click to open a menu and then move the cursor off the screen it will jump to the other edge of the screen because the menu actually blocked the switch from happening, so don't move the mouse pointer in those cases.