### PR TITLE
Fix overwriting current pressed keys.

### DIFF
--- a/sway/input_state.c
+++ b/sway/input_state.c
@@ -36,8 +36,8 @@ static uint8_t find_key(uint32_t key_sym, uint32_t key_code, bool update) {
 		if (0 == key_sym && 0 == key_code && key_state_array[i].key_sym == 0) {
 			break;
 		}
-		if (key_state_array[i].key_sym == key_sym
-			|| key_state_array[i].alt_sym == key_sym) {
+		if (key_sym != 0 && (key_state_array[i].key_sym == key_sym
+			|| key_state_array[i].alt_sym == key_sym)) {
 			break;
 		}
 		if (update && key_state_array[i].key_code == key_code) {


### PR DESCRIPTION
This fixes a bug where the key at index 0 in the `key_state_array` would
be overwritten by the next pressed key. This broke any bindings
consisting of multiple non-mod keys like: `$mod+a+b`.