### PR TITLE
Focus new sibling added to container

### DIFF
--- a/sway/layout.c
+++ b/sway/layout.c
@@ -99,6 +99,8 @@ swayc_t *add_sibling(swayc_t *fixed, swayc_t *active) {
 		list_insert(parent->children, i + 1, active);
 	}
 	active->parent = parent;
+	// focus new child
+	parent->focused = active;
 	return active->parent;
 }
 


### PR DESCRIPTION
This makes sure that the window being added to a container gets focus. For instance if you move a window from one workspace to another you want to keep focus on the window that is moved.