### PR TITLE
Stop swaybar from not rendering after the first go around

### DIFF
--- a/swaybar/main.c
+++ b/swaybar/main.c
@@ -690,10 +690,9 @@ void poll_for_update() {
 		if (dirty && window_prerender(window) && window->cairo) {
 			render();
 			window_render(window);
-		}
-
-		if (wl_display_dispatch(registry->display) == -1) {
-			break;
+			if (wl_display_dispatch(registry->display) == -1) {
+				break;
+			}
 		}
 
 		dirty = false;


### PR DESCRIPTION
I am not sure if this is a correct issue/fix but on my system at least
after an i3bar protocol is detected this while loop never goes back
around meaning it doesnt process the status line anymore.