### PR TITLE
Implement bar option: separator_symbol

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -96,6 +96,7 @@ struct bar_config {
 	int height; // -1 not defined
 	int tray_padding;
 	bool workspace_buttons;
+	char *separator_symbol;
 	bool strip_workspace_numbers;
 	bool binding_mode_indicator;
 	bool verbose;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -76,6 +76,7 @@ static sway_cmd bar_cmd_height;
 static sway_cmd bar_cmd_hidden_state;
 static sway_cmd bar_cmd_id;
 static sway_cmd bar_cmd_position;
+static sway_cmd bar_cmd_separator_symbol;
 static sway_cmd bar_cmd_status_command;
 static sway_cmd bar_cmd_strip_workspace_numbers;
 static sway_cmd bar_cmd_tray_output;
@@ -1840,6 +1841,23 @@ static struct cmd_results *bar_cmd_position(int argc, char **argv) {
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }
 
+static struct cmd_results *bar_cmd_separator_symbol(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "separator_symbol", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+
+	if (!config->current_bar) {
+		return cmd_results_new(CMD_FAILURE, "separator_symbol", "No bar defined.");
+	}
+
+	free(config->current_bar->separator_symbol);
+	config->current_bar->separator_symbol = strdup(argv[0]);
+	sway_log(L_DEBUG, "Settings separator_symbol '%s' for bar: %s", config->current_bar->separator_symbol, config->current_bar->id);
+
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}
+
 static struct cmd_results *bar_cmd_status_command(int argc, char **argv) {
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "status_command", EXPECTED_AT_LEAST, 1))) {
@@ -1945,7 +1963,7 @@ static struct cmd_handler bar_handlers[] = {
 	{ "modifier", bar_cmd_modifier },
 	{ "output", bar_cmd_output },
 	{ "position", bar_cmd_position },
-	{ "seperator_symbol", NULL },
+	{ "separator_symbol", bar_cmd_separator_symbol },
 	{ "status_command", bar_cmd_status_command },
 	{ "strip_workspace_numbers", bar_cmd_strip_workspace_numbers },
 	{ "tray_output", bar_cmd_tray_output },

--- a/sway/config.c
+++ b/sway/config.c
@@ -43,6 +43,7 @@ static void free_bar(struct bar_config *bar) {
 	free(bar->hidden_state);
 	free(bar->status_command);
 	free(bar->font);
+	free(bar->separator_symbol);
 	int i;
 	for (i = 0; i < bar->bindings->length; ++i) {
 		free_sway_mouse_binding(bar->bindings->items[i]);
@@ -570,6 +571,7 @@ struct bar_config *default_bar_config(void) {
 	bar->font = strdup("monospace 10");
 	bar->height = -1;
 	bar->workspace_buttons = true;
+	bar->separator_symbol = NULL;
 	bar->strip_workspace_numbers = false;
 	bar->binding_mode_indicator = true;
 	bar->tray_padding = 2;

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -419,6 +419,9 @@ void ipc_client_handle_command(struct ipc_client *client) {
 			}
 			json_object_object_add(json, "status_command", json_object_new_string(bar->status_command));
 			json_object_object_add(json, "font", json_object_new_string(bar->font));
+			if (bar->separator_symbol) {
+				json_object_object_add(json, "separator_symbol", json_object_new_string(bar->separator_symbol));
+			}
 			json_object_object_add(json, "bar_height", json_object_new_int(bar->height));
 			json_object_object_add(json, "workspace_buttons", json_object_new_boolean(bar->workspace_buttons));
 			json_object_object_add(json, "strip_workspace_numbers", json_object_new_boolean(bar->strip_workspace_numbers));


### PR DESCRIPTION
I think this concludes the implementation of the bar config parser.