### PR TITLE
Fix gaps

### DIFF
--- a/sway/container.c
+++ b/sway/container.c
@@ -671,7 +671,16 @@ int swayc_gap(swayc_t *container) {
 	if (container->type == C_VIEW) {
 		return container->gaps >= 0 ? container->gaps : config->gaps_inner;
 	} else if (container->type == C_WORKSPACE) {
-		return container->gaps >= 0 ? container->gaps : config->gaps_outer;
+		int base = container->gaps >= 0 ? container->gaps : config->gaps_outer;
+		if (config->edge_gaps) {
+			// the inner gap is created via a margin around each window which
+			// is half the gap size, so the workspace also needs half a gap
+			// size to make the outermost gap the same size (excluding the
+			// actual "outer gap" size which is handled independently)
+			return base + config->gaps_inner / 2;
+		} else {
+			return base;
+		}
 	} else {
 		return 0;
 	}

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -398,10 +398,10 @@ void update_geometry(swayc_t *container) {
 			geometry.size.h = container->height - gap/2;
 		}
 		if (container->x + container->width + gap >= ws->x + ws->width) {
-			geometry.size.w = ws->width - geometry.origin.x;
+			geometry.size.w = ws->x + ws->width - geometry.origin.x;
 		}
 		if (container->y + container->height + gap >= ws->y + ws->height) {
-			geometry.size.h = ws->height - geometry.origin.y;
+			geometry.size.h = ws->y + ws->height - geometry.origin.y;
 		}
 	}
 	wlc_view_set_geometry(container->handle, 0, &geometry);


### PR DESCRIPTION
First patch fixes inner gaps against screen edge (making all the gaps the same when `edge_gaps` is zero).

Second patch fixes inner gap when `edge_gap` is off and there's a top or left panel in place.