### PR TITLE
swaymsg - pretty mode and workaround to remove escaped forward slashes

### DIFF
--- a/swaymsg/CMakeLists.txt
+++ b/swaymsg/CMakeLists.txt
@@ -1,9 +1,14 @@
+include_directories(
+	${JSONC_INCLUDE_DIRS}
+)
+
 add_executable(swaymsg
 	main.c
 )
 
 target_link_libraries(swaymsg
 	sway-common
+	${JSONC_LIBRARIES}
 	)
 
 install(

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -6,6 +6,8 @@
 #include <sys/un.h>
 #include <sys/socket.h>
 #include <unistd.h>
+#include <json-c/json.h>
+#include <json-c/printbuf.h>
 #include "stringop.h"
 #include "ipc-client.h"
 #include "readline.h"
@@ -17,6 +19,7 @@ void sway_terminate(void) {
 
 int main(int argc, char **argv) {
 	static int quiet = 0;
+	static int pretty = 0;
 	char *socket_path = NULL;
 	char *cmdtype = NULL;
 
@@ -35,6 +38,7 @@ int main(int argc, char **argv) {
 		"Usage: swaymsg [options] [message]\n"
 		"\n"
 		"  -h, --help             Show help message and quit.\n"
+		"  -p, --pretty           Decode the JSON response and format it.\n"
 		"  -q, --quiet            Be quiet.\n"
 		"  -v, --version          Show the version number and quit.\n"
 		"  -s, --socket <socket>  Use the specified socket.\n"
@@ -43,13 +47,16 @@ int main(int argc, char **argv) {
 	int c;
 	while (1) {
 		int option_index = 0;
-		c = getopt_long(argc, argv, "hqvs:t:", long_options, &option_index);
+		c = getopt_long(argc, argv, "hpqvs:t:", long_options, &option_index);
 		if (c == -1) {
 			break;
 		}
 		switch (c) {
 		case 'q': // Quiet
 			quiet = 1;
+			break;
+		case 'p':
+			pretty = 1;
 			break;
 		case 's': // Socket
 			socket_path = strdup(optarg);
@@ -112,7 +119,20 @@ int main(int argc, char **argv) {
 	int socketfd = ipc_open_socket(socket_path);
 	uint32_t len = strlen(command);
 	char *resp = ipc_single_command(socketfd, type, command, &len);
-	if (!quiet) {
+
+	if (pretty) {
+		struct printbuf *pb;
+		if(!(pb = printbuf_new())) {
+			return -1;
+		}
+    	printbuf_memappend(pb, resp, sizeof(char)*strlen(resp));
+		struct json_object *obj = json_tokener_parse(pb->buf);
+
+		const char *resp_json = json_object_to_json_string_ext(obj, JSON_C_TO_STRING_PRETTY);
+		printf("%s\n", resp_json);
+		free((char*)resp_json);
+		printbuf_free(pb);
+	} else if (!quiet) {
 		printf("%s\n", resp);
 	}
 	close(socketfd);

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -144,7 +144,6 @@ int main(int argc, char **argv) {
 		struct json_object *obj = json_tokener_parse(pb->buf);
 
 		const char *resp_json = json_object_to_json_string_ext(obj, JSON_C_TO_STRING_PRETTY);
-
 		// Temporary workaround until json-c has a new release
 		// at which point json_object_to_json_string_ext has a flag that
 		// prevents the need for the following line.
@@ -154,6 +153,10 @@ int main(int argc, char **argv) {
 		free((char*)resp_json);
 		printbuf_free(pb);
 	} else if (!quiet) {
+		// Temporary workaround until json-c has a new release
+		// at which point json_object_to_json_string_ext has a flag that
+		// prevents the need for the following line.
+		scrub_escaped_forward_slash(resp);
 		printf("%s\n", resp);
 	}
 	close(socketfd);


### PR DESCRIPTION
Commit 1:

Introduce `--pretty` / `-p` flag. This uses json c to pretty print the json. Eventually this can be updated with a new json-c flag to not escape slashes.

It's off by default, which I think is correct. I think it's intentional that swaymsg was outputting valid json and don't want to break that assumption.

Commit 2:

Adds another function and calls it to remove the escaped forward slashes.

Questions:

Should the forward slashes be unescaped even in not-pretty mode? I think maybe so. It should still be valid JSON and will be less confusing to users that might not know to call it with `-p`. I'm going to update the commit to do this actually.