### PR TITLE
Add support for bincode command

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -23,6 +23,7 @@ struct sway_variable {
 struct sway_binding {
 	int order;
 	bool release;
+	bool bindcode;
 	list_t *keys;
 	uint32_t modifiers;
 	char *command;

--- a/sway/config.c
+++ b/sway/config.c
@@ -652,15 +652,27 @@ int sway_binding_cmp_keys(const void *a, const void *b) {
 	} else if (binda->modifiers < bindb->modifiers) {
 		return -1;
 	}
+	struct wlc_modifiers no_mods = { 0, 0 };
 	for (int i = 0; i < binda->keys->length; i++) {
-		xkb_keysym_t *ka = binda->keys->items[i],
-				*kb = bindb->keys->items[i];
-		if (*ka > *kb) {
+		xkb_keysym_t ka = *(xkb_keysym_t *)binda->keys->items[i],
+			kb = *(xkb_keysym_t *)bindb->keys->items[i];
+		if (binda->bindcode) {
+			uint32_t *keycode = binda->keys->items[i];
+			ka = wlc_keyboard_get_keysym_for_key(*keycode, &no_mods);
+		}
+
+		if (bindb->bindcode) {
+			uint32_t *keycode = bindb->keys->items[i];
+			kb = wlc_keyboard_get_keysym_for_key(*keycode, &no_mods);
+		}
+
+		if (ka > kb) {
 			return 1;
-		} else if (*ka < *kb) {
+		} else if (ka < kb) {
 			return -1;
 		}
 	}
+
 	return 0;
 }
 

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -363,9 +363,16 @@ static bool handle_bindsym(struct sway_binding *binding) {
 	bool match = false;
 	int i;
 	for (i = 0; i < binding->keys->length; ++i) {
-		xkb_keysym_t *key = binding->keys->items[i];
-		if ((match = check_key(*key, 0)) == false) {
-			break;
+		if (binding->bindcode) {
+			xkb_keycode_t *key = binding->keys->items[i];
+			if ((match = check_key(0, *key)) == false) {
+				break;
+			}
+		} else {
+			xkb_keysym_t *key = binding->keys->items[i];
+			if ((match = check_key(*key, 0)) == false) {
+				break;
+			}
 		}
 	}
 

--- a/sway/input_state.c
+++ b/sway/input_state.c
@@ -73,6 +73,9 @@ static uint8_t find_key(uint32_t key_sym, uint32_t key_code, bool update) {
 			key_state_array[i].alt_sym = key_sym;
 			break;
 		}
+		if (key_sym == 0 && key_code != 0 && key_state_array[i].key_code == key_code) {
+			break;
+		}
 	}
 	return i;
 }


### PR DESCRIPTION
If a bindsym and bincode maps to the same combination, the last one will
overwrite any previous mappings.