### PR TITLE
commands: Learn 'focus output <direction|name>'

### DIFF
--- a/sway.5.txt
+++ b/sway.5.txt
@@ -53,6 +53,11 @@ Commands
 	container, which is useful, for example, to open a sibling of the parent
 	container, or to move the entire container around.
 
+**focus** output <direction|name>::
+	Direction may be one of _up_, _down_, _left_, _right_. The directional focus
+	commands will move the focus to the output in that direction. When name is
+	given the focus is changed to the output with that name.
+
 **focus** mode_toggle::
 	Toggles focus between floating view and tiled view.
 

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -289,15 +289,16 @@ void move_container_to(swayc_t* container, swayc_t* destination) {
 		return;
 	}
 	swayc_t *parent = remove_child(container);
-	// reset container geometry
-	container->width = container->height = 0;
-
 	// Send to new destination
 	if (container->is_floating) {
 		add_floating(swayc_active_workspace_for(destination), container);
 	} else if (destination->type == C_WORKSPACE) {
+		// reset container geometry
+		container->width = container->height = 0;
 		add_child(destination, container);
 	} else {
+		// reset container geometry
+		container->width = container->height = 0;
 		add_sibling(destination, container);
 	}
 	// Destroy old container if we need to


### PR DESCRIPTION
Replicates i3 functionality. This is the first part of pull request #205 , and it works properly.
(+ The fix for moving floating windows to other workspaces.)

Please review, comments are welcomed.