### PR TITLE
FALLBACK_CONFIG_DIR did not work. Fixed.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,8 @@ cmake_minimum_required(VERSION 3.1.0)
 
 project(sway C)
 
-set(FALLBACK_CONFIG_DIR "/etc/sway/")
+set(FALLBACK_CONFIG_DIR "/etc/sway" CACHE PATH
+  "Fallback config directory defaults to /etc/sway")
 add_definitions('-DFALLBACK_CONFIG_DIR=\"${FALLBACK_CONFIG_DIR}\"')
 
 set(CMAKE_C_FLAGS "-g")

--- a/sway/config.c
+++ b/sway/config.c
@@ -136,7 +136,7 @@ static char *get_config_path(void) {
 		"$XDG_CONFIG_HOME/sway/config",
 		"$HOME/.i3/config",
 		"$XDG_CONFIG_HOME/i3/config",
-                FALLBACK_CONFIG_DIR "config",
+                FALLBACK_CONFIG_DIR "/config",
 		"/etc/i3/config",
 	};
 


### PR DESCRIPTION
- Flag was ignored. Now it's taken into account.
- Missing trailing slashes in path now behaves properly.

Sorry for the last PR. This one has been tested properly. It should build nicely.
Plus, the type "PATH" in CMake automatically removes trailing slashes.