### PR TITLE
Render outputs as soon as wlc is ready

### DIFF
--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -680,6 +680,13 @@ static void handle_wlc_ready(void) {
 		free(line);
 		list_del(config->cmd_queue, 0);
 	}
+
+	// render all outputs
+	int i;
+	for (i = 0; i < root_container.children->length; ++i) {
+		swayc_t *output = root_container.children->items[i];
+		wlc_output_schedule_render(output->handle);
+	}
 }
 
 struct wlc_interface interface = {


### PR DESCRIPTION
This makes sure that the outputs are rendered when sway is launched, so
the user doesn't have to move the cursor before the background and bar
gets rendered on screen.

Fixes #509