### PR TITLE
Readme: add link to sway article in Void Linux wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ available for you to install:
 * [Arch Linux](https://aur.archlinux.org/packages/sway-git/)
 * [Gentoo Linux](https://github.com/zetok/zetok-overlay/)
 * [openSUSE](https://build.opensuse.org/project/show/X11:Wayland)
+* [Void Linux](https://wiki.voidlinux.eu/sway)
 
 For other distros, [see this wiki page](https://github.com/SirCmpwn/sway/wiki/Install-on-other-distros).
 


### PR DESCRIPTION
The package didn't make it in the official repositories yet (that will happen, when there's a release version). But I've implemented some kind of overlay (AUR) for Void Linux, so we can have it there, too :+1: 

https://wiki.voidlinux.eu/sway
