### PR TITLE
Fix output configuration

### DIFF
--- a/sway.5.txt
+++ b/sway.5.txt
@@ -133,10 +133,6 @@ Commands
 	Disables the specified output.
 
 **NOTES FOR THE OUTPUT COMMAND**::
-	You may combine output commands into one, like so:
-	+
-	output HDMI-A-1 res 1920x1080 pos 1920,0 bg ~/wallpaper.png stretch
-	+
 	You can get a list of output names like so:
 	+
 	swaymsg -t get_outputs


### PR DESCRIPTION
Don't overwrite existing configuration. Previously, the configuration:

output WLC-1 position 1680,0
output WLC-1 background ~/background.png stretch

Would discard the positioning information.

This change fixes this, but removes support for combining different output
subcommands, to simplify error handling in individual subcommands.