### PR TITLE
swaygrab: make focused output default

### DIFF
--- a/swaygrab/CMakeLists.txt
+++ b/swaygrab/CMakeLists.txt
@@ -1,9 +1,14 @@
+include_directories(
+	${JSONC_INCLUDE_DIRS}
+)
+
 add_executable(swaygrab
 	main.c
 )
 
 target_link_libraries(swaygrab
 	sway-common
+	${JSONC_LIBRARIES}
 	rt
 )
 


### PR DESCRIPTION
This makes `swaygrab` use the currently focused output as source if no
other output is defined with the `-o, --output <output>` option.

Note this changes the way swaygrab is called:
```
Usage: swaygrab [options] [file]

  -h, --help             Show help message and quit.
  -c, --capture          Capture video.
  -o, --output <output>  Output source.
  -v, --version          Show the version number and quit.
  -s, --socket <socket>  Use the specified socket.
  -R, --rate <rate>      Specify framerate (default: 30)
  -r, --raw              Write raw rgba data to stdout.
```

If you don't like this change, please let me know.
I will update the man page when/if this is accepted. 