### PR TITLE
Add bindcode to binding events.

### DIFF
--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -667,19 +667,27 @@ void ipc_event_binding_keyboard(struct sway_binding *sb) {
 
 	json_object_object_add(sb_obj, "event_state_mask", modifiers);
 
-	// TODO: implement bindcode
-	json_object_object_add(sb_obj, "input_code", json_object_new_int(0));
-
+	json_object *input_codes = json_object_new_array();
 	json_object *symbols = json_object_new_array();
-	uint32_t keysym;
-	char buffer[64];
-	for (i = 0; i < sb->keys->length; ++i) {
-		keysym = *(uint32_t *)sb->keys->items[i];
-		if (xkb_keysym_get_name(keysym, buffer, 64) > 0) {
-			json_object_array_add(symbols, json_object_new_string(buffer));
+
+	if (sb->bindcode) { // bindcode: populate input_codes
+		uint32_t keycode;
+		for (i = 0; i < sb->keys->length; ++i) {
+			keycode = *(uint32_t *)sb->keys->items[i];
+			json_object_array_add(input_codes, json_object_new_int(keycode));
+		}
+	} else { // bindsym: populate symbols
+		uint32_t keysym;
+		char buffer[64];
+		for (i = 0; i < sb->keys->length; ++i) {
+			keysym = *(uint32_t *)sb->keys->items[i];
+			if (xkb_keysym_get_name(keysym, buffer, 64) > 0) {
+				json_object_array_add(symbols, json_object_new_string(buffer));
+			}
 		}
 	}
 
+	json_object_object_add(sb_obj, "input_codes", input_codes);
 	json_object_object_add(sb_obj, "symbols", symbols);
 	json_object_object_add(sb_obj, "input_type", json_object_new_string("keyboard"));
 

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -668,13 +668,18 @@ void ipc_event_binding_keyboard(struct sway_binding *sb) {
 	json_object_object_add(sb_obj, "event_state_mask", modifiers);
 
 	json_object *input_codes = json_object_new_array();
+	int input_code = 0;
 	json_object *symbols = json_object_new_array();
+	json_object *symbol = NULL;
 
 	if (sb->bindcode) { // bindcode: populate input_codes
 		uint32_t keycode;
 		for (i = 0; i < sb->keys->length; ++i) {
 			keycode = *(uint32_t *)sb->keys->items[i];
 			json_object_array_add(input_codes, json_object_new_int(keycode));
+			if (i == 0) {
+				input_code = keycode;
+			}
 		}
 	} else { // bindsym: populate symbols
 		uint32_t keysym;
@@ -682,13 +687,19 @@ void ipc_event_binding_keyboard(struct sway_binding *sb) {
 		for (i = 0; i < sb->keys->length; ++i) {
 			keysym = *(uint32_t *)sb->keys->items[i];
 			if (xkb_keysym_get_name(keysym, buffer, 64) > 0) {
-				json_object_array_add(symbols, json_object_new_string(buffer));
+				json_object *str = json_object_new_string(buffer);
+				json_object_array_add(symbols, str);
+				if (i == 0) {
+					symbol = str;
+				}
 			}
 		}
 	}
 
 	json_object_object_add(sb_obj, "input_codes", input_codes);
+	json_object_object_add(sb_obj, "input_code", json_object_new_int(input_code));
 	json_object_object_add(sb_obj, "symbols", symbols);
+	json_object_object_add(sb_obj, "symbol", symbol);
 	json_object_object_add(sb_obj, "input_type", json_object_new_string("keyboard"));
 
 	ipc_event_binding(sb_obj);


### PR DESCRIPTION
This adds the field `input_codes` to binding events.

Again, unlike i3, sway can handle multiple non-modifier keys, so `input_codes` is an array compared to the i3 version where it's a single value field, `input_code`.