### PR TITLE
Include header declaring ipc_event_workpace(2)

### DIFF
--- a/sway/focus.c
+++ b/sway/focus.c
@@ -6,6 +6,7 @@
 #include "layout.h"
 #include "config.h"
 #include "input_state.h"
+#include "ipc.h"
 
 bool locked_container_focus = false;
 bool locked_view_focus = false;


### PR DESCRIPTION
Build is throwing a warning because the header file is missing. So let it be included :)