### PR TITLE
Handle bindsym duplicates

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -104,6 +104,10 @@ void free_output_config(struct output_config *oc);
 
 int workspace_output_cmp_workspace(const void *a, const void *b);
 
+int sway_binding_cmp(const void *a, const void *b);
+int sway_binding_cmp_keys(const void *a, const void *b);
+void free_sway_binding(struct sway_binding *sb);
+
 /**
  * Global config singleton.
  */

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -1471,6 +1471,13 @@ struct cmd_results *handle_command(char *_exec) {
 	return results;
 }
 
+// this is like handle_command above, except:
+// 1) it ignores empty commands (empty lines)
+// 2) it does variable substitution
+// 3) it doesn't split commands (because the multiple commands are supposed to
+//	  be chained together)
+// 4) handle_command handles all state internally while config_command has some
+//	  state handled outside (notably the block mode, in read_config)
 struct cmd_results *config_command(char *exec) {
 	struct cmd_results *results = NULL;
 	int argc;

--- a/sway/config.c
+++ b/sway/config.c
@@ -383,3 +383,52 @@ int workspace_output_cmp_workspace(const void *a, const void *b) {
 	const struct workspace_output *wsa = a, *wsb = b;
 	return lenient_strcmp(wsa->workspace, wsb->workspace);
 }
+
+int sway_binding_cmp_keys(const void *a, const void *b) {
+	const struct sway_binding *binda = a, *bindb = b;
+
+	if (binda->modifiers > bindb->modifiers) {
+		return 1;
+	} else if (binda->modifiers < bindb->modifiers) {
+		return -1;
+	}
+
+	if (binda->keys->length > bindb->keys->length) {
+		return 1;
+	} else if (binda->keys->length < bindb->keys->length) {
+		return -1;
+	}
+
+	for (int i = 0; i < binda->keys->length; i++) {
+		xkb_keysym_t *ka = binda->keys->items[i],
+				*kb = bindb->keys->items[i];
+		if (*ka > *kb) {
+			return 1;
+		} else if (*ka < *kb) {
+			return -1;
+		}
+	}
+	return 0;
+}
+
+int sway_binding_cmp(const void *a, const void *b) {
+	int cmp = 0;
+	if ((cmp = sway_binding_cmp_keys(a, b)) != 0) {
+		return cmp;
+	}
+	const struct sway_binding *binda = a, *bindb = b;
+	return lenient_strcmp(binda->command, bindb->command);
+}
+
+void free_sway_binding(struct sway_binding *binding) {
+	if (binding->keys) {
+		for (int i = 0; i < binding->keys->length; i++) {
+			free(binding->keys->items[i]);
+		}
+		list_free(binding->keys);
+	}
+	if (binding->command) {
+		free(binding->command);
+	}
+	free(binding);
+}


### PR DESCRIPTION
First patch: Unrelated comment piggybacking the pull request.

Second patch: Detect/handle duplicates in `cmd_bindsym`. Duplicates are found and freed.

Also replace `bindsym_sort` with function `sway_binding_cmp` that takes
all data into account when comparing (although having the list sorted is never actually taken advantage of as far as I can tell...)

