### PR TITLE
Implement IPC binding event (keyboard)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ option(enable-swaybar "Enables the swaybar utility" YES)
 option(enable-swaygrab "Enables the swaygrab utility" YES)
 option(enable-swaymsg "Enables the swaymsg utility" YES)
 option(enable-gdk-pixbuf "Use Pixbuf to support more image formats" YES)
+option(enable-binding-event "Enables binding event subscription" YES)
 
 find_package(JsonC REQUIRED)
 find_package(PCRE REQUIRED)
@@ -111,6 +112,9 @@ if(enable-swaylock)
 	else()
 		message(WARNING "Not building swaylock - cairo, pango, and PAM are required.")
 	endif()
+endif()
+if(enable-binding-event)
+	add_definitions(-DSWAY_BINDING_EVENT=1)
 endif()
 
 install(

--- a/common/util.c
+++ b/common/util.c
@@ -51,3 +51,17 @@ const char *get_modifier_name_by_mask(uint32_t modifier) {
 
 	return NULL;
 }
+
+int get_modifier_names(const char **names, uint32_t modifier_masks) {
+	int length = 0;
+	int i;
+	for (i = 0; i < (int)(sizeof(modifiers) / sizeof(struct modifier_key)); ++i) {
+		if ((modifier_masks & modifiers[i].mod) != 0) {
+			names[length] = modifiers[i].name;
+			++length;
+			modifier_masks ^= modifiers[i].mod;
+		}
+	}
+
+	return length;
+}

--- a/include/config.h
+++ b/include/config.h
@@ -189,6 +189,7 @@ int sway_binding_cmp(const void *a, const void *b);
 int sway_binding_cmp_qsort(const void *a, const void *b);
 int sway_binding_cmp_keys(const void *a, const void *b);
 void free_sway_binding(struct sway_binding *sb);
+struct sway_binding *sway_binding_dup(struct sway_binding *sb);
 
 int sway_mouse_binding_cmp(const void *a, const void *b);
 int sway_mouse_binding_cmp_qsort(const void *a, const void *b);

--- a/include/ipc-server.h
+++ b/include/ipc-server.h
@@ -21,6 +21,10 @@ void ipc_event_mode(const char *mode);
  * the name of that modifier.
  */
 void ipc_event_modifier(uint32_t modifier, const char *state);
+/**
+ * Send IPC keyboard binding event.
+ */
+void ipc_event_binding_keyboard(struct sway_binding *sb);
 const char *swayc_type_string(enum swayc_types type);
 
 #endif

--- a/include/util.h
+++ b/include/util.h
@@ -29,4 +29,11 @@ uint32_t get_modifier_mask_by_name(const char *name);
  */
 const char *get_modifier_name_by_mask(uint32_t modifier);
 
+/**
+ * Get an array of modifier names from modifier_masks
+ *
+ * Populates the names array and return the number of names added.
+ */
+int get_modifier_names(const char **names, uint32_t modifier_masks);
+
 #endif

--- a/sway/config.c
+++ b/sway/config.c
@@ -721,6 +721,24 @@ void free_sway_mouse_binding(struct sway_mouse_binding *binding) {
 	free(binding);
 }
 
+struct sway_binding *sway_binding_dup(struct sway_binding *sb) {
+	struct sway_binding *new_sb = malloc(sizeof(struct sway_binding));
+
+	new_sb->order = sb->order;
+	new_sb->modifiers = sb->modifiers;
+	new_sb->command = strdup(sb->command);
+
+	new_sb->keys = create_list();
+	int i;
+	for (i = 0; i < sb->keys->length; ++i) {
+		xkb_keysym_t *key = malloc(sizeof(xkb_keysym_t));
+		*key = *(xkb_keysym_t *)sb->keys->items[i];
+		list_add(new_sb->keys, key);
+	}
+
+	return new_sb;
+}
+
 struct bar_config *default_bar_config(void) {
 	struct bar_config *bar = NULL;
 	bar = malloc(sizeof(struct bar_config));

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -347,11 +347,14 @@ static bool handle_bindsym(struct sway_binding *binding) {
 	}
 
 	if (match) {
+		struct sway_binding *binding_copy = sway_binding_dup(binding);
 		struct cmd_results *res = handle_command(binding->command);
 		if (res->status != CMD_SUCCESS) {
 			sway_log(L_ERROR, "Command '%s' failed: %s", res->input, res->error);
 		}
+		ipc_event_binding_keyboard(binding_copy);
 		free_cmd_results(res);
+		free_sway_binding(binding_copy);
 		return true;
 	}
 
@@ -362,11 +365,14 @@ static bool handle_bindsym_release(struct sway_binding *binding) {
 	if (binding->keys->length == 1) {
 		xkb_keysym_t *key = binding->keys->items[0];
 		if (check_released_key(*key)) {
+			struct sway_binding *binding_copy = sway_binding_dup(binding);
 			struct cmd_results *res = handle_command(binding->command);
 			if (res->status != CMD_SUCCESS) {
 				sway_log(L_ERROR, "Command '%s' failed: %s", res->input, res->error);
 			}
+			ipc_event_binding_keyboard(binding_copy);
 			free_cmd_results(res);
+			free_sway_binding(binding_copy);
 			return true;
 		}
 	}

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -298,6 +298,8 @@ void ipc_client_handle_command(struct ipc_client *client) {
 				client->subscribed_events |= IPC_EVENT_MODE;
 			} else if (strcmp(event_type, "modifier") == 0) {
 				client->subscribed_events |= IPC_EVENT_MODIFIER;
+			} else if (strcmp(event_type, "binding") == 0) {
+				client->subscribed_events |= IPC_EVENT_BINDING;
 			} else {
 				ipc_send_reply(client, "{\"success\": false}", 18);
 				ipc_client_disconnect(client);
@@ -632,4 +634,49 @@ void ipc_event_modifier(uint32_t modifier, const char *state) {
 	ipc_send_event(json_string, IPC_EVENT_MODIFIER);
 
 	json_object_put(obj); // free
+}
+
+static void ipc_event_binding(json_object *sb_obj) {
+	json_object *obj = json_object_new_object();
+	json_object_object_add(obj, "change", json_object_new_string("run"));
+	json_object_object_add(obj, "binding", sb_obj);
+
+	const char *json_string = json_object_to_json_string(obj);
+	ipc_send_event(json_string, IPC_EVENT_BINDING);
+
+	json_object_put(obj); // free
+}
+
+void ipc_event_binding_keyboard(struct sway_binding *sb) {
+	json_object *sb_obj = json_object_new_object();
+	json_object_object_add(sb_obj, "command", json_object_new_string(sb->command));
+
+	const char *names[10];
+
+	int len = get_modifier_names(names, sb->modifiers);
+	int i;
+	json_object *modifiers = json_object_new_array();
+	for (i = 0; i < len; ++i) {
+		json_object_array_add(modifiers, json_object_new_string(names[i]));
+	}
+
+	json_object_object_add(sb_obj, "event_state_mask", modifiers);
+
+	// TODO: implement bindcode
+	json_object_object_add(sb_obj, "input_code", json_object_new_int(0));
+
+	json_object *symbols = json_object_new_array();
+	uint32_t keysym;
+	char buffer[64];
+	for (i = 0; i < sb->keys->length; ++i) {
+		keysym = *(uint32_t *)sb->keys->items[i];
+		if (xkb_keysym_get_name(keysym, buffer, 64) > 0) {
+			json_object_array_add(symbols, json_object_new_string(buffer));
+		}
+	}
+
+	json_object_object_add(sb_obj, "symbols", symbols);
+	json_object_object_add(sb_obj, "input_type", json_object_new_string("keyboard"));
+
+	ipc_event_binding(sb_obj);
 }

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -298,8 +298,10 @@ void ipc_client_handle_command(struct ipc_client *client) {
 				client->subscribed_events |= IPC_EVENT_MODE;
 			} else if (strcmp(event_type, "modifier") == 0) {
 				client->subscribed_events |= IPC_EVENT_MODIFIER;
+#if SWAY_BINDING_EVENT
 			} else if (strcmp(event_type, "binding") == 0) {
 				client->subscribed_events |= IPC_EVENT_BINDING;
+#endif
 			} else {
 				ipc_send_reply(client, "{\"success\": false}", 18);
 				ipc_client_disconnect(client);
@@ -636,6 +638,7 @@ void ipc_event_modifier(uint32_t modifier, const char *state) {
 	json_object_put(obj); // free
 }
 
+#if SWAY_BINDING_EVENT
 static void ipc_event_binding(json_object *sb_obj) {
 	json_object *obj = json_object_new_object();
 	json_object_object_add(obj, "change", json_object_new_string("run"));
@@ -646,8 +649,10 @@ static void ipc_event_binding(json_object *sb_obj) {
 
 	json_object_put(obj); // free
 }
+#endif
 
 void ipc_event_binding_keyboard(struct sway_binding *sb) {
+#if SWAY_BINDING_EVENT
 	json_object *sb_obj = json_object_new_object();
 	json_object_object_add(sb_obj, "command", json_object_new_string(sb->command));
 
@@ -679,4 +684,5 @@ void ipc_event_binding_keyboard(struct sway_binding *sb) {
 	json_object_object_add(sb_obj, "input_type", json_object_new_string("keyboard"));
 
 	ipc_event_binding(sb_obj);
+#endif
 }


### PR DESCRIPTION
This implements the IPC binding event for keyboard bindings.  It is
slightly different from the i3 implementation [1] since sway supports
more than one non-modifier key in a binding. Thus the json interface has
been changed from:

    {
      ...
      "symbol": "t",
      ...
    }

to:

    {
      ...
      "symbols": [ "t" ],
      ...
    }

(Also note that `input_code` is not implemented because it depends on `bindcode`)

[1] http://i3wm.org/docs/ipc.html#_binding_event