### PR TITLE
Fix layout calculations

### DIFF
--- a/sway/CMakeLists.txt
+++ b/sway/CMakeLists.txt
@@ -32,6 +32,7 @@ target_link_libraries(sway
 	${PCRE_LIBRARIES}
 	${JSONC_LIBRARIES}
 	${WAYLAND_SERVER_LIBRARIES}
+	m
 )
 
 install(

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -279,8 +279,8 @@ static void handle_view_focus(wlc_handle view, bool focus) {
 }
 
 static void handle_view_geometry_request(wlc_handle handle, const struct wlc_geometry *geometry) {
-	sway_log(L_DEBUG, "geometry request for %ld %dx%d : %dx%d",
-			handle, geometry->origin.x, geometry->origin.y, geometry->size.w, geometry->size.h);
+	sway_log(L_DEBUG, "geometry request for %ld %dx%d @ %d,%d", handle,
+			geometry->size.w, geometry->size.h, geometry->origin.x, geometry->origin.y);
 	// If the view is floating, then apply the geometry.
 	// Otherwise save the desired width/height for the view.
 	// This will not do anything for the time being as WLC improperly sends geometry requests

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -434,7 +434,7 @@ static void arrange_windows_r(swayc_t *container, double width, double height) {
 	sway_log(L_DEBUG, "Arranging layout for %p %s %fx%f+%f,%f", container,
 		container->name, container->width, container->height, container->x, container->y);
 
-	int x = 0, y = 0;
+	double x = 0, y = 0;
 	switch (container->type) {
 	case C_ROOT:
 		for (i = 0; i < container->children->length; ++i) {
@@ -489,8 +489,8 @@ static void arrange_windows_r(swayc_t *container, double width, double height) {
 				}
 			}
 			int gap = swayc_gap(container);
-			container->x = x + gap;
-			container->y = y + gap;
+			x = container->x = x + gap;
+			y = container->y = y + gap;
 			width = container->width = width - gap * 2;
 			height = container->height = height - gap * 2;
 			sway_log(L_DEBUG, "Arranging workspace '%s' at %f, %f", container->name, container->x, container->y);
@@ -509,10 +509,11 @@ static void arrange_windows_r(swayc_t *container, double width, double height) {
 	default:
 		container->width = width;
 		container->height = height;
+		x = container->x;
+		y = container->y;
 		break;
 	}
 
-	x = y = 0;
 	double scale = 0;
 	switch (container->layout) {
 	case L_HORIZ:
@@ -536,8 +537,8 @@ static void arrange_windows_r(swayc_t *container, double width, double height) {
 			for (i = 0; i < container->children->length; ++i) {
 				swayc_t *child = container->children->items[i];
 				sway_log(L_DEBUG, "Calculating arrangement for %p:%d (will scale %f by %f)", child, child->type, width, scale);
-				child->x = x + container->x;
-				child->y = y + container->y;
+				child->x = x;
+				child->y = y;
 				arrange_windows_r(child, child->width * scale, height);
 				x += child->width;
 			}
@@ -563,8 +564,8 @@ static void arrange_windows_r(swayc_t *container, double width, double height) {
 			for (i = 0; i < container->children->length; ++i) {
 				swayc_t *child = container->children->items[i];
 				sway_log(L_DEBUG, "Calculating arrangement for %p:%d (will scale %f by %f)", child, child->type, height, scale);
-				child->x = x + container->x;
-				child->y = y + container->y;
+				child->x = x;
+				child->y = y;
 				arrange_windows_r(child, width, child->height * scale);
 				y += child->height;
 			}


### PR DESCRIPTION
If the width or height of a container can't be evenly distributed to its
children, then the layout algorithm still thought it got it right (due
to using decimals) which caused a gap of one or more pixels for some
window arrangements.

This is fixed (by the second patch) by first rounding off the width and height
(so that decimals are never introduced) and then adjusting the last
view in a container to fill the remaining pixels (which now is counted
correctly due to the decimals being removed).

Also, due to the way gaps are implemented, an odd sized gap can never be
aligned properly, so just adjust to closest even number.

Fixes #392 .

First patch is a "minor refactoring" of the layout algorithm. Third patch adjusts some debug output that was annoying me.