### PR TITLE
Fix assigning workspaces to outputs

### DIFF
--- a/include/workspace.h
+++ b/include/workspace.h
@@ -7,7 +7,7 @@
 
 extern char *prev_workspace_name;
 
-char *workspace_next_name(void);
+char *workspace_next_name(const char *output_name);
 swayc_t *workspace_create(const char*);
 swayc_t *workspace_by_name(const char*);
 swayc_t *workspace_by_number(const char*);

--- a/sway/container.c
+++ b/sway/container.c
@@ -143,7 +143,7 @@ swayc_t *new_output(wlc_handle handle) {
 		}
 	}
 	if (!ws_name) {
-		ws_name = workspace_next_name();
+		ws_name = workspace_next_name(output->name);
 	}
 
 	// create and initilize default workspace

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -364,7 +364,7 @@ void move_workspace_to(swayc_t* workspace, swayc_t* destination) {
 
 	// make sure source output has a workspace
 	if (src_op->children->length == 0) {
-		char *ws_name = workspace_next_name();
+		char *ws_name = workspace_next_name(src_op->name);
 		swayc_t *ws = new_workspace(src_op, ws_name);
 		ws->is_focused = true;
 		free(ws_name);


### PR DESCRIPTION
It's possible to assign workspaces to certain outputs using the command:

    workspace <name> output <output>

However, this did not work in some cases where the workspace was
assigned before the given output was made available to sway.

This patch fixes those cases.