### PR TITLE
commands: Learn 'debuglog'.

### DIFF
--- a/include/log.h
+++ b/include/log.h
@@ -11,6 +11,10 @@ typedef enum {
 } log_importance_t;
 
 void init_log(log_importance_t verbosity);
+void set_log_level(log_importance_t verbosity);
+void reset_log_level(void);
+// returns whether debug logging is on after switching.
+bool toggle_debug_logging(void);
 void sway_log_colors(int mode);
 void sway_log(log_importance_t verbosity, const char* format, ...) __attribute__((format(printf,2,3)));
 void sway_log_errno(log_importance_t verbosity, char* format, ...) __attribute__((format(printf,2,3)));

--- a/sway.5.txt
+++ b/sway.5.txt
@@ -28,6 +28,11 @@ Commands
 	execute Firefox if the alt, shift, and F keys are pressed together. Any
 	valid sway command is eligible to be bound to a key combo.
 
+**debuglog** <on|off|toggle>::
+	Turn debug log output _on_ or _off_. This will override any command line
+	option given. _toggle_ will toggle between debug and log level given as
+	command line option.
+
 **exec** <shell command>::
 	Executes _shell command_ with sh.
 

--- a/sway.5.txt
+++ b/sway.5.txt
@@ -28,11 +28,6 @@ Commands
 	execute Firefox if the alt, shift, and F keys are pressed together. Any
 	valid sway command is eligible to be bound to a key combo.
 
-**debuglog** <on|off|toggle>::
-	Turn debug log output _on_ or _off_. This will override any command line
-	option given. _toggle_ will toggle between debug and log level given as
-	command line option.
-
 **exec** <shell command>::
 	Executes _shell command_ with sh.
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -30,6 +30,7 @@ struct cmd_handler {
 
 static sway_cmd cmd_bindsym;
 static sway_cmd cmd_orientation;
+static sway_cmd cmd_debuglog;
 static sway_cmd cmd_exec;
 static sway_cmd cmd_exec_always;
 static sway_cmd cmd_exit;
@@ -226,6 +227,28 @@ static struct cmd_results *cmd_exec_always(int argc, char **argv) {
 	}
 	// cleanup child process
 	wait(0);
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}
+
+static struct cmd_results *cmd_debuglog(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "debuglog", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	} else if (strcasecmp(argv[0], "toggle") == 0) {
+		if (config->reading) {
+			return cmd_results_new(CMD_FAILURE, "debuglog toggle", "Can't be used in config file.");
+		}
+		if (toggle_debug_logging()) {
+			sway_log(L_DEBUG, "Debuglog turned on.");
+		}
+	} else if (strcasecmp(argv[0], "on") == 0) {
+		set_log_level(L_DEBUG);
+		sway_log(L_DEBUG, "Debuglog turned on.");
+	} else if (strcasecmp(argv[0], "off") == 0) {
+		reset_log_level();
+	} else {
+		return cmd_results_new(CMD_FAILURE, "debuglog", "Expected 'debuglog on|off|toggle'");
+	}
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }
 
@@ -1162,6 +1185,7 @@ static struct cmd_results *cmd_ws_auto_back_and_forth(int argc, char **argv) {
 /* Keep alphabetized */
 static struct cmd_handler handlers[] = {
 	{ "bindsym", cmd_bindsym },
+	{ "debuglog", cmd_debuglog },
 	{ "default_orientation", cmd_orientation },
 	{ "exec", cmd_exec },
 	{ "exec_always", cmd_exec_always },

--- a/sway/log.c
+++ b/sway/log.c
@@ -11,6 +11,7 @@
 #include <execinfo.h>
 
 int colored = 1;
+log_importance_t loglevel_default = L_ERROR;
 log_importance_t v = L_SILENT;
 
 static const char *verbosity_colors[] = {
@@ -21,9 +22,27 @@ static const char *verbosity_colors[] = {
 };
 
 void init_log(log_importance_t verbosity) {
+	if (verbosity != L_DEBUG) {
+		// command "debuglog" needs to know the user specified log level when
+		// turning off debug logging.
+		loglevel_default = verbosity;
+	}
 	v = verbosity;
 	signal(SIGSEGV, error_handler);
 	signal(SIGABRT, error_handler);
+}
+
+void set_log_level(log_importance_t verbosity) {
+	v = verbosity;
+}
+
+void reset_log_level(void) {
+	v = loglevel_default;
+}
+
+bool toggle_debug_logging(void) {
+	v = (v == L_DEBUG) ? loglevel_default : L_DEBUG;
+	return (v == L_DEBUG);
 }
 
 void sway_log_colors(int mode) {


### PR DESCRIPTION
Replicates i3 option. Verbosity level given as command line argument
becomes default log level, and using 'debuglog toggle' switches back and
forth between default and debug (or L_ERROR and debug if default is also
L_DEBUG).

