### PR TITLE
swaybar: Check that registry is set before teardown

### DIFF
--- a/swaybar/main.c
+++ b/swaybar/main.c
@@ -87,7 +87,9 @@ struct colors colors = {
 
 void sway_terminate(void) {
 	window_teardown(window);
-	registry_teardown(registry);
+	if (registry) {
+		registry_teardown(registry);
+	}
 	exit(EXIT_FAILURE);
 }
 


### PR DESCRIPTION
This fixes a segfault which would occur if you try to run swaybar without any arguments.