### PR TITLE
Implement bindsym --release

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -22,6 +22,7 @@ struct sway_variable {
  */
 struct sway_binding {
 	int order;
+	bool release;
 	list_t *keys;
 	uint32_t modifiers;
 	char *command;

--- a/include/input_state.h
+++ b/include/input_state.h
@@ -9,6 +9,9 @@
 // returns true if key has been pressed, otherwise false
 bool check_key(uint32_t key_sym, uint32_t key_code);
 
+// returns true if key_sym matches latest released key.
+bool check_released_key(uint32_t key_sym);
+
 // sets a key as pressed
 void press_key(uint32_t key_sym, uint32_t key_code);
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -163,9 +163,25 @@ static struct cmd_results *cmd_bindsym(int argc, char **argv) {
 		return cmd_results_new(CMD_FAILURE, "bindsym", "Can only be used in config file.");
 	}
 
+
 	struct sway_binding *binding = malloc(sizeof(struct sway_binding));
 	binding->keys = create_list();
 	binding->modifiers = 0;
+	binding->release = false;
+
+	// Handle --release
+	if (strcmp("--release", argv[0]) == 0) {
+		if (argc >= 3) {
+			binding->release = true;
+			argv++;
+			argc--;
+		} else {
+			return cmd_results_new(CMD_FAILURE, "bindsym",
+				"Invalid bindsym command"
+				"(expected more than 2 arguments, got %d)", argc);
+		}
+	}
+
 	binding->command = join_args(argv + 1, argc - 1);
 
 	list_t *split = split_string(argv[0], "+");

--- a/sway/input_state.c
+++ b/sway/input_state.c
@@ -22,6 +22,8 @@ struct key_state {
 
 static struct key_state key_state_array[KEY_STATE_MAX_LENGTH];
 
+static struct key_state last_released;
+
 static uint32_t modifiers_state;
 
 void input_init(void) {
@@ -30,6 +32,9 @@ void input_init(void) {
 		struct key_state none = { 0, 0, 0 };
 		key_state_array[i] = none;
 	}
+
+	struct key_state none = { 0, 0, 0 };
+	last_released = none;
 
 	modifiers_state = 0;
 }
@@ -76,6 +81,12 @@ bool check_key(uint32_t key_sym, uint32_t key_code) {
 	return find_key(key_sym, key_code, false) < KEY_STATE_MAX_LENGTH;
 }
 
+bool check_released_key(uint32_t key_sym) {
+	return (key_sym != 0
+		&& (last_released.key_sym == key_sym
+		|| last_released.alt_sym == key_sym));
+}
+
 void press_key(uint32_t key_sym, uint32_t key_code) {
 	if (key_code == 0) {
 		return;
@@ -94,6 +105,9 @@ void press_key(uint32_t key_sym, uint32_t key_code) {
 void release_key(uint32_t key_sym, uint32_t key_code) {
 	uint8_t index = find_key(key_sym, key_code, true);
 	if (index < KEY_STATE_MAX_LENGTH) {
+		last_released.key_sym = key_state_array[index].key_sym;
+		last_released.alt_sym = key_state_array[index].alt_sym;
+		last_released.key_code = key_state_array[index].key_code;
 		struct key_state none = { 0, 0, 0 };
 		key_state_array[index] = none;
 	}


### PR DESCRIPTION
This is a "simple" version of --release (same as i3) that only supports
a binding that contain one normal key. e.g.:

    bindsym --release $mod+x exec somthing-fun

I didn't bother implementing it for a combination like `$mod+x+z` since
it is a bit tricky to get right and also a bit weird to actually do on a
keyboard.