### PR TITLE
Return focus to fullscreen view

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -1464,7 +1464,7 @@ static struct cmd_results *cmd_fullscreen(int argc, char **argv) {
 	wlc_view_set_state(container->handle, WLC_BIT_FULLSCREEN, !current);
 	// Resize workspace if going from  fullscreen -> notfullscreen
 	// otherwise just resize container
-	if (current) {
+	if (!current) {
 		arrange_windows(workspace, -1, -1);
 		workspace->fullscreen = container;
 	} else {

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -220,6 +220,10 @@ static bool handle_view_created(wlc_handle handle) {
 			// refocus in-between command lists
 			set_focused_container(newview);
 		}
+		swayc_t *workspace = swayc_parent_by_type(focused, C_WORKSPACE);
+		if (workspace && workspace->fullscreen) {
+			set_focused_container(workspace->fullscreen);
+		}
 	} else {
 		swayc_t *output = swayc_parent_by_type(focused, C_OUTPUT);
 		wlc_handle *h = malloc(sizeof(wlc_handle));


### PR DESCRIPTION
This fixes https://github.com/SirCmpwn/sway/issues/431 by returning
focus to the fullscreen view. Also it fixes the issue with the
fullscreen view pointer not being set which did my head in