### PR TITLE
Clean up gaps command

### DIFF
--- a/sway.5.txt
+++ b/sway.5.txt
@@ -69,18 +69,18 @@ Commands
 	Toggles fullscreen status for the focused view.
 
 **gaps** <amount>::
-	Sets _amount_ pixels as the gap between each view, and around each
+	Sets default _amount_ pixels as the gap between each view, and around each
 	workspace.
 
 **gaps** <inner|outer> <amount>::
-	Sets _amount_ pixels as the _inner_ or _outer_ gap, where the former affects
-	spacing between views and the latter affects the space around each
+	Sets default _amount_ pixels as the _inner_ or _outer_ gap, where the former
+	affects spacing between views and the latter affects the space around each
 	workspace.
 
 **gaps** <inner|outer> <all|workspace|current> <set|plus|minus> <amount>::
 	Changes the gaps for the _inner_ or _outer_ gap. _all_ changes the gaps for
 	all views or workspace, _workspace_ changes gaps for all views in current
-	workspace, or current workspace, and _current_ changes gaps for the current
+	workspace (or current workspace), and _current_ changes gaps for the current
 	view or workspace.
 
 **kill**::

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -760,6 +760,8 @@ static struct cmd_results *cmd_gaps(int argc, char **argv) {
 	if ((error = checkarg(argc, "gaps", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
+	const char* expected_syntax =
+		"Expected 'gaps <inner|outer> <current|all|workspace> <set|plus|minus n>'";
 	const char *amount_str = argv[0];
 	// gaps amount
 	if (argc >= 1 && isdigit(*amount_str)) {
@@ -793,7 +795,7 @@ static struct cmd_results *cmd_gaps(int argc, char **argv) {
 	}
 	// gaps inner|outer current|all set|plus|minus n
 	if (argc < 4 || config->reading) {
-		return cmd_results_new(CMD_INVALID, "gaps", "Expected 'gaps <inner|outer> <current|all|workspace> <set|plus|minus n>'");
+		return cmd_results_new(CMD_INVALID, "gaps", expected_syntax);
 	}
 	// gaps inner|outer ...
 	const char *inout_str = argv[0];
@@ -803,7 +805,7 @@ static struct cmd_results *cmd_gaps(int argc, char **argv) {
 	} else if (strcasecmp(inout_str, "outer") == 0) {
 		inout = OUTER;
 	} else {
-		return cmd_results_new(CMD_INVALID, "gaps", "Expected 'gaps <inner|outer> <current|all|workspace> <set|plus|minus n>'");
+		return cmd_results_new(CMD_INVALID, "gaps", expected_syntax);
 	}
 
 	// gaps ... current|all ...
@@ -821,7 +823,7 @@ static struct cmd_results *cmd_gaps(int argc, char **argv) {
 			target = WORKSPACE;
 		}
 	} else {
-		return cmd_results_new(CMD_INVALID, "gaps", "Expected 'gaps <inner|outer> <current|all|workspace> <set|plus|minus n>'");
+		return cmd_results_new(CMD_INVALID, "gaps", expected_syntax);
 	}
 
 	// gaps ... n
@@ -843,7 +845,7 @@ static struct cmd_results *cmd_gaps(int argc, char **argv) {
 		method = ADD;
 		amount *= -1;
 	} else {
-		return cmd_results_new(CMD_INVALID, "gaps", "Expected 'gaps <inner|outer> <current|all> <set|plus|minus n>'");
+		return cmd_results_new(CMD_INVALID, "gaps", expected_syntax);
 	}
 
 	if (target == CURRENT) {

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -770,12 +770,7 @@ static struct cmd_results *cmd_gaps(int argc, char **argv) {
 			errno = 0;
 			return cmd_results_new(CMD_INVALID, "gaps", "Number is out out of range.");
 		}
-		if (config->gaps_inner == 0) {
-			config->gaps_inner = amount;
-		}
-		if (config->gaps_outer == 0) {
-			config->gaps_outer = amount;
-		}
+		config->gaps_inner = config->gaps_outer = amount;
 		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 	}
 	// gaps inner|outer n

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -766,7 +766,7 @@ static struct cmd_results *cmd_gaps(int argc, char **argv) {
 	// gaps amount
 	if (argc >= 1 && isdigit(*amount_str)) {
 		int amount = (int)strtol(amount_str, NULL, 10);
-		if (errno == ERANGE || amount == 0) {
+		if (errno == ERANGE) {
 			errno = 0;
 			return cmd_results_new(CMD_INVALID, "gaps", "Number is out out of range.");
 		}
@@ -781,7 +781,7 @@ static struct cmd_results *cmd_gaps(int argc, char **argv) {
 	// gaps inner|outer n
 	else if (argc >= 2 && isdigit((amount_str = argv[1])[0])) {
 		int amount = (int)strtol(amount_str, NULL, 10);
-		if (errno == ERANGE || amount == 0) {
+		if (errno == ERANGE) {
 			errno = 0;
 			return cmd_results_new(CMD_INVALID, "gaps", "Number is out out of range.");
 		}
@@ -829,7 +829,7 @@ static struct cmd_results *cmd_gaps(int argc, char **argv) {
 	// gaps ... n
 	amount_str = argv[3];
 	int amount = (int)strtol(amount_str, NULL, 10);
-	if (errno == ERANGE || amount == 0) {
+	if (errno == ERANGE) {
 		errno = 0;
 		return cmd_results_new(CMD_INVALID, "gaps", "Number is out out of range.");
 	}

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -771,6 +771,7 @@ static struct cmd_results *cmd_gaps(int argc, char **argv) {
 			return cmd_results_new(CMD_INVALID, "gaps", "Number is out out of range.");
 		}
 		config->gaps_inner = config->gaps_outer = amount;
+		arrange_windows(&root_container, -1, -1);
 		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 	}
 	// gaps inner|outer n
@@ -786,6 +787,7 @@ static struct cmd_results *cmd_gaps(int argc, char **argv) {
 		} else if (strcasecmp(target_str, "outer") == 0) {
 			config->gaps_outer = amount;
 		}
+		arrange_windows(&root_container, -1, -1);
 		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 	}
 	// gaps inner|outer current|all set|plus|minus n


### PR DESCRIPTION
Multiple fixes:
1) Accept zero value (fixes #207).
2) Always set default gaps config when command is given (not just once like before).
3) Re-arrange windows after setting new gaps value (so that effect is immediate).

Please review, comments are welcomed.