### PR TITLE
Add clang build to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 sudo: required
 
+language: c
+
+compiler:
+  - gcc
+  - clang
+
 arch:
   packages:
     - cmake


### PR DESCRIPTION
I have added clang support to [arch-travis](https://github.com/mikkeloscar/arch-travis), and this enables it for sway travis builds.

Note that building wlc with clang throws a lot of warnings, if this is a problem then we can either use `gcc` for `wlc` or silence the warnings (or fix them upstream).