### PR TITLE
Update readme dependency list and build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Install dependencies:
 * pango
 * cairo
 * gdk-pixbuf2
+* pam
 
 Run these commands:
 


### PR DESCRIPTION
Hi!
It seems pam dependency is missing from the readme file.
Also "cd .." is missing in "run these commands" section.