### PR TITLE
Learn focus / move container to adjacent output

### DIFF
--- a/include/layout.h
+++ b/include/layout.h
@@ -47,6 +47,7 @@ void swap_geometry(swayc_t *a, swayc_t *b);
 
 void move_container(swayc_t* container, enum movement_direction direction);
 void move_container_to(swayc_t* container, swayc_t* destination);
+void move_workspace_to(swayc_t* workspace, swayc_t* destination);
 
 // Layout
 void update_geometry(swayc_t *view);

--- a/sway.5.txt
+++ b/sway.5.txt
@@ -102,6 +102,10 @@ Commands
 	Moves the focused container to the workspace identified by _name_.
 	_name_ may be a special workspace name. See **workspace**.
 
+**move** <container|window> to output <name|direction>::
+	Moves the focused container to the output identified by _name_ or _direction_.
+	_direction_ may be one of _up_, _down_, _left_, _right_.
+
 **mouse_warping** <output|none>::
 	When _output_: place mouse at center of newly focused window when changing
 	output. When _none_: don't move mouse.

--- a/sway.5.txt
+++ b/sway.5.txt
@@ -102,9 +102,9 @@ Commands
 	Moves the focused container to the workspace identified by _name_.
 	_name_ may be a special workspace name. See **workspace**.
 
-**move** <container|window> to output <name|direction>::
-	Moves the focused container to the output identified by _name_ or _direction_.
-	_direction_ may be one of _up_, _down_, _left_, _right_.
+**move** <container|window|workspace> to output <name|direction>::
+	Moves the focused container or workspace to the output identified by _name_ or
+	_direction_. _direction_ may be one of _up_, _down_, _left_, _right_.
 
 **mouse_warping** <output|none>::
 	When _output_: place mouse at center of newly focused window when changing

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -556,7 +556,7 @@ static struct cmd_results *cmd_move(int argc, char **argv) {
 	}
 	const char* expected_syntax = "Expected 'move <left|right|up|down>' or "
 		"'move <container|window> to workspace <name>' or "
-		"'move <container|window> to output <name|direction>'";
+		"'move <container|window|workspace> to output <name|direction>'";
 	swayc_t *view = get_focused_container(&root_container);
 
 	if (strcasecmp(argv[0], "left") == 0) {
@@ -606,6 +606,25 @@ static struct cmd_results *cmd_move(int argc, char **argv) {
 			}
 		} else {
 			return cmd_results_new(CMD_INVALID, "move", expected_syntax);
+		}
+	} else if (strcasecmp(argv[0], "workspace") == 0) {
+		// move workspace (to output x)
+		swayc_t *output = NULL;
+		if ((error = checkarg(argc, "move workspace", EXPECTED_EQUAL_TO, 4))) {
+			return error;
+		} else if (strcasecmp(argv[1], "to") != 0 || strcasecmp(argv[2], "output") != 0) {
+			return cmd_results_new(CMD_INVALID, "move", expected_syntax);
+		} else if (!(output = output_by_name(argv[3]))) {
+			return cmd_results_new(CMD_FAILURE, "move workspace",
+				"Can't find output with name/at direction '%s'", argv[3]);
+		}
+		if (view->type == C_WORKSPACE) {
+			// This probably means we're moving an empty workspace, but
+			// that's fine.
+			move_workspace_to(view, output);
+		} else {
+			swayc_t *workspace = swayc_parent_by_type(view, C_WORKSPACE);
+			move_workspace_to(workspace, output);
 		}
 	} else if (strcasecmp(argv[0], "scratchpad") == 0) {
 		// move scratchpad ...

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -555,7 +555,8 @@ static struct cmd_results *cmd_move(int argc, char **argv) {
 		return error;
 	}
 	const char* expected_syntax = "Expected 'move <left|right|up|down>' or "
-		"'move <container|window> to workspace <name>'";
+		"'move <container|window> to workspace <name>' or "
+		"'move <container|window> to output <name|direction>'";
 	swayc_t *view = get_focused_container(&root_container);
 
 	if (strcasecmp(argv[0], "left") == 0) {
@@ -587,6 +588,22 @@ static struct cmd_results *cmd_move(int argc, char **argv) {
 				ws = workspace_create(ws_name);
 			}
 			move_container_to(view, get_focused_container(ws));
+		} else if (strcasecmp(argv[1], "to") == 0 && strcasecmp(argv[2], "output") == 0) {
+			// move container to output x
+			swayc_t *output = NULL;
+			if (view->type != C_CONTAINER && view->type != C_VIEW) {
+				return cmd_results_new(CMD_FAILURE, "move", "Can only move containers and views.");
+			} else if (!(output = output_by_name(argv[3]))) {
+				return cmd_results_new(CMD_FAILURE, "move",
+					"Can't find output with name/direction '%s'", argv[3]);
+			} else {
+				swayc_t *container = get_focused_container(output);
+				if (container->is_floating) {
+					move_container_to(view, container->parent);
+				} else {
+					move_container_to(view, container);
+				}
+			}
 		} else {
 			return cmd_results_new(CMD_INVALID, "move", expected_syntax);
 		}

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -317,6 +317,30 @@ void move_container_to(swayc_t* container, swayc_t* destination) {
 	}
 }
 
+void move_workspace_to(swayc_t* workspace, swayc_t* destination) {
+	if (workspace == destination || swayc_is_parent_of(workspace, destination)) {
+		return;
+	}
+	swayc_t *src_op = remove_child(workspace);
+	// reset container geometry
+	workspace->width = workspace->height = 0;
+	add_child(destination, workspace);
+	// Refocus destination (change to new workspace)
+	set_focused_container(get_focused_view(workspace));
+	arrange_windows(destination, -1, -1);
+	update_visibility(destination);
+
+	// make sure source output has a workspace
+	if (src_op->children->length == 0) {
+		char *ws_name = workspace_next_name();
+		swayc_t *ws = new_workspace(src_op, ws_name);
+		ws->is_focused = true;
+		free(ws_name);
+	}
+	set_focused_container(get_focused_view(src_op));
+	update_visibility(src_op);
+}
+
 void update_geometry(swayc_t *container) {
 	if (container->type != C_VIEW) {
 		return;


### PR DESCRIPTION
Three new functionalities related to outputs (I have a quad monitor setup so that stuff is of interest to me). All three are replicas of i3 functionality. 

Known issues:
1) Sometimes when moving a workspace, the windows on that workspace go black until one of those windows receive focus again. I haven't looked properly into why that is yet.

2) If you switch focus with a normal `focus <direction>` command, you might switch output also. However, that code doesn't take output positions into account, so it ends up switching to an "arbitrary" output. That's confusing and should be fixed.

Please review, comments are welcomed.