### PR TITLE
Learn "gaps edge_gaps <on|off|toggle>".

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -57,6 +57,7 @@ struct sway_config {
 	bool auto_back_and_forth;
 	bool seamless_mouse;
 
+	bool edge_gaps;
 	int gaps_inner;
 	int gaps_outer;
 };

--- a/sway.5.txt
+++ b/sway.5.txt
@@ -68,6 +68,11 @@ Commands
 **fullscreen**::
 	Toggles fullscreen status for the focused view.
 
+**gaps** edge_gaps <on|off|toggle>::
+	Whether or not to add gaps between views and workspace edges if amount of
+	inner gap is not zero. When _no_, no gap is added where the view is aligned to
+	the workspace edge, effectively creating gaps only between views.
+
 **gaps** <amount>::
 	Sets default _amount_ pixels as the gap between each view, and around each
 	workspace.

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -761,7 +761,8 @@ static struct cmd_results *cmd_gaps(int argc, char **argv) {
 		return error;
 	}
 	const char* expected_syntax =
-		"Expected 'gaps <inner|outer> <current|all|workspace> <set|plus|minus n>'";
+		"Expected 'gaps edge_gaps <on|off|toggle>' or "
+		"'gaps <inner|outer> <current|all|workspace> <set|plus|minus n>'";
 	const char *amount_str = argv[0];
 	// gaps amount
 	if (argc >= 1 && isdigit(*amount_str)) {
@@ -786,6 +787,20 @@ static struct cmd_results *cmd_gaps(int argc, char **argv) {
 			config->gaps_inner = amount;
 		} else if (strcasecmp(target_str, "outer") == 0) {
 			config->gaps_outer = amount;
+		}
+		arrange_windows(&root_container, -1, -1);
+		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	} else if (argc == 2 && strcasecmp(argv[0], "edge_gaps") == 0) {
+		// gaps edge_gaps <on|off|toggle>
+		if (strcasecmp(argv[1], "toggle") == 0) {
+			if (config->reading) {
+				return cmd_results_new(CMD_FAILURE, "gaps edge_gaps toggle",
+					"Can't be used in config file.");
+			}
+			config->edge_gaps = !config->edge_gaps;
+		} else {
+			config->edge_gaps =
+				(strcasecmp(argv[1], "yes") == 0 || strcasecmp(argv[1], "on") == 0);
 		}
 		arrange_windows(&root_container, -1, -1);
 		return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/config.c
+++ b/sway/config.c
@@ -105,6 +105,7 @@ static void config_defaults(struct sway_config *config) {
 	config->seamless_mouse = true;
 	config->reading = false;
 
+	config->edge_gaps = false;
 	config->gaps_inner = 0;
 	config->gaps_outer = 0;
 }

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -367,9 +367,27 @@ void update_geometry(swayc_t *container) {
 		if (op->focused == ws) {
 			wlc_view_bring_to_front(container->handle);
 		}
+	} else if (!config->edge_gaps && gap > 0) {
+		// Remove gap against the workspace edges. Because a pixel is not
+		// divisable, depending on gap size and the number of siblings our view
+		// might be at the workspace edge without being exactly so (thus test
+		// with gap, and align correctly).
+		if (container->x - gap <= ws->x) {
+			geometry.origin.x = ws->x;
+			geometry.size.w = container->width - gap/2;
+		}
+		if (container->y - gap <= ws->y) {
+			geometry.origin.y = ws->y;
+			geometry.size.h = container->height - gap/2;
+		}
+		if (container->x + container->width + gap >= ws->x + ws->width) {
+			geometry.size.w = ws->width - geometry.origin.x;
+		}
+		if (container->y + container->height + gap >= ws->y + ws->height) {
+			geometry.size.h = ws->height - geometry.origin.y;
+		}
 	}
 	wlc_view_set_geometry(container->handle, 0, &geometry);
-	return;
 }
 
 static void arrange_windows_r(swayc_t *container, double width, double height) {


### PR DESCRIPTION
When yes, the old behaviour of adding half the inner gap around each
view is used.

When no, don't add any gap when an edge of the view aligns with the
workspace. The result is inner gap only between views, not against the
workspace edge.

The algorithm is not perfect because it means the extra space is
distributed amongst edge-aligned views only, but it's simple, looks good
and it works.

Please review, comments are welcomed.

(The name was kind of hard to make up, "gaps edge_gaps on" looks kind of clumsy, but it's descriptive at least...)