### PR TITLE
extensions: add missing include

### DIFF
--- a/sway/extensions.c
+++ b/sway/extensions.c
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include <wlc/wlc.h>
 #include <wlc/wlc-wayland.h>
 #include "wayland-desktop-shell-server-protocol.h"


### PR DESCRIPTION
This fixes a compiler warning:

../sway/extensions.c: In function ‘set_background’:
../sway/extensions.c:16:37: warning: implicit declaration of function ‘malloc’ [-Wimplicit-function-declaration]
  struct background_config *config = malloc(sizeof(struct background_config));
                                     ^
../sway/extensions.c:16:37: warning: incompatible implicit declaration of built-in function ‘malloc’
../sway/extensions.c:16:37: note: include ‘<stdlib.h>’ or provide a declaration of ‘malloc’