### PR TITLE
Clearer order of locations searched for config file.

### DIFF
--- a/sway/sway.1.txt
+++ b/sway/sway.1.txt
@@ -68,10 +68,10 @@ Configuration
 If _-c_ is not specified, sway will look in several locations for your config
 file. The suggested location for your config file is ~/.config/sway/config.
 ~/.sway/config will also work, and the rest of the usual XDG config locations
-are supported. At last, sway looks for a config file in a fallback directory,
-which is /etc/sway/ by default. A standard configuration file is installed at
-this location. If no sway config is found, sway will attempt to load an i3
-config from all the config locations i3 supports. If still nothing is found,
+are supported.  If no sway config is found, sway will attempt to load an i3
+config from all the config locations i3 supports.  At last, sway looks for a
+config file in a fallback directory, which is /etc/sway/ by default. A standard
+configuration file is installed at this location.  If still nothing is found,
 you will receive an error.
 
 For information on the config file format, see **sway**(5).


### PR DESCRIPTION
The i3wm config locations are visited _before_ using the fallback
configs. The man page was confusing - it talked about the fallback
configs first, but also said they are looked at "at last". By changing
the order of the sentences, this should be clearer.