### PR TITLE
Add new swaybg dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ arch:
     - xcb-util-image
     - libgl
     - mesa
+    - pango
+    - cairo
   script:
     - "bash .ci/build.sh"
 


### PR DESCRIPTION
Add missing `pango` and `cario` packages to travis build.