### PR TITLE
Implement bar { } config parsing

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -77,6 +77,7 @@ struct bar_config {
 	char *status_command;
 	char *font;
 	int bar_height;
+	int tray_padding;
 	bool workspace_buttons;
 	bool strip_workspace_numbers;
 	bool binding_mode_indicator;
@@ -102,12 +103,14 @@ struct bar_config {
 struct sway_config {
 	list_t *symbols;
 	list_t *modes;
+	list_t *bars;
 	list_t *cmd_queue;
 	list_t *workspace_outputs;
 	list_t *output_configs;
 	list_t *criteria;
 	struct sway_mode *current_mode;
 	struct bar_config bar;
+	struct bar_config *current_bar;
 	uint32_t floating_mod;
 	uint32_t dragging_key;
 	uint32_t resizing_key;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -32,6 +32,7 @@ struct cmd_handler {
 	sway_cmd *handle;
 };
 
+static sway_cmd cmd_bar;
 static sway_cmd cmd_bindsym;
 static sway_cmd cmd_debuglog;
 static sway_cmd cmd_exec;
@@ -1099,6 +1100,43 @@ static struct cmd_results *cmd_resize(int argc, char **argv) {
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }
 
+static struct cmd_results *cmd_bar(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "bar", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+
+	if (strcmp("{", argv[0]) != 0) {
+		return cmd_results_new(CMD_INVALID, "bar",
+				"Expected '{' at start of bar config definition.");
+	}
+
+	if (!config->reading) {
+		return cmd_results_new(CMD_FAILURE, "bar", "Can only be used in config file.");
+	}
+
+	// Create new bar from default bar config
+	struct bar_config *bar = NULL;
+	bar = malloc(sizeof*bar);
+	bar->mode = strdup(config->bar.mode);
+	bar->hidden_state = strdup(config->bar.hidden_state);
+	bar->modifier = config->bar.modifier;
+	bar->position = config->bar.position;
+	bar->status_command = strdup(config->bar.status_command);
+	bar->font = strdup(config->bar.font);
+	bar->bar_height = config->bar.bar_height;
+	bar->workspace_buttons = config->bar.workspace_buttons;
+	bar->strip_workspace_numbers = config->bar.strip_workspace_numbers;
+	bar->binding_mode_indicator = config->bar.binding_mode_indicator;
+	bar->tray_padding = config->bar.tray_padding;
+	list_add(config->bars, bar);
+
+	// Set current bar
+	config->current_bar = bar;
+	sway_log(L_DEBUG, "Configuring bar");
+	return cmd_results_new(CMD_BLOCK_BAR, NULL, NULL);
+}
+
 static swayc_t *fetch_view_from_scratchpad() {
 	if (sp_index >= scratchpad->length) {
 		sp_index = 0;
@@ -1446,6 +1484,7 @@ static struct cmd_results *cmd_ws_auto_back_and_forth(int argc, char **argv) {
 
 /* Keep alphabetized */
 static struct cmd_handler handlers[] = {
+	{ "bar", cmd_bar },
 	{ "bindsym", cmd_bindsym },
 	{ "debuglog", cmd_debuglog },
 	{ "default_orientation", cmd_orientation },
@@ -1505,14 +1544,17 @@ static int handler_compare(const void *_a, const void *_b) {
 }
 
 static struct cmd_handler *find_handler(char *line, enum cmd_status block) {
-	struct cmd_handler *h = handlers;
-	if (block == CMD_BLOCK_BAR) {
-		h = bar_handlers;
-	}
 	struct cmd_handler d = { .command=line };
-	struct cmd_handler *res = bsearch(&d, h,
+	struct cmd_handler *res = NULL;
+	if (block == CMD_BLOCK_BAR) {
+		res = bsearch(&d, bar_handlers,
+			sizeof(bar_handlers) / sizeof(struct cmd_handler),
+			sizeof(struct cmd_handler), handler_compare);
+	} else {
+		res = bsearch(&d, handlers,
 			sizeof(handlers) / sizeof(struct cmd_handler),
 			sizeof(struct cmd_handler), handler_compare);
+	}
 	return res;
 }
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -63,6 +63,8 @@ static sway_cmd cmd_splitv;
 static sway_cmd cmd_sticky;
 static sway_cmd cmd_workspace;
 static sway_cmd cmd_ws_auto_back_and_forth;
+
+static sway_cmd bar_cmd_tray_padding;
 static sway_cmd bar_cmd_workspace_buttons;
 
 swayc_t *sp_view;
@@ -1519,6 +1521,30 @@ static struct cmd_handler handlers[] = {
 	{ "workspace_auto_back_and_forth", cmd_ws_auto_back_and_forth },
 };
 
+static struct cmd_results *bar_cmd_tray_padding(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "tray_padding", EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+
+	if (!config->current_bar) {
+		return cmd_results_new(CMD_FAILURE, "tray_padding", "No bar defined.");
+	}
+
+	int padding = atoi(argv[0]);
+	if (padding < 0) {
+		return cmd_results_new(CMD_INVALID, "tray_padding",
+				"Invalid padding value %s, minimum is 0", argv[0]);
+	}
+
+	if (argc > 1 && strcasecmp("px", argv[1]) != 0) {
+		return cmd_results_new(CMD_INVALID, "tray_padding",
+				"Unknown unit %s", argv[1]);
+	}
+	config->current_bar->tray_padding = padding;
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}
+
 static struct cmd_results *bar_cmd_workspace_buttons(int argc, char **argv) {
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "workspace_buttons", EXPECTED_EQUAL_TO, 1))) {
@@ -1555,7 +1581,7 @@ static struct cmd_handler bar_handlers[] = {
 	{ "status_command", NULL },
 	{ "strip_workspace_numbers", NULL },
 	{ "tray_output", NULL },
-	{ "tray_padding", NULL },
+	{ "tray_padding", bar_cmd_tray_padding },
 	{ "workspace_buttons", bar_cmd_workspace_buttons },
 };
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -63,6 +63,7 @@ static sway_cmd cmd_splitv;
 static sway_cmd cmd_sticky;
 static sway_cmd cmd_workspace;
 static sway_cmd cmd_ws_auto_back_and_forth;
+static sway_cmd bar_cmd_workspace_buttons;
 
 swayc_t *sp_view;
 int sp_index = 0;
@@ -1518,6 +1519,27 @@ static struct cmd_handler handlers[] = {
 	{ "workspace_auto_back_and_forth", cmd_ws_auto_back_and_forth },
 };
 
+static struct cmd_results *bar_cmd_workspace_buttons(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "workspace_buttons", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+
+	if (!config->current_bar) {
+		return cmd_results_new(CMD_FAILURE, "workspace_buttons", "No bar defined.");
+	}
+
+	if (strcasecmp("yes", argv[0]) == 0) {
+		config->current_bar->workspace_buttons = true;
+	} else if (strcasecmp("no", argv[0]) == 0) {
+		config->current_bar->workspace_buttons = false;
+	} else {
+		error = cmd_results_new(CMD_INVALID, "workspace_buttons", "Invalid value %s", argv[0]);
+		return error;
+	}
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}
+
 static struct cmd_handler bar_handlers[] = {
 	{ "binding_mode_indicator", NULL },
 	{ "bindsym", NULL },
@@ -1534,7 +1556,7 @@ static struct cmd_handler bar_handlers[] = {
 	{ "strip_workspace_numbers", NULL },
 	{ "tray_output", NULL },
 	{ "tray_padding", NULL },
-	{ "workspace_buttons", NULL },
+	{ "workspace_buttons", bar_cmd_workspace_buttons },
 };
 
 static int handler_compare(const void *_a, const void *_b) {

--- a/sway/config.c
+++ b/sway/config.c
@@ -144,6 +144,7 @@ static void config_defaults(struct sway_config *config) {
 	config->bar.workspace_buttons = true;
 	config->bar.strip_workspace_numbers = false;
 	config->bar.binding_mode_indicator = true;
+	config->bar.tray_padding = 2;
 }
 
 static char *get_config_path(void) {


### PR DESCRIPTION
This implements parsing of `bar { }` blocks in the config file. I have also implemented parsing of `workspace_buttons <yes|no>` and `tray_padding <px> [px]` as an example for implementing the other sub-commands.

I have just assumed that the `bar-id` can be the index of the bar in `config->bars->items`. Is this alright, or should we generate a custom id, like in i3 [1]?

This will affect the implementation of #309. @gpyh can you please check this out, so we are sure that we are on the same page? Hopefully I haven't created too much new work for you :)

[1] http://i3wm.org/docs/ipc.html#_bar_config_reply (Example of configured bars:)
