### PR TITLE
Extra view metadata

### DIFF
--- a/include/container.h
+++ b/include/container.h
@@ -78,6 +78,7 @@ struct sway_container {
 	// Attributes that mostly views have.
 	char *name;
 	char *class;
+	char *app_id;
 
 	int gaps;
 

--- a/include/container.h
+++ b/include/container.h
@@ -75,7 +75,9 @@ struct sway_container {
 	bool is_floating;
 	bool is_focused;
 
+	// Attributes that mostly views have.
 	char *name;
+	char *class;
 
 	int gaps;
 

--- a/sway/container.c
+++ b/sway/container.c
@@ -50,6 +50,9 @@ static void free_swayc(swayc_t *cont) {
 	if (cont->name) {
 		free(cont->name);
 	}
+	if (cont->class) {
+		free(cont->class);
+	}
 	free(cont);
 }
 
@@ -214,6 +217,8 @@ swayc_t *new_view(swayc_t *sibling, wlc_handle handle) {
 	// Setup values
 	view->handle = handle;
 	view->name = title ? strdup(title) : NULL;
+	const char *class = wlc_view_get_class(handle);
+	view->class = class ? strdup(class) : NULL;
 	view->visible = true;
 	view->is_focused = true;
 	// Setup geometry
@@ -246,6 +251,8 @@ swayc_t *new_floating_view(wlc_handle handle) {
 	// Setup values
 	view->handle = handle;
 	view->name = title ? strdup(title) : NULL;
+	const char *class = wlc_view_get_class(handle);
+	view->class = class ? strdup(class) : NULL;
 	view->visible = true;
 
 	// Set the geometry of the floating view

--- a/sway/container.c
+++ b/sway/container.c
@@ -53,6 +53,9 @@ static void free_swayc(swayc_t *cont) {
 	if (cont->class) {
 		free(cont->class);
 	}
+	if (cont->app_id) {
+		free(cont->app_id);
+	}
 	free(cont);
 }
 
@@ -219,6 +222,8 @@ swayc_t *new_view(swayc_t *sibling, wlc_handle handle) {
 	view->name = title ? strdup(title) : NULL;
 	const char *class = wlc_view_get_class(handle);
 	view->class = class ? strdup(class) : NULL;
+	const char *app_id = wlc_view_get_app_id(handle);
+	view->app_id = app_id ? strdup(app_id) : NULL;
 	view->visible = true;
 	view->is_focused = true;
 	// Setup geometry
@@ -253,6 +258,8 @@ swayc_t *new_floating_view(wlc_handle handle) {
 	view->name = title ? strdup(title) : NULL;
 	const char *class = wlc_view_get_class(handle);
 	view->class = class ? strdup(class) : NULL;
+	const char *app_id = wlc_view_get_app_id(handle);
+	view->app_id = app_id ? strdup(app_id) : NULL;
 	view->visible = true;
 
 	// Set the geometry of the floating view


### PR DESCRIPTION
Store `class` and `app_id` attributes in view containers (fetched from wlc).

(Not used at the moment, but are needed when using criteria strings to filter which views to execute commands on.)