### PR TITLE
Fix issue #455

### DIFF
--- a/sway/CMakeLists.txt
+++ b/sway/CMakeLists.txt
@@ -26,6 +26,10 @@ add_executable(sway
 	workspace.c
 )
 
+add_definitions(
+	-DSYSCONFDIR="${CMAKE_INSTALL_FULL_SYSCONFDIR}"
+)
+
 target_link_libraries(sway
 	sway-common
 	sway-protocols

--- a/sway/config.c
+++ b/sway/config.c
@@ -197,8 +197,8 @@ static char *get_config_path(void) {
 		"$XDG_CONFIG_HOME/sway/config",
 		"$HOME/.i3/config",
 		"$XDG_CONFIG_HOME/i3/config",
-		"${CMAKE_INSTALL_FULL_SYSCONFDIR}/sway/config",
-		"${CMAKE_INSTALL_FULL_SYSCONFDIR}/i3/config",
+		SYSCONFDIR "/sway/config",
+		SYSCONFDIR "/i3/config",
 	};
 
 	if (!getenv("XDG_CONFIG_HOME")) {


### PR DESCRIPTION
CMAKE_INSTALL_FULL_SYSCONFIG is not actually passed to
the C preprocessor. I remember it working, so I must have
messed up somewhere last time I touched this.

This is fixed by manually passing its value to the C preprocessor
through the SYSCONFDIR definition