### PR TITLE
Can customize fallback config directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.1.0)
 
 project(sway C)
 
+set(FALLBACK_CONFIG_DIR "/etc/sway/")
+add_definitions('-DFALLBACK_CONFIG_DIR=\"${FALLBACK_CONFIG_DIR}\"')
+
 set(CMAKE_C_FLAGS "-g")
 set(CMAKE_C_STANDARD 99)
 SET(CMAKE_C_EXTENSIONS OFF)
@@ -80,7 +83,7 @@ install(
   COMPONENT runtime)
 install(
   FILES       "${CMAKE_CURRENT_SOURCE_DIR}/config"
-  DESTINATION /etc/sway/
+  DESTINATION "${FALLBACK_CONFIG_DIR}"
   COMPONENT   configuration)
 
 add_custom_target(man ALL)

--- a/README.md
+++ b/README.md
@@ -57,8 +57,10 @@ On systems without logind, you need to suid the sway binary:
 ## Configuration
 
 If you already use i3, then copy your i3 config to `~/.config/sway/config` and
-it'll work out of the box. Otherwise, copy `/etc/sway/config` to
-`~/.config/sway/config`. Run `man 5 sway` for information on the configuration.
+it'll work out of the box. Otherwise, copy the sample configuration file to
+`~/.config/sway/config`. It is located at `/etc/sway/config`, unless the 
+`DFALLBACK_CONFIG_DIR` flag has been set. Run `man 5 sway` for information on
+the configuration.
 
 ## Running
 

--- a/sway.1.txt
+++ b/sway.1.txt
@@ -66,11 +66,13 @@ Configuration
 -------------
 
 If _-c_ is not specified, sway will look in several locations for your config
-file. The default one is provided at /etc/sway/config. The suggested location for
-your config file is ~/.config/sway/config. ~/.sway/config will also work, and the
-rest of the usual XDG config locations are supported. If no sway config is found,
-sway will attempt to load an i3 config from all the config locations i3 supports.
-If still nothing is found, you will receive an error.
+file. The suggested location for your config file is ~/.config/sway/config.
+~/.sway/config will also work, and the rest of the usual XDG config locations
+are supported. At last, sway looks for a config file in a fallback directory,
+which is /etc/sway/ by default. A standard configuration file is installed at
+this location. If no sway config is found, sway will attempt to load an i3
+config from all the config locations i3 supports. If still nothing is found,
+you will receive an error.
 
 For information on the config file format, see **sway**(5).
 

--- a/sway/config.c
+++ b/sway/config.c
@@ -136,7 +136,7 @@ static char *get_config_path(void) {
 		"$XDG_CONFIG_HOME/sway/config",
 		"$HOME/.i3/config",
 		"$XDG_CONFIG_HOME/i3/config",
-		"/etc/sway/config",
+                FALLBACK_CONFIG_DIR "config",
 		"/etc/i3/config",
 	};
 


### PR DESCRIPTION
CMake takes a `DDUMP_CONFIG_DIR` flag which is the directory where the
standard configuration file `config` is copied at installation.