### PR TITLE
Check the client_setup() return value

### DIFF
--- a/swaybg/main.c
+++ b/swaybg/main.c
@@ -14,7 +14,9 @@ void sway_terminate(void) {
 
 int main(int argc, char **argv) {
 	init_log(L_INFO);
-	state = client_setup();
+	if (!(state = client_setup())) {
+		return -1;
+	}
 
 	uint8_t r = 0, g = 0, b = 0;
 


### PR DESCRIPTION
In case that there's no Wayland compositor running, swaybg will crash because client_setup() will return NULL.