### PR TITLE
Gracefully exit when config is not found

### DIFF
--- a/sway/config.c
+++ b/sway/config.c
@@ -256,7 +256,7 @@ bool load_config(const char *file) {
 
 	FILE *f = fopen(path, "r");
 	if (!f) {
-		fprintf(stderr, "Unable to open %s for reading", path);
+		sway_log(L_ERROR, "Unable to open %s for reading", path);
 		free(path);
 		return false;
 	}
@@ -272,7 +272,11 @@ bool load_config(const char *file) {
 
 	update_active_bar_modifiers();
 
-	return config_load_success;
+	if (!config_load_success) {
+		sway_log(L_ERROR, "Error(s) loading config!");
+	}
+
+	return true;
 }
 
 bool read_config(FILE *file, bool is_active) {

--- a/sway/main.c
+++ b/sway/main.c
@@ -211,8 +211,9 @@ int main(int argc, char **argv) {
 	}
 
 	if (!load_config(config_path)) {
-		sway_log(L_ERROR, "Error(s) loading config!");
+		sway_terminate(EXIT_FAILURE);
 	}
+
 	if (config_path) {
 		free(config_path);
 	}


### PR DESCRIPTION
This makes sure that sway will gracefully exit if the config is not
found or sway is unable to read it.