### PR TITLE
Refactor IPC server/client

### DIFF
--- a/include/ipc-client.h
+++ b/include/ipc-client.h
@@ -4,6 +4,16 @@
 #include "ipc.h"
 
 /**
+ * IPC response including type of IPC response, size of payload and the json
+ * encoded payload string.
+ */
+struct ipc_response {
+	uint32_t size;
+	uint32_t type;
+	char *payload;
+};
+
+/**
  * Gets the path to the IPC socket from sway.
  */
 char *get_socketpath(void);
@@ -17,9 +27,12 @@ int ipc_open_socket(const char *socket_path);
  */
 char *ipc_single_command(int socketfd, uint32_t type, const char *payload, uint32_t *len);
 /**
- * Receives a single IPC resposne and returns the buffer. len will be updated
- * with the length of the buffer returned from sway.
+ * Receives a single IPC response and returns an ipc_response.
  */
-char *ipc_recv_response(int socketfd, uint32_t *len);
+struct ipc_response *ipc_recv_response(int socketfd);
+/**
+ * Free ipc_response struct
+ */
+void free_ipc_response(struct ipc_response *response);
 
 #endif

--- a/include/ipc.h
+++ b/include/ipc.h
@@ -10,6 +10,13 @@ enum ipc_command_type {
 	IPC_GET_MARKS = 5,
 	IPC_GET_BAR_CONFIG = 6,
 	IPC_GET_VERSION	= 7,
+	// Events send from sway to clients. Events have the higest bit set.
+	IPC_EVENT_WORKSPACE = (1 << 31 | 0),
+	IPC_EVENT_OUTPUT = (1 << 31 | 1),
+	IPC_EVENT_MODE = (1 << 31 | 2),
+	IPC_EVENT_WINDOW = (1 << 31 | 3),
+	IPC_EVENT_BARCONFIG_UPDATE = (1 << 31 | 4),
+	IPC_EVENT_BINDING = (1 << 31 | 5),
 	IPC_SWAY_GET_PIXELS = 0x81
 };
 

--- a/swaybar/main.c
+++ b/swaybar/main.c
@@ -1025,9 +1025,8 @@ void poll_for_update() {
 
 		if (FD_ISSET(ipc_event_socketfd, &readfds)) {
 			sway_log(L_DEBUG, "Got workspace update.");
-			uint32_t len;
-			char *buf = ipc_recv_response(ipc_event_socketfd, &len);
-			free(buf);
+			struct ipc_response *resp = ipc_recv_response(ipc_event_socketfd);
+			free_ipc_response(resp);
 			ipc_update_workspaces();
 			dirty = true;
 		}

--- a/swaybar/main.c
+++ b/swaybar/main.c
@@ -66,7 +66,7 @@ struct status_block {
 list_t *status_line = NULL;
 
 list_t *workspaces = NULL;
-int ipc_socketfd, ipc_listen_socketfd;
+int ipc_socketfd, ipc_event_socketfd;
 pid_t pid;
 int status_read_fd;
 char line[1024];
@@ -155,8 +155,8 @@ void swaybar_teardown() {
 		close(ipc_socketfd);
 	}
 
-	if (ipc_listen_socketfd) {
-		close(ipc_listen_socketfd);
+	if (ipc_event_socketfd) {
+		close(ipc_event_socketfd);
 	}
 }
 
@@ -403,9 +403,9 @@ void bar_ipc_init(int outputi, const char *bar_id) {
 	json_object_put(bar_config);
 	free(res);
 
-	const char *subscribe_json = "[ \"workspace\" ]";
+	const char *subscribe_json = "[ \"workspace\", \"mode\" ]";
 	len = strlen(subscribe_json);
-	res = ipc_single_command(ipc_listen_socketfd, IPC_SUBSCRIBE, subscribe_json, &len);
+	res = ipc_single_command(ipc_event_socketfd, IPC_SUBSCRIBE, subscribe_json, &len);
 	free(res);
 
 	ipc_update_workspaces();
@@ -1015,7 +1015,7 @@ void poll_for_update() {
 
 		dirty = false;
 		FD_ZERO(&readfds);
-		FD_SET(ipc_listen_socketfd, &readfds);
+		FD_SET(ipc_event_socketfd, &readfds);
 		FD_SET(status_read_fd, &readfds);
 
 		activity = select(FD_SETSIZE, &readfds, NULL, NULL, NULL);
@@ -1023,10 +1023,10 @@ void poll_for_update() {
 			sway_log(L_ERROR, "polling failed: %d", errno);
 		}
 
-		if (FD_ISSET(ipc_listen_socketfd, &readfds)) {
+		if (FD_ISSET(ipc_event_socketfd, &readfds)) {
 			sway_log(L_DEBUG, "Got workspace update.");
 			uint32_t len;
-			char *buf = ipc_recv_response(ipc_listen_socketfd, &len);
+			char *buf = ipc_recv_response(ipc_event_socketfd, &len);
 			free(buf);
 			ipc_update_workspaces();
 			dirty = true;
@@ -1131,7 +1131,7 @@ int main(int argc, char **argv) {
 		}
 	}
 	ipc_socketfd = ipc_open_socket(socket_path);
-	ipc_listen_socketfd = ipc_open_socket(socket_path);
+	ipc_event_socketfd = ipc_open_socket(socket_path);
 
 
 	if (argc == optind) {


### PR DESCRIPTION
This includes some changes/additions to the IPC server/client which makes it use custom IPC_EVENT_* types for events as required by the i3 IPC spec, and also includes the type in the response from `ipc_recv_response` such that the type can be checked at the client side.

(This is needed before I can implement the binding mode indicator)