### PR TITLE
cmd_floating: Support `enable` and `disable` commands too.

### DIFF
--- a/sway.5.txt
+++ b/sway.5.txt
@@ -38,8 +38,8 @@ Commands
 **exit**::
 	Exit sway and end your Wayland session.
 
-**floating** toggle::
-	Toggles the "floating" status of the focused view.
+**floating** <enable|disable|toggle>::
+	Make focused view floating, non-floating, or the opposite of what it is now.
 
 **floating_modifier** <modifier>::
 	When the _modifier_ key is held down, you may use left click to drag floating

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -306,60 +306,71 @@ static struct cmd_results *cmd_floating(int argc, char **argv) {
 	if ((error = checkarg(argc, "floating", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
-
-	if (strcasecmp(argv[0], "toggle") == 0) {
-		swayc_t *view = get_focused_container(&root_container);
-		// Prevent running floating commands on things like workspaces
-		if (view->type != C_VIEW) {
-			return cmd_results_new(CMD_SUCCESS, NULL, NULL);
-		}
-		// Change from nonfloating to floating
-		if (!view->is_floating) {
-			// Remove view from its current location
-			destroy_container(remove_child(view));
-
-			// and move it into workspace floating
-			add_floating(swayc_active_workspace(), view);
-			view->x = (swayc_active_workspace()->width - view->width)/2;
-			view->y = (swayc_active_workspace()->height - view->height)/2;
-			if (view->desired_width != -1) {
-				view->width = view->desired_width;
-			}
-			if (view->desired_height != -1) {
-				view->height = view->desired_height;
-			}
-			arrange_windows(swayc_active_workspace(), -1, -1);
-		} else {
-			// Delete the view from the floating list and unset its is_floating flag
-			// Using length-1 as the index is safe because the view must be the currently
-			// focused floating output
-			remove_child(view);
-			view->is_floating = false;
-			// Get the properly focused container, and add in the view there
-			swayc_t *focused = container_under_pointer();
-			// If focused is null, it's because the currently focused container is a workspace
-			if (focused == NULL) {
-				focused = swayc_active_workspace();
-			}
-			set_focused_container(focused);
-
-			sway_log(L_DEBUG, "Non-floating focused container is %p", focused);
-
-			// Case of focused workspace, just create as child of it
-			if (focused->type == C_WORKSPACE) {
-				add_child(focused, view);
-			}
-			// Regular case, create as sibling of current container
-			else {
-				add_sibling(focused, view);
-			}
-			// Refocus on the view once its been put back into the layout
-			view->width = view->height = 0;
-			arrange_windows(swayc_active_workspace(), -1, -1);
-			remove_view_from_scratchpad(view);
-		}
-		set_focused_container(view);
+	swayc_t *view = get_focused_container(&root_container);
+	bool wants_floating;
+	if (strcasecmp(argv[0], "enable") == 0) {
+		wants_floating = true;
+	} else if (strcasecmp(argv[0], "disable") == 0) {
+		wants_floating = false;
+	} else if (strcasecmp(argv[0], "toggle") == 0) {
+		wants_floating = !view->is_floating;
+	} else {
+		return cmd_results_new(CMD_FAILURE, "floating",
+			"Expected 'floating <enable|disable|toggle>");
 	}
+
+	// Prevent running floating commands on things like workspaces
+	if (view->type != C_VIEW) {
+		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	}
+
+	// Change from nonfloating to floating
+	if (!view->is_floating && wants_floating) {
+		// Remove view from its current location
+		destroy_container(remove_child(view));
+
+		// and move it into workspace floating
+		add_floating(swayc_active_workspace(), view);
+		view->x = (swayc_active_workspace()->width - view->width)/2;
+		view->y = (swayc_active_workspace()->height - view->height)/2;
+		if (view->desired_width != -1) {
+			view->width = view->desired_width;
+		}
+		if (view->desired_height != -1) {
+			view->height = view->desired_height;
+		}
+		arrange_windows(swayc_active_workspace(), -1, -1);
+
+	} else if (view->is_floating && !wants_floating) {
+		// Delete the view from the floating list and unset its is_floating flag
+		// Using length-1 as the index is safe because the view must be the currently
+		// focused floating output
+		remove_child(view);
+		view->is_floating = false;
+		// Get the properly focused container, and add in the view there
+		swayc_t *focused = container_under_pointer();
+		// If focused is null, it's because the currently focused container is a workspace
+		if (focused == NULL) {
+			focused = swayc_active_workspace();
+		}
+		set_focused_container(focused);
+
+		sway_log(L_DEBUG, "Non-floating focused container is %p", focused);
+
+		// Case of focused workspace, just create as child of it
+		if (focused->type == C_WORKSPACE) {
+			add_child(focused, view);
+		}
+		// Regular case, create as sibling of current container
+		else {
+			add_sibling(focused, view);
+		}
+		// Refocus on the view once its been put back into the layout
+		view->width = view->height = 0;
+		arrange_windows(swayc_active_workspace(), -1, -1);
+		remove_view_from_scratchpad(view);
+	}
+	set_focused_container(view);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }
 


### PR DESCRIPTION
This is especially relevant in combination with `for_window`, e.g.:
`for_window [title="Terminal"] floating enable`.