### PR TITLE
FALLBACK_CONFIG_DIR did not work. Fixed.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1.0)
 
 project(sway C)
 
-set(FALLBACK_CONFIG_DIR "/etc/sway/")
+set(FALLBACK_CONFIG_DIR "${FALLBACK_CONFIG_DIR}" CACHE STRING "/etc/sway/")
 add_definitions('-DFALLBACK_CONFIG_DIR=\"${FALLBACK_CONFIG_DIR}\"')
 
 set(CMAKE_C_FLAGS "-g")


### PR DESCRIPTION
I didn't know anything about CMake, and apparently the way I did it, the default value would always take precedence over the flag.
This commit fixes this, although I really don't understand why.