### PR TITLE
ipc: Store socketname in SWAYSOCK. Fixes `--get-socketpath`.

### DIFF
--- a/sway/ipc.c
+++ b/sway/ipc.c
@@ -52,7 +52,8 @@ void ipc_init(void) {
 
 	ipc_sockaddr = ipc_user_sockaddr();
 
-	if (getenv("SWAYSOCK") != NULL) {
+	// We want to use socket name set by user, not existing socket from another sway instance.
+	if (getenv("SWAYSOCK") != NULL && access(getenv("SWAYSOCK"), F_OK) == -1) {
 		strncpy(ipc_sockaddr->sun_path, getenv("SWAYSOCK"), sizeof(ipc_sockaddr->sun_path));
 	}
 
@@ -66,7 +67,12 @@ void ipc_init(void) {
 	}
 
 	// Set i3 IPC socket path so that i3-msg works out of the box
-	setenv("I3SOCK", ipc_sockaddr->sun_path, 1);
+	if (!getenv("I3SOCK")) {
+		setenv("I3SOCK", ipc_sockaddr->sun_path, 1);
+	}
+	if (!getenv("SWAYSOCK")) {
+		setenv("SWAYSOCK", ipc_sockaddr->sun_path, 1);
+	}
 
 	ipc_client_list = create_list();
 

--- a/sway/main.c
+++ b/sway/main.c
@@ -107,10 +107,13 @@ int main(int argc, char **argv) {
 			verbose = 1;
 			break;
 		case 'p': ; // --get-socketpath
-			struct sockaddr_un *ipc_sockaddr = ipc_user_sockaddr();
-			fprintf(stdout, "%s\n", ipc_sockaddr->sun_path);
-			free(ipc_sockaddr);
-			exit(0);
+			if (getenv("SWAYSOCK")) {
+				fprintf(stdout, "%s\n", getenv("SWAYSOCK"));
+				exit(0);
+			} else {
+				fprintf(stderr, "sway socket not detected.\n");
+				exit(1);
+			}
 			break;
 		}
 	}


### PR DESCRIPTION
After adding pid to the socket path the `--get-socketpath` command broke
because it doesn't know the pid of the running instance. Fix this by
setting and querying `SWAYSOCK`.

Also ignore `SWAYSOCK` upon normal startup if a socket exists at that
location (ie. from another sway instance), and don't overwrite `I3SOCK`
if it exists either.