### PR TITLE
Learn mouse_warping

### DIFF
--- a/include/commands.h
+++ b/include/commands.h
@@ -2,6 +2,7 @@
 #define _SWAY_COMMANDS_H
 #include <stdbool.h>
 #include <json-c/json.h>
+#include <wlc/wlc.h>
 #include "config.h"
 
 

--- a/include/container.h
+++ b/include/container.h
@@ -5,6 +5,8 @@ typedef struct sway_container swayc_t;
 
 #include "layout.h"
 
+extern struct wlc_origin mouse_origin;
+
 enum swayc_types{
 	C_ROOT,
 	C_OUTPUT,
@@ -98,6 +100,8 @@ swayc_t *swayc_by_name(const char *name);
 swayc_t *swayc_active_output(void);
 swayc_t *swayc_active_workspace(void);
 swayc_t *swayc_active_workspace_for(swayc_t *view);
+// set focus to current pointer location and return focused container
+swayc_t *container_under_pointer(void);
 
 // Container information
 

--- a/include/container.h
+++ b/include/container.h
@@ -5,8 +5,6 @@ typedef struct sway_container swayc_t;
 
 #include "layout.h"
 
-extern struct wlc_origin mouse_origin;
-
 enum swayc_types{
 	C_ROOT,
 	C_OUTPUT,

--- a/include/handlers.h
+++ b/include/handlers.h
@@ -5,10 +5,6 @@
 #include <wlc/wlc.h>
 
 extern struct wlc_interface interface;
-extern struct wlc_origin mouse_origin;
 extern uint32_t keys_pressed[32];
-
-// set focus to current pointer location and return focused container
-swayc_t *container_under_pointer(void);
 
 #endif

--- a/include/input_state.h
+++ b/include/input_state.h
@@ -65,6 +65,8 @@ extern struct pointer_state {
 	int mode;
 } pointer_state;
 
+void pointer_position_set(struct wlc_origin *new_origin, bool force_focus);
+
 // on button release unset mode depending on the button.
 // on button press set mode conditionally depending on the button
 void pointer_mode_set(uint32_t button, bool condition);

--- a/include/input_state.h
+++ b/include/input_state.h
@@ -66,6 +66,7 @@ extern struct pointer_state {
 } pointer_state;
 
 void pointer_position_set(struct wlc_origin *new_origin, bool force_focus);
+void center_pointer_on(swayc_t *view);
 
 // on button release unset mode depending on the button.
 // on button press set mode conditionally depending on the button

--- a/include/input_state.h
+++ b/include/input_state.h
@@ -48,11 +48,6 @@ extern struct pointer_state {
 	struct pointer_button_state right;
 	struct pointer_button_state scroll;
 
-	// pointer position
-	struct mouse_origin{
-		int x, y;
-	} origin;
-
 	// change in pointer position
 	struct {
 		int x, y;

--- a/sway.5.txt
+++ b/sway.5.txt
@@ -102,6 +102,10 @@ Commands
 	Moves the focused container to the workspace identified by _name_.
 	_name_ may be a special workspace name. See **workspace**.
 
+**mouse_warping** <output|none>::
+	When _output_: place mouse at center of newly focused window when changing
+	output. When _none_: don't move mouse.
+
 **output** <name> <resolution|res WIDTHxHEIGHT> <position|pos X,Y>::
 	Configures the specified output. It will use the given resolution and be
 	arranged at the given position in the layout tree. You may omit either of

--- a/sway/container.c
+++ b/sway/container.c
@@ -510,7 +510,7 @@ swayc_t *swayc_active_workspace_for(swayc_t *cont) {
 }
 
 static bool pointer_test(swayc_t *view, void *_origin) {
-	const struct mouse_origin *origin = _origin;
+	const struct wlc_origin *origin = _origin;
 	// Determine the output that the view is under
 	swayc_t *parent = swayc_parent_by_type(view, C_OUTPUT);
 	if (origin->x >= view->x && origin->y >= view->y
@@ -531,6 +531,8 @@ swayc_t *container_under_pointer(void) {
 	if (lookup->children == 0) {
 		return NULL;
 	}
+	struct wlc_origin origin;
+	wlc_pointer_get_origin(&origin);
 	while (lookup->type != C_VIEW) {
 		int i;
 		int len;
@@ -545,7 +547,7 @@ swayc_t *container_under_pointer(void) {
 			i = len = lookup->floating->length;
 			bool got_floating = false;
 			while (--i > -1) {
-				if (pointer_test(lookup->floating->items[i], &pointer_state.origin)) {
+				if (pointer_test(lookup->floating->items[i], &origin)) {
 					lookup = lookup->floating->items[i];
 					got_floating = true;
 					break;
@@ -558,7 +560,7 @@ swayc_t *container_under_pointer(void) {
 		// search children
 		len = lookup->children->length;
 		for (i = 0; i < len; ++i) {
-			if (pointer_test(lookup->children->items[i], &pointer_state.origin)) {
+			if (pointer_test(lookup->children->items[i], &origin)) {
 				lookup = lookup->children->items[i];
 				break;
 			}

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -343,10 +343,6 @@ static bool handle_pointer_button(wlc_handle view, uint32_t time, const struct w
 	// Update view pointer is on
 	pointer_state.view = container_under_pointer();
 
-	// Update pointer origin
-	pointer_state.origin.x = origin->x;
-	pointer_state.origin.y = origin->y;
-
 	// Update pointer_state
 	switch (button) {
 	case M_LEFT_CLICK:

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -24,68 +24,6 @@
 // Event handled by sway and should not be sent to client
 #define EVENT_HANDLED true
 
-static bool pointer_test(swayc_t *view, void *_origin) {
-	const struct mouse_origin *origin = _origin;
-	// Determine the output that the view is under
-	swayc_t *parent = swayc_parent_by_type(view, C_OUTPUT);
-	if (origin->x >= view->x && origin->y >= view->y
-		&& origin->x < view->x + view->width && origin->y < view->y + view->height
-		&& view->visible && parent == root_container.focused) {
-		return true;
-	}
-	return false;
-}
-
-swayc_t *container_under_pointer(void) {
-	// root.output->workspace
-	if (!root_container.focused || !root_container.focused->focused) {
-		return NULL;
-	}
-	swayc_t *lookup = root_container.focused->focused;
-	// Case of empty workspace
-	if (lookup->children == 0) {
-		return NULL;
-	}
-	while (lookup->type != C_VIEW) {
-		int i;
-		int len;
-		// if tabbed/stacked go directly to focused container, otherwise search
-		// children
-		if (lookup->layout == L_TABBED || lookup->layout == L_STACKED) {
-			lookup = lookup->focused;
-			continue;
-		}
-		// if workspace, search floating
-		if (lookup->type == C_WORKSPACE) {
-			i = len = lookup->floating->length;
-			bool got_floating = false;
-			while (--i > -1) {
-				if (pointer_test(lookup->floating->items[i], &pointer_state.origin)) {
-					lookup = lookup->floating->items[i];
-					got_floating = true;
-					break;
-				}
-			}
-			if (got_floating) {
-				continue;
-			}
-		}
-		// search children
-		len = lookup->children->length;
-		for (i = 0; i < len; ++i) {
-			if (pointer_test(lookup->children->items[i], &pointer_state.origin)) {
-				lookup = lookup->children->items[i];
-				break;
-			}
-		}
-		// when border and titles are done, this could happen
-		if (i == len) {
-			break;
-		}
-	}
-	return lookup;
-}
-
 /* Handles */
 
 static bool handle_output_created(wlc_handle output) {

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -332,27 +332,7 @@ static bool handle_pointer_motion(wlc_handle handle, uint32_t time, const struct
 		}
 	}
 
-	// Update pointer origin
-	pointer_state.delta.x = origin->x - pointer_state.origin.x;
-	pointer_state.delta.y = origin->y - pointer_state.origin.y;
-	pointer_state.origin.x = origin->x;
-	pointer_state.origin.y = origin->y;
-
-	// Update view under pointer
-	swayc_t *prev_view = pointer_state.view;
-	pointer_state.view = container_under_pointer();
-
-	// If pointer is in a mode, update it
-	if (pointer_state.mode) {
-		pointer_mode_update();
-	}
-	// Otherwise change focus if config is set an
-	else if (prev_view != pointer_state.view && config->focus_follows_mouse) {
-		if (pointer_state.view && pointer_state.view->type == C_VIEW) {
-			set_focused_container(pointer_state.view);
-		}
-	}
-	wlc_pointer_set_origin(&new_origin);
+	pointer_position_set(&new_origin, false);
 	return EVENT_PASSTHROUGH;
 }
 

--- a/sway/input_state.c
+++ b/sway/input_state.c
@@ -163,10 +163,10 @@ static void reset_initial_sibling(void) {
 }
 
 void pointer_position_set(struct wlc_origin *new_origin, bool force_focus) {
-	pointer_state.delta.x = new_origin->x - pointer_state.origin.x;
-	pointer_state.delta.y = new_origin->y - pointer_state.origin.y;
-	pointer_state.origin.x = new_origin->x;
-	pointer_state.origin.y = new_origin->y;
+	struct wlc_origin origin;
+	wlc_pointer_get_origin(&origin);
+	pointer_state.delta.x = new_origin->x - origin.x;
+	pointer_state.delta.y = new_origin->y - origin.y;
 
 	// Update view under pointer
 	swayc_t *prev_view = pointer_state.view;
@@ -214,8 +214,10 @@ static void pointer_mode_set_right(void) {
 	int midway_x = initial.ptr->x + initial.ptr->width/2;
 	int midway_y = initial.ptr->y + initial.ptr->height/2;
 
-	lock.left = pointer_state.origin.x > midway_x;
-	lock.top = pointer_state.origin.y > midway_y;
+	struct wlc_origin origin;
+	wlc_pointer_get_origin(&origin);
+	lock.left = origin.x > midway_x;
+	lock.top = origin.y > midway_y;
 
 	if (initial.ptr->is_floating) {
 		pointer_state.mode = M_RESIZING | M_FLOATING;
@@ -277,8 +279,10 @@ void pointer_mode_update(void) {
 		pointer_state.mode = 0;
 		return;
 	}
-	int dx = pointer_state.origin.x;
-	int dy = pointer_state.origin.y;
+	struct wlc_origin origin;
+	wlc_pointer_get_origin(&origin);
+	int dx = origin.x;
+	int dy = origin.y;
 
 	switch (pointer_state.mode) {
 	case M_FLOATING | M_DRAGGING:

--- a/sway/input_state.c
+++ b/sway/input_state.c
@@ -185,6 +185,13 @@ void pointer_position_set(struct wlc_origin *new_origin, bool force_focus) {
 	wlc_pointer_set_origin(new_origin);
 }
 
+void center_pointer_on(swayc_t *view) {
+	struct wlc_origin new_origin;
+	new_origin.x = view->x + view->width/2;
+	new_origin.y = view->y + view->height/2;
+	pointer_position_set(&new_origin, true);
+}
+
 // Mode set left/right click
 
 static void pointer_mode_set_left(void) {


### PR DESCRIPTION
This patch series contains two patches with refactoring and a third with a new `mouse_warping` command (same as in i3). The refactoring is done in order to reuse code in the last patch.

`mouse_warping` can be triggered in multiple ways:
A) via `workspace <name>` which changes output
B) via `focus <direction>` which changes output
C) via `focus output <name>` which (obviously) changes output

Please review, comments are welcomed. 