### PR TITLE
Fix dangling pointer on focus swap/describe WS

### DIFF
--- a/sway/focus.c
+++ b/sway/focus.c
@@ -96,6 +96,7 @@ bool set_focused_container(swayc_t *c) {
 		return false;
 	}
 	swayc_t *active_ws = swayc_active_workspace();
+	int active_ws_child_count = active_ws->children->length + active_ws->floating->length;
 
 	swayc_log(L_DEBUG, c, "Setting focus to %p:%ld", c, c->handle);
 
@@ -117,6 +118,11 @@ bool set_focused_container(swayc_t *c) {
 		update_focus(p);
 		p = p->parent;
 		p->is_focused = false;
+	}
+	// active_ws might have been destroyed by now
+	// (focus swap away from empty ws = destroy ws)
+	if (active_ws_child_count == 0) {
+		active_ws = NULL;
 	}
 
 	// get new focused view and set focus to it.

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -455,7 +455,11 @@ void ipc_get_outputs_callback(swayc_t *container, void *data) {
 void ipc_event_workspace(swayc_t *old, swayc_t *new) {
 	json_object *obj = json_object_new_object();
 	json_object_object_add(obj, "change", json_object_new_string("focus"));
-	json_object_object_add(obj, "old", ipc_json_describe_workspace(old));
+	if (old) {
+		json_object_object_add(obj, "old", ipc_json_describe_workspace(old));
+	} else {
+		json_object_object_add(obj, "old", NULL);
+	}
 	json_object_object_add(obj, "current", ipc_json_describe_workspace(new));
 	const char *json_string = json_object_to_json_string(obj);
 


### PR DESCRIPTION
Empty workspaces are deleted on focus-swap, made set_focused_container aware of that.