### PR TITLE
put ipc_event_workspace in update_focus

### DIFF
--- a/sway/focus.c
+++ b/sway/focus.c
@@ -11,7 +11,6 @@ bool locked_container_focus = false;
 bool locked_view_focus = false;
 
 // switches parent focus to c. will switch it accordingly
-// TODO: Everything needs a handle, so we can set front/back position properly
 static void update_focus(swayc_t *c) {
 	// Handle if focus switches
 	swayc_t *parent = c->parent;
@@ -20,6 +19,7 @@ static void update_focus(swayc_t *c) {
 		swayc_t *prev = parent->focused;
 		// Set new focus
 		parent->focused = c;
+
 		switch (c->type) {
 		// Shouldnt happen
 		case C_ROOT: return;
@@ -32,6 +32,7 @@ static void update_focus(swayc_t *c) {
 		// Case where workspace changes
 		case C_WORKSPACE:
 			if (prev) {
+				ipc_event_workspace(prev, c);
 				// update visibility of old workspace
 				update_visibility(prev);
 				destroy_workspace(prev);

--- a/sway/workspace.c
+++ b/sway/workspace.c
@@ -223,7 +223,5 @@ bool workspace_switch(swayc_t *workspace) {
 	}
 	arrange_windows(workspace, -1, -1);
 
-	ipc_event_workspace(active_ws, workspace);
-
 	return true;
 }


### PR DESCRIPTION
from the comment here 6cd106d23c73c1f5c5f87d4c024400cfd5edc93f
>This part is problematic, as active_ws is not allocated:
>
>==23819==    at 0x4C2A7FB: free (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
>==23819==    by 0x412912: free_swayc (container.c:53)
>==23819==    by 0x413645: destroy_workspace (container.c:319)
>==23819==    by 0x409DE1: update_focus (focus.c:37)
>==23819==    by 0x40A001: set_focused_container (focus.c:108)
>
>it depends only on timing if the data will be there or not.

this should fix it.
`ipc_event_workspace` should get called before destroying empty workspaces and will also be called in every situation where workspace switches.
duno if that last part is desirable or not though, but if not then just move `ipc_event_workspace` before `set_focused_container` in `switch_workspace`.