### PR TITLE
Use correct type for keycode

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -316,7 +316,7 @@ static struct cmd_results *cmd_bindcode(int argc, char **argv) {
 			continue;
 		}
 		// parse keycode
-		int keycode = (int)strtol(split->items[i], NULL, 10);
+		xkb_keycode_t keycode = (int)strtol(split->items[i], NULL, 10);
 		if (!xkb_keycode_is_legal_ext(keycode)) {
 			error = cmd_results_new(CMD_INVALID, "bindcode", "Invalid keycode '%s'", (char *)split->items[i]);
 			free_sway_binding(binding);


### PR DESCRIPTION
Use of wrong type results in warning from clang. This fixes that.