### PR TITLE
cmd_floating: Don't add non-float as sibling to float.

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -344,14 +344,12 @@ static struct cmd_results *cmd_floating(int argc, char **argv) {
 
 	} else if (view->is_floating && !wants_floating) {
 		// Delete the view from the floating list and unset its is_floating flag
-		// Using length-1 as the index is safe because the view must be the currently
-		// focused floating output
 		remove_child(view);
 		view->is_floating = false;
 		// Get the properly focused container, and add in the view there
 		swayc_t *focused = container_under_pointer();
 		// If focused is null, it's because the currently focused container is a workspace
-		if (focused == NULL) {
+		if (focused == NULL || focused->is_floating) {
 			focused = swayc_active_workspace();
 		}
 		set_focused_container(focused);


### PR DESCRIPTION
When turning a float to a non-float, `get_focused_container` might
return another floating view, causing the active view to be inserted
into the floating list on its workspace instead of the normal child list
which it should. (Since it has `is_floating` as false the resulting
discrepency triggered other bad behaviour eventually leading sway to
crash.)

This patch fixes that by simply checking floating status before making
it a sibling.

This should fix the extra issue reported at #241 .