### PR TITLE
config: free_bar: Check if outputs is NULL.

### DIFF
--- a/sway/config.c
+++ b/sway/config.c
@@ -53,7 +53,9 @@ static void free_bar(struct bar_config *bar) {
 	}
 	list_free(bar->bindings);
 
-	free_flat_list(bar->outputs);
+	if (bar->outputs) {
+		free_flat_list(bar->outputs);
+	}
 	free(bar);
 }
 


### PR DESCRIPTION
bar_config.outputs is NULL if no output is explicitly defined in config
(ie. use for all outputs).

Should fix #363 .