### PR TITLE
Add WLC_INCLUDE_DIRS to subprojects

### DIFF
--- a/swaybg/CMakeLists.txt
+++ b/swaybg/CMakeLists.txt
@@ -10,6 +10,7 @@ WAYLAND_ADD_PROTOCOL_CLIENT(proto-xdg-shell "${PROJECT_SOURCE_DIR}/../protocols/
 WAYLAND_ADD_PROTOCOL_CLIENT(proto-desktop-shell "${PROJECT_SOURCE_DIR}/../protocols/desktop-shell.xml" desktop-shell)
 
 include_directories(
+  ${WLC_INCLUDE_DIRS}
   ${WAYLAND_CLIENT_INCLUDE_DIR}
   ${CAIRO_INCLUDE_DIRS}
   ${PANGO_INCLUDE_DIRS}

--- a/swaygrab/CMakeLists.txt
+++ b/swaygrab/CMakeLists.txt
@@ -2,6 +2,10 @@ project(swaygrab)
 
 set(CMAKE_CURRENT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/../bin/)
 
+include_directories(
+  ${WLC_INCLUDE_DIRS}
+)
+
 FILE(GLOB sources ${PROJECT_SOURCE_DIR}/*.c)
 FILE(GLOB common ${PROJECT_SOURCE_DIR}/../common/*.c)
 

--- a/swaymsg/CMakeLists.txt
+++ b/swaymsg/CMakeLists.txt
@@ -2,6 +2,10 @@ project(swaymsg)
 
 set(CMAKE_CURRENT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/../bin/)
 
+include_directories(
+  ${WLC_INCLUDE_DIRS}
+)
+
 FILE(GLOB sources ${PROJECT_SOURCE_DIR}/*.c)
 FILE(GLOB common ${PROJECT_SOURCE_DIR}/../common/*.c)
 


### PR DESCRIPTION
Hello, I asked about this on irc, but looking at the CMake setup this might in fact be the correct way to do it.

Basically I want to be able to do:

```
$ cmake \
  -DWLC_LIBRARIES=../path/to/wlc/target/src/libwlc.so \
  -DWLC_INCLUDE_DIRS=../path/to/wlc/include .
```

and build against that version of wlc rather than the globally installed version.

Just reject if this in fact isn't the right way to handle this issue.

Thanks.