### PR TITLE
Per panel config

### DIFF
--- a/include/extensions.h
+++ b/include/extensions.h
@@ -9,13 +9,15 @@
 struct background_config {
         wlc_handle output;
         wlc_resource surface;
-        struct wl_resource *resource;
+        // we need the wl_resource of the surface in the destructor
+        struct wl_resource *wl_surface_res;
 };
 
 struct panel_config {
         wlc_handle output;
         wlc_resource surface;
-        struct wl_resource *resource;
+        // we need the wl_resource of the surface in the destructor
+        struct wl_resource *wl_surface_res;
 };
 
 struct desktop_shell_state {

--- a/include/extensions.h
+++ b/include/extensions.h
@@ -14,10 +14,13 @@ struct background_config {
 };
 
 struct panel_config {
+        // wayland resource used in callbacks, is used to track this panel
+        struct wl_resource *wl_resource;
         wlc_handle output;
         wlc_resource surface;
         // we need the wl_resource of the surface in the destructor
         struct wl_resource *wl_surface_res;
+        enum desktop_shell_panel_position panel_position;
 };
 
 struct desktop_shell_state {
@@ -25,7 +28,6 @@ struct desktop_shell_state {
         list_t *panels;
         list_t *lock_surfaces;
         bool is_locked;
-        enum desktop_shell_panel_position panel_position;
         struct wlc_size panel_size;
 };
 

--- a/sway/extensions.c
+++ b/sway/extensions.c
@@ -14,7 +14,7 @@ void background_surface_destructor(struct wl_resource *resource) {
 	int i;
 	for (i = 0; i < desktop_shell.backgrounds->length; ++i) {
 		struct background_config *config = desktop_shell.backgrounds->items[i];
-		if (config->resource == resource) {
+		if (config->wl_surface_res == resource) {
 			list_del(desktop_shell.backgrounds, i);
 			break;
 		}
@@ -26,7 +26,7 @@ void panel_surface_destructor(struct wl_resource *resource) {
 	int i;
 	for (i = 0; i < desktop_shell.panels->length; ++i) {
 		struct panel_config *config = desktop_shell.panels->items[i];
-		if (config->resource == resource) {
+		if (config->wl_surface_res == resource) {
 			list_del(desktop_shell.panels, i);
 			arrange_windows(&root_container, -1, -1);
 			break;
@@ -58,7 +58,7 @@ static void set_background(struct wl_client *client, struct wl_resource *resourc
 	struct background_config *config = malloc(sizeof(struct background_config));
 	config->output = output;
 	config->surface = wlc_resource_from_wl_surface_resource(surface);
-	config->resource = surface;
+	config->wl_surface_res = surface;
 	list_add(desktop_shell.backgrounds, config);
 	wl_resource_set_destructor(surface, background_surface_destructor);
 }
@@ -73,7 +73,7 @@ static void set_panel(struct wl_client *client, struct wl_resource *resource,
 	struct panel_config *config = malloc(sizeof(struct panel_config));
 	config->output = output;
 	config->surface = wlc_resource_from_wl_surface_resource(surface);
-	config->resource = surface;
+	config->wl_surface_res = surface;
 	list_add(desktop_shell.panels, config);
 	wl_resource_set_destructor(surface, panel_surface_destructor);
 	desktop_shell.panel_size = *wlc_surface_get_size(config->surface);

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -90,7 +90,7 @@ static void handle_output_pre_render(wlc_handle output) {
 			struct wlc_geometry geo = {
 				.size = size
 			};
-			switch (desktop_shell.panel_position) {
+			switch (config->panel_position) {
 			case DESKTOP_SHELL_PANEL_POSITION_TOP:
 				geo.origin = (struct wlc_point){ 0, 0 };
 				break;

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -455,8 +455,8 @@ static void arrange_windows_r(swayc_t *container, double width, double height) {
 				struct panel_config *config = desktop_shell.panels->items[i];
 				if (config->output == output->handle) {
 					struct wlc_size size = *wlc_surface_get_size(config->surface);
-					sway_log(L_DEBUG, "-> Found panel for this workspace: %ux%u, position: %u", size.w, size.h, desktop_shell.panel_position);
-					switch (desktop_shell.panel_position) {
+					sway_log(L_DEBUG, "-> Found panel for this workspace: %ux%u, position: %u", size.w, size.h, config->panel_position);
+					switch (config->panel_position) {
 					case DESKTOP_SHELL_PANEL_POSITION_TOP:
 						y += size.h; height -= size.h;
 						break;


### PR DESCRIPTION
Panel position was a single property that applied to all swaybars. With this patch it is placed in `panel_config` instead so that each panel can have its own position.

In order to make this work the `wl_resource` used in the requests from the client needs to be stored and matched to the correct panel config.

Also, `set_panel_position` might be called before `set_panel` (for unknown reasons), so existing `panel_config` is used in `set_panel` if found.