### PR TITLE
saybar: remove stray logline

### DIFF
--- a/swaybar/main.c
+++ b/swaybar/main.c
@@ -548,8 +548,6 @@ void render_block(struct status_block *block, double *x, bool edge) {
 		pos += block->border_right;
 	}
 
-	sway_log(L_DEBUG, "%s", separator_symbol);
-
 	// render separator
 	if (!edge && block->separator) {
 		cairo_set_source_u32(window->cairo, colors.separator);


### PR DESCRIPTION
I accidentally left a random debug log in d72be6c0d59b02e21c056e7b41be784eceaa540a.