### PR TITLE
Make key handling less strict

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -317,7 +317,7 @@ static struct cmd_results *cmd_bindcode(int argc, char **argv) {
 		}
 		// parse keycode
 		int keycode = (int)strtol(split->items[i], NULL, 10);
-		if (!xkb_keycode_is_legal_x11(keycode)) {
+		if (!xkb_keycode_is_legal_ext(keycode)) {
 			error = cmd_results_new(CMD_INVALID, "bindcode", "Invalid keycode '%s'", (char *)split->items[i]);
 			free_sway_binding(binding);
 			list_free(split);


### PR DESCRIPTION
Sway has been very strict when it comes to key handling. Only on an
exact match would a bindsym be triggered.

This patch makes it less strict by for instance allowing the key combo
`$mod+1+2` to act as `$mod+2` if 2 was the last pressed key and `$mod+1`
if 1 was the last pressed key.

The new key handling uses the following algorithm:

1. List of bindings sorted by number of keys in binding (already the
default)
2. Find all bindings covered by the current keyboard state and list them
by same order as in 1.
3. Select the first binding from the list where the last pressed key is
part of the binding.

Addresses #452

@SirCmpwn we discussed the situation of `$mod+Shift+s` acting as `$mod+s`, but this will actually not happen because modifiers are checked [separately from other keys](https://github.com/SirCmpwn/sway/blob/9a04f9d8d6de49b64f255e32257bba55f9656dcd/sway/handlers.c#L494), and I have not changed that behavior.