### PR TITLE
Bugfix: Added include(GNUInstallDirs)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ endif()
 
 include(FeatureSummary)
 include(Manpage)
+include(GNUInstallDirs)
 
 if (enable-gdk-pixbuf)
   if (GDK_PIXBUF_FOUND)


### PR DESCRIPTION
Silent bug introduced by f02cf75.

I forgot to commit this change so variables were not initialized. This did not raise any warning because CMake doesn't care.
It may have polluted the root directory. Check for /sway and /pam.d folders and delete them.