### PR TITLE
Implement ipc_event_barconfig_update

### DIFF
--- a/include/ipc-server.h
+++ b/include/ipc-server.h
@@ -2,6 +2,7 @@
 #define _SWAY_IPC_SERVER_H
 
 #include "container.h"
+#include "config.h"
 #include "ipc.h"
 
 void ipc_init(void);
@@ -9,6 +10,7 @@ void ipc_terminate(void);
 struct sockaddr_un *ipc_user_sockaddr(void);
 
 void ipc_event_workspace(swayc_t *old, swayc_t *new);
+void ipc_event_barconfig_update(struct bar_config *bar);
 const char *swayc_type_string(enum swayc_types type);
 
 #endif

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -25,6 +25,7 @@
 #include "resize.h"
 #include "input_state.h"
 #include "criteria.h"
+#include "ipc-server.h"
 
 typedef struct cmd_results *sway_cmd(int argc, char **argv);
 
@@ -1707,7 +1708,7 @@ static struct cmd_results *bar_set_hidden_state(struct bar_config *bar, const ch
 
 	if (strcmp(old_state, bar->hidden_state) != 0) {
 		if (!config->reading) {
-			// TODO: IPC event
+			ipc_event_barconfig_update(bar);
 		}
 		sway_log(L_DEBUG, "Setting hidden_state: '%s' for bar: %s", bar->hidden_state, bar->id);
 	}
@@ -1779,7 +1780,7 @@ static struct cmd_results *bar_set_mode(struct bar_config *bar, const char *mode
 
 	if (strcmp(old_mode, bar->mode) != 0) {
 		if (!config->reading) {
-			// TODO: IPC event
+			ipc_event_barconfig_update(bar);
 		}
 		sway_log(L_DEBUG, "Setting mode: '%s' for bar: %s", bar->mode, bar->id);
 	}


### PR DESCRIPTION
This implements the `barconfig_update` event (missing part in #388).

Eventually we should also trigger a `barconfig_update` when reloading the config file, but I don't think it makes sense to implement this before `swaybar` has been refactored and supports the event.