### PR TITLE
Add config option workspace_layout

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -75,6 +75,7 @@ static sway_cmd cmd_splitv;
 static sway_cmd cmd_sticky;
 static sway_cmd cmd_workspace;
 static sway_cmd cmd_ws_auto_back_and_forth;
+static sway_cmd cmd_workspace_layout;
 
 static sway_cmd bar_cmd_binding_mode_indicator;
 static sway_cmd bar_cmd_bindsym;
@@ -1982,6 +1983,24 @@ static struct cmd_results *cmd_workspace(int argc, char **argv) {
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }
 
+static struct cmd_results *cmd_workspace_layout(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "workspace_layout", EXPECTED_EQUAL_TO, 1))) {
+		return error;
+	}
+
+	if (strcasecmp(argv[0], "default") == 0) {
+		config->default_layout = L_NONE;
+	} else if (strcasecmp(argv[0], "stacking") == 0) {
+		config->default_layout = L_STACKED;
+	} else if (strcasecmp(argv[0], "tabbed") == 0) {
+		config->default_layout = L_TABBED;
+	} else {
+		return cmd_results_new(CMD_INVALID, "workspace_layout", "Expected 'workspace_layout <default|stacking|tabbed>'");
+	}
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}
+
 static struct cmd_results *cmd_ws_auto_back_and_forth(int argc, char **argv) {
 	struct cmd_results *error = NULL;
 	if ((error = checkarg(argc, "workspace_auto_back_and_forth", EXPECTED_EQUAL_TO, 1))) {
@@ -2036,6 +2055,7 @@ static struct cmd_handler handlers[] = {
 	{ "sticky", cmd_sticky },
 	{ "workspace", cmd_workspace },
 	{ "workspace_auto_back_and_forth", cmd_ws_auto_back_and_forth },
+	{ "workspace_layout", cmd_workspace_layout },
 };
 
 static struct cmd_results *bar_cmd_binding_mode_indicator(int argc, char **argv) {

--- a/sway/sway.5.txt
+++ b/sway/sway.5.txt
@@ -15,7 +15,7 @@ A sway configuration file is a list of sway commands that are executed by sway
 on startup.  These commands usually consist of setting your preferences and
 setting key bindings. An example config is likely present in /etc/sway/config
 for you to check out.
-	
+
 Some of the commands can also or only be sent at runtime with **sway-msg**(1).
 
 Commands
@@ -207,6 +207,9 @@ or triggered at runtime.
 **workspace** <name> output <output>::
 	Specifies that the workspace named _name_ should appear on the specified
 	_output_.
+
+**workspace_layout** <default|stacking|tabbed>::
+	Specifies the start layout for new workspaces.
 
 Criteria
 --------


### PR DESCRIPTION
So I was looking through #2 and found this :)

This just adds the config parsing of `workspace_layout <default|stacking|tabbed>` we obviously need borders for the actual implementation.