### PR TITLE
Fix segfault when trying to use sway as IPC without a sway instance

### DIFF
--- a/sway/main.c
+++ b/sway/main.c
@@ -148,6 +148,9 @@ int main(int argc, char **argv) {
 	}
 
 	if (optind < argc) { // Behave as IPC client
+		if(optind != 1) {
+			sway_abort("Don't use options with the IPC client");
+		}
 		if (getuid() != geteuid() || getgid() != getegid()) {
 			if (setgid(getgid()) != 0 || setuid(getuid()) != 0) {
 				sway_abort("Unable to drop root");

--- a/sway/main.c
+++ b/sway/main.c
@@ -25,6 +25,7 @@ static bool terminate_request = false;
 void sway_terminate(void) {
 	terminate_request = true;
 	wlc_terminate();
+	exit(EXIT_FAILURE);
 }
 
 void sig_handler(int signal) {

--- a/sway/main.c
+++ b/sway/main.c
@@ -103,7 +103,7 @@ int main(int argc, char **argv) {
 	int c;
 	while (1) {
 		int option_index = 0;
-		c = getopt_long(argc, argv, "hCdvVpc:", long_options, &option_index);
+		c = getopt_long(argc, argv, "hCdvVc:", long_options, &option_index);
 		if (c == -1) {
 			break;
 		}

--- a/sway/sway.5.txt
+++ b/sway/sway.5.txt
@@ -16,7 +16,7 @@ startup. These commands usually consist of setting your preferences and setting
 key bindings. An example config is likely present in /etc/sway/config for you to
 check out.
 
-All of these commands may be issued at runtime through **sway-msg**(1).
+All of these commands may be issued at runtime through **swaymsg**(1).
 
 Commands
 --------


### PR DESCRIPTION
Ultimately, this is caused by the `sway_abort` that does not exit in this case.
It calls `wlc_terminate`, which itself does not exit if there is not current display.

Added some very minor fix here and there while browsing through the code ; they each have their separate commit.