### PR TITLE
Move default bar config to bar creation.

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -125,7 +125,6 @@ struct sway_config {
 	list_t *output_configs;
 	list_t *criteria;
 	struct sway_mode *current_mode;
-	struct bar_config bar;
 	struct bar_config *current_bar;
 	uint32_t floating_mod;
 	uint32_t dragging_key;
@@ -175,6 +174,11 @@ void free_sway_binding(struct sway_binding *sb);
 int sway_mouse_binding_cmp(const void *a, const void *b);
 int sway_mouse_binding_cmp_buttons(const void *a, const void *b);
 void free_sway_mouse_binding(struct sway_mouse_binding *smb);
+
+/**
+ * Allocate and initialize default bar configuration.
+ */
+struct bar_config *default_bar_config(void);
 
 /**
  * Global config singleton.

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -1126,22 +1126,8 @@ static struct cmd_results *cmd_bar(int argc, char **argv) {
 		return cmd_results_new(CMD_FAILURE, "bar", "Can only be used in config file.");
 	}
 
-	// Create new bar from default bar config
-	struct bar_config *bar = NULL;
-	bar = malloc(sizeof*bar);
-	bar->mode = strdup(config->bar.mode);
-	bar->hidden_state = strdup(config->bar.hidden_state);
-	bar->modifier = config->bar.modifier;
-	bar->position = config->bar.position;
-	bar->bindings = create_list();
-	bar->status_command = strdup(config->bar.status_command);
-	bar->font = strdup(config->bar.font);
-	bar->bar_height = config->bar.bar_height;
-	bar->workspace_buttons = config->bar.workspace_buttons;
-	bar->strip_workspace_numbers = config->bar.strip_workspace_numbers;
-	bar->binding_mode_indicator = config->bar.binding_mode_indicator;
-	bar->tray_padding = config->bar.tray_padding;
-	list_add(config->bars, bar);
+	// Create new bar with default values
+	struct bar_config *bar = default_bar_config();
 
 	// set bar id
 	int i;

--- a/sway/config.c
+++ b/sway/config.c
@@ -132,19 +132,6 @@ static void config_defaults(struct sway_config *config) {
 	config->edge_gaps = true;
 	config->gaps_inner = 0;
 	config->gaps_outer = 0;
-
-	// Bar
-	config->bar.mode = "dock";
-	config->bar.hidden_state = "hide";
-	config->bar.modifier = 0;
-	config->bar.position = DESKTOP_SHELL_PANEL_POSITION_BOTTOM;
-	config->bar.status_command = "while :; do date +'%Y-%m-%d %l:%M:%S %p' && sleep 1; done";
-	config->bar.font = "monospace 10";
-	config->bar.bar_height = -1;
-	config->bar.workspace_buttons = true;
-	config->bar.strip_workspace_numbers = false;
-	config->bar.binding_mode_indicator = true;
-	config->bar.tray_padding = 2;
 }
 
 static char *get_config_path(void) {
@@ -545,4 +532,24 @@ void free_sway_mouse_binding(struct sway_mouse_binding *binding) {
 		free(binding->command);
 	}
 	free(binding);
+}
+
+struct bar_config *default_bar_config(void) {
+	struct bar_config *bar = NULL;
+	bar = malloc(sizeof(struct bar_config));
+	bar->mode = strdup("dock");
+	bar->hidden_state = strdup("hide");
+	bar->modifier = 0;
+	bar->position = DESKTOP_SHELL_PANEL_POSITION_BOTTOM;
+	bar->bindings = create_list();
+	bar->status_command = strdup("while :; do date +'%Y-%m-%d %l:%M:%S %p' && sleep 1; done");
+	bar->font = strdup("monospace 10");
+	bar->bar_height = -1;
+	bar->workspace_buttons = true;
+	bar->strip_workspace_numbers = false;
+	bar->binding_mode_indicator = true;
+	bar->tray_padding = 2;
+	list_add(config->bars, bar);
+
+	return bar;
 }


### PR DESCRIPTION
Get rid of `config->bar` and define the default bar config options when
a bar is initialized.