### PR TITLE
Prevent video from overlapping logo

### DIFF
--- a/_layouts/master.html
+++ b/_layouts/master.html
@@ -12,7 +12,7 @@
             <div class="row">
                 <div class="col-md-4">
                     <h1>
-                        <img src="/assets/logo.png" alt="Sway" width="300" />
+                        <img src="/assets/logo.png" id="logo" alt="Sway" />
                     </h1>
                     <p>
                         Sway is a drop-in replacement for the <a href="http://i3wm.org/">i3

--- a/css/master.scss
+++ b/css/master.scss
@@ -31,3 +31,8 @@ hr {
 nav {
     background: black;
 }
+
+#logo {
+  max-width: 300px;
+  width: 100%;
+}


### PR DESCRIPTION
The video was overlapping the logo when the browser window wasn't wide enough. :)