### PR TITLE
swaygrab: Add support for custom filetypes

### DIFF
--- a/swaygrab/main.c
+++ b/swaygrab/main.c
@@ -72,7 +72,7 @@ void grab_and_apply_movie_magic(const char *file, const char *output,
 		"-video_size %dx%d -pixel_format argb "
 		"-i pipe:0 -r %d -vf vflip %s";
 	char *cmd = malloc(strlen(fmt) - 8 /*args*/
-			+ numlen(width) + numlen(height) + numlen(framerate) * 2 
+			+ numlen(width) + numlen(height) + numlen(framerate) * 2
 			+ strlen(file) + 1);
 	sprintf(cmd, fmt, framerate, width, height, framerate, file);
 
@@ -151,6 +151,7 @@ char *default_filename(const char *extension) {
 int main(int argc, char **argv) {
 	static int capture = 0, raw = 0;
 	char *socket_path = NULL;
+	char *filetype = NULL;
 	char *output = NULL;
 	int framerate = 30;
 
@@ -162,6 +163,7 @@ int main(int argc, char **argv) {
 		{"output", required_argument, NULL, 'o'},
 		{"version", no_argument, NULL, 'v'},
 		{"socket", required_argument, NULL, 's'},
+		{"type", required_argument, NULL, 't'},
 		{"raw", no_argument, NULL, 'r'},
 		{"rate", required_argument, NULL, 'R'},
 		{0, 0, 0, 0}
@@ -175,19 +177,23 @@ int main(int argc, char **argv) {
 		"  -o, --output <output>  Output source.\n"
 		"  -v, --version          Show the version number and quit.\n"
 		"  -s, --socket <socket>  Use the specified socket.\n"
+		"  -t, --type <filetype>  Specify image/video filetype.\n"
 		"  -R, --rate <rate>      Specify framerate (default: 30)\n"
 		"  -r, --raw              Write raw rgba data to stdout.\n";
 
 	int c;
 	while (1) {
 		int option_index = 0;
-		c = getopt_long(argc, argv, "hco:vs:r", long_options, &option_index);
+		c = getopt_long(argc, argv, "hco:vs:t:r", long_options, &option_index);
 		if (c == -1) {
 			break;
 		}
 		switch (c) {
 		case 's': // Socket
 			socket_path = strdup(optarg);
+			break;
+		case 't': // Filetype
+			filetype = strdup(optarg);
 			break;
 		case 'r':
 			raw = 1;
@@ -240,9 +246,15 @@ int main(int argc, char **argv) {
 
 	if (!file) {
 		if (!capture) {
-			file = default_filename("png");
+			if (!filetype) {
+				filetype = strdup("png");
+			}
+			file = default_filename(filetype);
 		} else {
-			file = default_filename("webm");
+			if (!filetype) {
+				filetype = strdup("webm");
+			}
+			file = default_filename(filetype);
 		}
 	}
 
@@ -254,6 +266,7 @@ int main(int argc, char **argv) {
 
 	free(output);
 	free(file);
+	free(filetype);
 	close(socketfd);
 	return 0;
 }

--- a/swaygrab/swaygrab.1.txt
+++ b/swaygrab/swaygrab.1.txt
@@ -38,6 +38,11 @@ Options
 	Use the specified socket path. Otherwise, swaymsg will ask sway where the
 	socket is (which is the value of $SWAYSOCK, then of $I3SOCK).
 
+*-t, --type* <filetype>::
+	Specify the image/video filetype to produce. If no type is defined it will
+	default to png for images and webm for videos. If _file_ is specified this
+	option will not take effect.
+
 *-r, --rate* <rate>::
 	Specify a framerate (in frames per second). Used in combination with -c.
 	Default is 30. Must be an integer.


### PR DESCRIPTION
Adds the option `-t, --type <filetype>` which can be used to select the
filetype of the produced image/video.

This will only take effect if you don't pass a filename to swaygrab e.g.
let swaygrab use the default date based filename.