### PR TITLE
Add bar option: swaybar_command <command>

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -92,6 +92,7 @@ struct bar_config {
 	enum desktop_shell_panel_position position;
 	list_t *bindings;
 	char *status_command;
+	char *swaybar_command;
 	char *font;
 	int height; // -1 not defined
 	int tray_padding;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -79,6 +79,7 @@ static sway_cmd bar_cmd_position;
 static sway_cmd bar_cmd_separator_symbol;
 static sway_cmd bar_cmd_status_command;
 static sway_cmd bar_cmd_strip_workspace_numbers;
+static sway_cmd bar_cmd_swaybar_command;
 static sway_cmd bar_cmd_tray_output;
 static sway_cmd bar_cmd_tray_padding;
 static sway_cmd bar_cmd_workspace_buttons;
@@ -1909,6 +1910,23 @@ static struct cmd_results *bar_cmd_strip_workspace_numbers(int argc, char **argv
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }
 
+static struct cmd_results *bar_cmd_swaybar_command(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "swaybar_command", EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+
+	if (!config->current_bar) {
+		return cmd_results_new(CMD_FAILURE, "swaybar_command", "No bar defined.");
+	}
+
+	free(config->current_bar->swaybar_command);
+	config->current_bar->swaybar_command = join_args(argv, argc);
+	sway_log(L_DEBUG, "Using custom swaybar command: %s", config->current_bar->swaybar_command);
+
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}
+
 static struct cmd_results *bar_cmd_tray_output(int argc, char **argv) {
 	sway_log(L_ERROR, "warning: tray_output is not supported on wayland");
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
@@ -1977,6 +1995,7 @@ static struct cmd_handler bar_handlers[] = {
 	{ "separator_symbol", bar_cmd_separator_symbol },
 	{ "status_command", bar_cmd_status_command },
 	{ "strip_workspace_numbers", bar_cmd_strip_workspace_numbers },
+	{ "swaybar_command", bar_cmd_swaybar_command },
 	{ "tray_output", bar_cmd_tray_output },
 	{ "tray_padding", bar_cmd_tray_padding },
 	{ "workspace_buttons", bar_cmd_workspace_buttons },

--- a/sway/config.c
+++ b/sway/config.c
@@ -610,6 +610,7 @@ struct bar_config *default_bar_config(void) {
 	bar->position = DESKTOP_SHELL_PANEL_POSITION_BOTTOM;
 	bar->bindings = create_list();
 	bar->status_command = strdup("while :; do date +'%Y-%m-%d %l:%M:%S %p' && sleep 1; done");
+	bar->swaybar_command = NULL;
 	bar->font = strdup("monospace 10");
 	bar->height = -1;
 	bar->workspace_buttons = true;


### PR DESCRIPTION
This adds config support for a custom `swaybar_command` in a `bar { }` block as mentioned here: https://github.com/SirCmpwn/sway/issues/343#issuecomment-165625365.

I will add the rest when #358 is merged as it builds on top of that.