### PR TITLE
fix list sorting

### DIFF
--- a/common/list.c
+++ b/common/list.c
@@ -50,8 +50,14 @@ void list_cat(list_t *list, list_t *source) {
 	}
 }
 
+// pass the pointer of the object we care about to the comparison function
+static int list_cmp(const void *l, const void *r, void *_cmp) {
+	int (*cmp)(const void *, const void *) = _cmp;
+	return cmp(*(void**)l, *(void**)r);
+}
+
 void list_sort(list_t *list, int compare(const void *left, const void *right)) {
-	qsort(list->items, list->length, sizeof(void *), compare);
+	qsort_r(list->items, list->length, sizeof(void *), list_cmp, compare);
 }
 
 int list_seq_find(list_t *list, int compare(const void *item, const void *data), const void *data) {

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -1128,9 +1128,9 @@ static struct cmd_results *cmd_scratchpad(int argc, char **argv) {
 
 // sort in order of longest->shortest
 static int compare_set(const void *_l, const void *_r) {
-	struct sway_variable * const *l = _l;
-	struct sway_variable * const *r = _r;
-	return strlen((*r)->name) - strlen((*l)->name);
+	struct sway_variable const *l = _l;
+	struct sway_variable const *r = _r;
+	return strlen(r->name) - strlen(l->name);
 }
 
 static struct cmd_results *cmd_set(int argc, char **argv) {


### PR DESCRIPTION
list_sort has changed so that comparison functions passed to it receive the pointer to the object it cares about, instead of a pointer to that pointer.

the comparison function in #247 `list_sort(mode->bindings, sway_binding_cmp);` would use the wrong pointer, and could cause all sorts of fun.