### PR TITLE
Add -R option to getopt opt_string

### DIFF
--- a/swaygrab/main.c
+++ b/swaygrab/main.c
@@ -182,7 +182,7 @@ int main(int argc, char **argv) {
 	int c;
 	while (1) {
 		int option_index = 0;
-		c = getopt_long(argc, argv, "hco:vs:r", long_options, &option_index);
+		c = getopt_long(argc, argv, "hco:vs:R:r", long_options, &option_index);
 		if (c == -1) {
 			break;
 		}


### PR DESCRIPTION
This pr fixes opt_string in swaybar, so that -R will be accepted in short form.