### PR TITLE
swaybar: Remove stropts.h, fixes build for fedora.

### DIFF
--- a/swaybar/main.c
+++ b/swaybar/main.c
@@ -4,7 +4,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <unistd.h>
-#include <stropts.h>
 #include <json-c/json.h>
 #include <sys/un.h>
 #include <sys/socket.h>


### PR DESCRIPTION
Turns out that fedora killed off stropts.h some time ago [1] and
removing it seems to work just fine. (Tested on Fedora 23)

[1] https://bugzilla.redhat.com/show_bug.cgi?id=439403

Same as issue #162 .