### PR TITLE
sway/main: Move wlc init to after args are handled.

### DIFF
--- a/sway/main.c
+++ b/sway/main.c
@@ -64,21 +64,7 @@ int main(int argc, char **argv) {
 		{0, 0, 0, 0}
 	};
 
-	setenv("WLC_DIM", "0", 0);
-
-	wlc_log_set_handler(wlc_log_handler);
-
-	detect_nvidia();
-
-	/* Changing code earlier than this point requires detailed review */
-	if (!wlc_init(&interface, argc, argv)) {
-		return 1;
-	}
-	
-	register_extensions();
-
 	char *config_path = NULL;
-
 	int c;
 	while (1) {
 		int option_index = 0;
@@ -120,6 +106,18 @@ int main(int argc, char **argv) {
 			break;
 		}
 	}
+
+	setenv("WLC_DIM", "0", 0);
+	wlc_log_set_handler(wlc_log_handler);
+	detect_nvidia();
+
+	/* Changing code earlier than this point requires detailed review */
+	/* (That code runs as root on systems without logind, and wlc_init drops to
+	 * another user.) */
+	if (!wlc_init(&interface, argc, argv)) {
+		return 1;
+	}
+	register_extensions();
 
 	if (debug) {
 		init_log(L_DEBUG);


### PR DESCRIPTION
First of all because it's not needed that early, and second of all
because there's a bug where calling `sway --get-socketpath` via `popen`
causes the child sway process to spin/hang instead of returning EOF.
(Specifically `(unset SWAYSOCK; swaymsg)` hangs.) This patch fixes that.

(Also note that this patch moves the "detailed review" comment, so I
guess this patch requires extra detailed review?)