### PR TITLE
workspace: Learn sticky.

### DIFF
--- a/include/container.h
+++ b/include/container.h
@@ -74,6 +74,7 @@ struct sway_container {
 	bool visible;
 	bool is_floating;
 	bool is_focused;
+	bool sticky; // floating view always visible on its output
 
 	// Attributes that mostly views have.
 	char *name;

--- a/sway.5.txt
+++ b/sway.5.txt
@@ -166,6 +166,10 @@ Commands
 **splitv**::
 	Equivalent to **split vertical**.
 
+**sticky** <enable|disable|toggle>::
+	If enabled and the windows is floating it will always be present on the active
+	workspace on that output.
+
 **workspace** <name>::
 	Switches to the specified workspace.
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -33,7 +33,6 @@ struct cmd_handler {
 };
 
 static sway_cmd cmd_bindsym;
-static sway_cmd cmd_orientation;
 static sway_cmd cmd_debuglog;
 static sway_cmd cmd_exec;
 static sway_cmd cmd_exec_always;
@@ -51,6 +50,7 @@ static sway_cmd cmd_log_colors;
 static sway_cmd cmd_mode;
 static sway_cmd cmd_mouse_warping;
 static sway_cmd cmd_move;
+static sway_cmd cmd_orientation;
 static sway_cmd cmd_output;
 static sway_cmd cmd_reload;
 static sway_cmd cmd_resize;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -59,6 +59,7 @@ static sway_cmd cmd_set;
 static sway_cmd cmd_split;
 static sway_cmd cmd_splith;
 static sway_cmd cmd_splitv;
+static sway_cmd cmd_sticky;
 static sway_cmd cmd_workspace;
 static sway_cmd cmd_ws_auto_back_and_forth;
 
@@ -1237,6 +1238,28 @@ static struct cmd_results *cmd_splith(int argc, char **argv) {
 	return _do_split(argc, argv, L_HORIZ);
 }
 
+static struct cmd_results *cmd_sticky(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if (config->reading) return cmd_results_new(CMD_FAILURE, "sticky", "Can't be used in config file.");
+	if (!config->active) return cmd_results_new(CMD_FAILURE, "sticky", "Can only be used when sway is running.");
+	if ((error = checkarg(argc, "sticky", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+	char *action = argv[0];
+	swayc_t *cont = get_focused_view(&root_container);
+	if (strcmp(action, "toggle") == 0) {
+		cont->sticky = !cont->sticky;
+	} else if (strcmp(action, "enable") == 0) {
+		cont->sticky = true;
+	} else if (strcmp(action, "disable") == 0) {
+		cont->sticky = false;
+	} else {
+		return cmd_results_new(CMD_FAILURE, "sticky",
+				"Expected 'sticky enable|disable|toggle'");
+	}
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}
+
 static struct cmd_results *cmd_log_colors(int argc, char **argv) {
 	struct cmd_results *error = NULL;
 	if (!config->reading) return cmd_results_new(CMD_FAILURE, "log_colors", "Can only be used in config file.");
@@ -1416,6 +1439,7 @@ static struct cmd_handler handlers[] = {
 	{ "split", cmd_split },
 	{ "splith", cmd_splith },
 	{ "splitv", cmd_splitv },
+	{ "sticky", cmd_sticky },
 	{ "workspace", cmd_workspace },
 	{ "workspace_auto_back_and_forth", cmd_ws_auto_back_and_forth },
 };

--- a/sway/container.c
+++ b/sway/container.c
@@ -226,6 +226,7 @@ swayc_t *new_view(swayc_t *sibling, wlc_handle handle) {
 	view->app_id = app_id ? strdup(app_id) : NULL;
 	view->visible = true;
 	view->is_focused = true;
+	view->sticky = false;
 	// Setup geometry
 	const struct wlc_geometry* geometry = wlc_view_get_geometry(handle);
 	view->width = 0;
@@ -261,6 +262,7 @@ swayc_t *new_floating_view(wlc_handle handle) {
 	const char *app_id = wlc_view_get_app_id(handle);
 	view->app_id = app_id ? strdup(app_id) : NULL;
 	view->visible = true;
+	view->sticky = false;
 
 	// Set the geometry of the floating view
 	const struct wlc_geometry* geometry = wlc_view_get_geometry(handle);


### PR DESCRIPTION
A floating window that's sticky will move to the new active workspace
whenever the workspace on the same output changes.

(Another one bites the dust: #2 ) Please review, comments are welcomed.