### PR TITLE
Add cmds new_window and new_float

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -213,7 +213,9 @@ struct sway_config {
 	const char *current_config;
 
 	enum swayc_border_types border;
+	enum swayc_border_types floating_border;
 	int border_thickness;
+	int floating_border_thickness;
 	enum edge_border_types hide_edge_borders;
 
 	// border colors

--- a/sway/config.c
+++ b/sway/config.c
@@ -187,7 +187,9 @@ static void config_defaults(struct sway_config *config) {
 
 	// borders
 	config->border = B_NORMAL;
+	config->floating_border = B_NORMAL;
 	config->border_thickness = 2;
+	config->floating_border_thickness = 2;
 	config->hide_edge_borders = E_NONE;
 
 	// border colors

--- a/sway/container.c
+++ b/sway/container.c
@@ -22,11 +22,8 @@ static swayc_t *new_swayc(enum swayc_types type) {
 	c->gaps = -1;
 	c->layout = L_NONE;
 	c->type = type;
-	c->border_type = config->border;
-	c->border_thickness = config->border_thickness;
 	if (type != C_VIEW) {
 		c->children = create_list();
-		c->border_type = B_NONE;
 	}
 	return c;
 }
@@ -275,6 +272,9 @@ swayc_t *new_view(swayc_t *sibling, wlc_handle handle) {
 	view->height = 0;
 	view->desired_width = geometry.size.w;
 	view->desired_height = geometry.size.h;
+	// setup border
+	view->border_type = config->border;
+	view->border_thickness = config->border_thickness;
 
 	view->is_floating = false;
 
@@ -318,6 +318,10 @@ swayc_t *new_floating_view(wlc_handle handle) {
 
 	view->desired_width = view->width;
 	view->desired_height = view->height;
+
+	// setup border
+	view->border_type = config->floating_border;
+	view->border_thickness = config->floating_border_thickness;
 
 	view->is_floating = true;
 

--- a/sway/sway.5.txt
+++ b/sway/sway.5.txt
@@ -44,13 +44,20 @@ The following commands cannot be used directly in the configuration file.
 They are expected to be used with **bindsym** or at runtime through **swaymsg**(1).
 
 **border** <normal|pixel> [<n>]::
-	Set border style for windows. _normal_ includes a border of thickness _n_ and
-	a title bar. _pixel_ is just the border without title bar. Default is _normal_
-	with border thickness 2.
+	Set border style for focused window. _normal_ includes a border of thickness
+	_n_ and a title bar. _pixel_ is just the border without title bar. Default is
+	_normal_ with border thickness 2.
 
 **border** <none|toggle>::
-	Set border style to _none_ or _toggle_ between the available border styles:
-	_normal_, _pixel_, _none_.
+	Set border style for focused window to _none_ or _toggle_ between the
+	available border styles: _normal_, _pixel_, _none_.
+
+**new_window** <normal|none|pixel> [<n>]::
+	Set default border style for new windows.
+
+**new_float** <normal|none|pixel> [<n>]::
+	Set default border style for new floating windows. This does only apply to
+	windows that are spawned in floating mode.
 
 **exit**::
 	Exit sway and end your Wayland session.


### PR DESCRIPTION
Makes it possible to set default layout style for new windows and new
floating windows.

Close #556 

Note #559 also implements `new_window` and I don't mind rebasing on top of that if it's merged first.