### PR TITLE
swaybar: Abort when receiving 0 bytes in IPC call

### DIFF
--- a/common/ipc-client.c
+++ b/common/ipc-client.c
@@ -47,7 +47,7 @@ struct ipc_response *ipc_recv_response(int socketfd) {
 	size_t total = 0;
 	while (total < ipc_header_size) {
 		ssize_t received = recv(socketfd, data + total, ipc_header_size - total, 0);
-		if (received < 0) {
+		if (received <= 0) {
 			sway_abort("Unable to receive IPC response");
 		}
 		total += received;


### PR DESCRIPTION
When sway crashes a swaybar process is sometimes left behind running at
100% CPU. This was caused by the swaybar trying to retrieve an IPC
response from the closed sway socket.

This patch fixes the problem by aborting when the socket has been closed
(recv return 0).

Fix #528