### PR TITLE
Swaybar cleanup

### DIFF
--- a/include/ipc-client.h
+++ b/include/ipc-client.h
@@ -22,6 +22,11 @@ char *get_socketpath(void);
  */
 int ipc_open_socket(const char *socket_path);
 /**
+ * Issues a single IPC command without waiting for a response.
+ * Useful if events are sent on the same socket.
+ */
+void ipc_send_command(int socketfd, uint32_t type, const char *payload, uint32_t len);
+/**
  * Issues a single IPC command and returns the buffer. len will be updated with
  * the length of the buffer returned from sway.
  */


### PR DESCRIPTION
These commits clean up some things that annoy me when I read the swaybar code.
* The first one splits the spawning of the status command in a new functions
* The other two change the way swaybar sends commands to sway. Now it only uses a single socket to communicate with sway and treat responses to ipc commands the same as events.