### PR TITLE
Replace deprecated function wlc_output_get_pixels.

### DIFF
--- a/include/ipc-server.h
+++ b/include/ipc-server.h
@@ -1,6 +1,8 @@
 #ifndef _SWAY_IPC_SERVER_H
 #define _SWAY_IPC_SERVER_H
 
+#include <wlc/wlc.h>
+
 #include "container.h"
 #include "config.h"
 #include "ipc.h"
@@ -26,5 +28,10 @@ void ipc_event_modifier(uint32_t modifier, const char *state);
  */
 void ipc_event_binding_keyboard(struct sway_binding *sb);
 const char *swayc_type_string(enum swayc_types type);
+
+/**
+ * Send pixel data to registered clients.
+ */
+void ipc_get_pixels(wlc_handle output);
 
 #endif

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -150,6 +150,10 @@ static void handle_output_pre_render(wlc_handle output) {
 	}
 }
 
+static void handle_output_post_render(wlc_handle output) {
+	ipc_get_pixels(output);
+}
+
 static void handle_output_resolution_change(wlc_handle output, const struct wlc_size *from, const struct wlc_size *to) {
 	sway_log(L_DEBUG, "Output %u resolution changed to %d x %d", (unsigned int)output, to->w, to->h);
 	swayc_t *c = swayc_by_handle(output);
@@ -675,7 +679,8 @@ struct wlc_interface interface = {
 		.resolution = handle_output_resolution_change,
 		.focus = handle_output_focused,
 		.render = {
-			.pre = handle_output_pre_render
+			.pre = handle_output_pre_render,
+			.post = handle_output_post_render
 		}
 	},
 	.view = {


### PR DESCRIPTION
This makes IPC GET_PIXELS use the new `wlc_pixels_read` call instead of the deprecated `wlc_output_get_pixels`.

The old version worked by passing a callback function to wlc which would grab the pixels and send them to the IPC client.
The new version works by maintaining a list of clients who have requested the pixels of some output and then grap and send the pixels in the output_post_render hook of the `wlc_interface`.