### PR TITLE
Schedule render when adding bg and panel

### DIFF
--- a/sway/extensions.c
+++ b/sway/extensions.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <wlc/wlc.h>
 #include <wlc/wlc-wayland.h>
+#include <wlc/wlc-render.h>
 #include "wayland-desktop-shell-server-protocol.h"
 #include "wayland-swaylock-server-protocol.h"
 #include "layout.h"
@@ -77,6 +78,7 @@ static void set_background(struct wl_client *client, struct wl_resource *resourc
 	config->wl_surface_res = surface;
 	list_add(desktop_shell.backgrounds, config);
 	wl_resource_set_destructor(surface, background_surface_destructor);
+	wlc_output_schedule_render(config->output);
 }
 
 static void set_panel(struct wl_client *client, struct wl_resource *resource,
@@ -93,6 +95,7 @@ static void set_panel(struct wl_client *client, struct wl_resource *resource,
 	wl_resource_set_destructor(surface, panel_surface_destructor);
 	desktop_shell.panel_size = *wlc_surface_get_size(config->surface);
 	arrange_windows(&root_container, -1, -1);
+	wlc_output_schedule_render(config->output);
 }
 
 static void desktop_set_lock_surface(struct wl_client *client, struct wl_resource *resource, struct wl_resource *surface) {

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -680,13 +680,6 @@ static void handle_wlc_ready(void) {
 		free(line);
 		list_del(config->cmd_queue, 0);
 	}
-
-	// render all outputs
-	int i;
-	for (i = 0; i < root_container.children->length; ++i) {
-		swayc_t *output = root_container.children->items[i];
-		wlc_output_schedule_render(output->handle);
-	}
 }
 
 struct wlc_interface interface = {


### PR DESCRIPTION
This should be a real fix for #509

This schedules a render when a background or panel is added to sway
through the desktop shell interface, that makes sure the render isn't
scheduled before the bg or panel is ready and you don't end up with a
black screen until the cursor is moved.