### PR TITLE
Fix rendering of view when moving to new workspace

### DIFF
--- a/sway/container.c
+++ b/sway/container.c
@@ -721,9 +721,7 @@ void update_visibility_output(swayc_t *container, wlc_handle output) {
 	if (container->type == C_VIEW) {
 		wlc_view_set_output(container->handle, output);
 		wlc_view_set_mask(container->handle, container->visible ? VISIBLE : 0);
-		if (container->visible) {
-			wlc_view_bring_to_front(container->handle);
-		} else {
+		if (!container->visible) {
 			wlc_view_send_to_back(container->handle);
 		}
 	}


### PR DESCRIPTION
This is a possible fix for #384.

To be honest I don't fully understand why this bug is happening, but I
have narrowed it down to the view stack in wlc and how sway orders views
in very specific situations (those described in #384).

Anyway this should fix the problem by eliminating the call to
`wlc_view_bring_to_front` which isn't really needed anyway since sending
all invisible views to the back is the same as bringing all visible
views to the front (rotating the view stack).

It would be nice if someone could test this patch for a bit and report back if any issues are found. Basically, if a view doesn't show up when it should, or does when it shouldn't then it's a bug caused by this.