### PR TITLE
cmd_output: Replace existing config if called multiple times.

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -98,6 +98,7 @@ char *do_var_replacement(char *str);
 /** Sets up a WLC output handle based on a given output_config.
  */
 void apply_output_config(struct output_config *oc, swayc_t *output);
+void free_output_config(struct output_config *oc);
 
 /**
  * Global config singleton.

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -733,6 +733,15 @@ static struct cmd_results *cmd_output(int argc, char **argv) {
 		}
 	}
 
+	for (i = 0; i < config->output_configs->length; ++i) {
+		struct output_config *oc = config->output_configs->items[i];
+		if (strcmp(oc->name, output->name) == 0) {
+			// replace existing config
+			list_del(config->output_configs, i);
+			free_output_config(oc);
+			break;
+		}
+	}
 	list_add(config->output_configs, output);
 
 	sway_log(L_DEBUG, "Config stored for output %s (%d x %d @ %d, %d)",

--- a/sway/config.c
+++ b/sway/config.c
@@ -36,7 +36,7 @@ static void free_mode(struct sway_mode *mode) {
 	free(mode);
 }
 
-static void free_output_config(struct output_config *oc) {
+void free_output_config(struct output_config *oc) {
 	free(oc->name);
 	free(oc);
 }


### PR DESCRIPTION
When issuing multiple output commands, always replace existing output config.

