### PR TITLE
Handle SIGTERM sent to sway

### DIFF
--- a/include/container.h
+++ b/include/container.h
@@ -260,4 +260,9 @@ void add_gaps(swayc_t *view, void *amount);
  */
 void update_visibility(swayc_t *container);
 
+/**
+ * Close all child views of container
+ */
+void close_views(swayc_t *container);
+
 #endif

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -318,12 +318,6 @@ static struct cmd_results *cmd_exec(int argc, char **argv) {
 	return cmd_exec_always(argc, argv);
 }
 
-static void kill_views(swayc_t *container, void *data) {
-	if (container->type == C_VIEW) {
-		wlc_view_close(container->handle);
-	}
-}
-
 static struct cmd_results *cmd_exit(int argc, char **argv) {
 	struct cmd_results *error = NULL;
 	if (config->reading) return cmd_results_new(CMD_FAILURE, "exit", "Can't be used in config file.");
@@ -331,7 +325,7 @@ static struct cmd_results *cmd_exit(int argc, char **argv) {
 		return error;
 	}
 	// Close all views
-	container_map(&root_container, kill_views, NULL);
+	close_views(&root_container);
 	sway_terminate();
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/container.c
+++ b/sway/container.c
@@ -796,3 +796,13 @@ void add_gaps(swayc_t *view, void *_data) {
 		}
 	}
 }
+
+static void close_view(swayc_t *container, void *data) {
+	if (container->type == C_VIEW) {
+		wlc_view_close(container->handle);
+	}
+}
+
+void close_views(swayc_t *container) {
+	container_map(container, close_view, NULL);
+}

--- a/sway/main.c
+++ b/sway/main.c
@@ -26,6 +26,11 @@ void sway_terminate(void) {
 	wlc_terminate();
 }
 
+void sig_handler(int signal) {
+	close_views(&root_container);
+	sway_terminate();
+}
+
 static void wlc_log_handler(enum wlc_log_type type, const char *str) {
 	if (type == WLC_LOG_ERROR) {
 		sway_log(L_ERROR, "[wlc] %s", str);
@@ -175,6 +180,9 @@ int main(int argc, char **argv) {
 		return 1;
 	}
 	register_extensions();
+
+	// handle SIGTERM signals
+	signal(SIGTERM, sig_handler);
 
 #if defined SWAY_GIT_VERSION && defined SWAY_GIT_BRANCH && defined SWAY_VERSION_DATE
 	sway_log(L_INFO, "Starting sway version %s (%s, branch \"%s\")\n", SWAY_GIT_VERSION, SWAY_VERSION_DATE, SWAY_GIT_BRANCH);


### PR DESCRIPTION
This makes sway handle and gracefully shut down everything when
receiving a SIGTERM.

Fix #416