### PR TITLE
Remove unused panel_size (and fix rearrange)

### DIFF
--- a/include/extensions.h
+++ b/include/extensions.h
@@ -28,7 +28,6 @@ struct desktop_shell_state {
         list_t *panels;
         list_t *lock_surfaces;
         bool is_locked;
-        struct wlc_size panel_size;
 };
 
 struct swaylock_state {

--- a/sway/extensions.c
+++ b/sway/extensions.c
@@ -93,7 +93,6 @@ static void set_panel(struct wl_client *client, struct wl_resource *resource,
 	config->surface = wlc_resource_from_wl_surface_resource(surface);
 	config->wl_surface_res = surface;
 	wl_resource_set_destructor(surface, panel_surface_destructor);
-	desktop_shell.panel_size = *wlc_surface_get_size(config->surface);
 	arrange_windows(&root_container, -1, -1);
 	wlc_output_schedule_render(config->output);
 }

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -141,10 +141,6 @@ static void handle_output_pre_render(wlc_handle output) {
 				break;
 			}
 			wlc_surface_render(config->surface, &geo);
-			if (size.w != desktop_shell.panel_size.w || size.h != desktop_shell.panel_size.h) {
-				desktop_shell.panel_size = size;
-				arrange_windows(&root_container, -1, -1);
-			}
 			break;
 		}
 	}


### PR DESCRIPTION
desktop_shell.panel_size was only used to determine if sway should
rearrange the output when rendering the panel in the output_pre_render
hook.
This is not needed since the output will have been arranged at
that point.
It also caused sway to rearrange all the time when running with two
or more different monitors/resolutions because panel_size kept changing
with every output_pre_render callback.

Should fix #514 (unless there are more cases where this happen, but I don't think so)