### PR TITLE
Tabbed and stacked layout

### DIFF
--- a/include/border.h
+++ b/include/border.h
@@ -3,6 +3,11 @@
 #include <wlc/wlc.h>
 #include "container.h"
 
+struct border {
+	unsigned char *buffer;
+	struct wlc_geometry geometry;
+};
+
 void render_view_borders(wlc_handle view);
 void update_view_border(swayc_t *view);
 void map_update_view_border(swayc_t *view, void *data);

--- a/include/container.h
+++ b/include/container.h
@@ -56,6 +56,7 @@ struct sway_container {
 
 	enum swayc_types type;
 	enum swayc_layouts layout;
+	enum swayc_layouts prev_layout;
 
 	/**
 	 * Width and height of this container, without borders or gaps.

--- a/include/container.h
+++ b/include/container.h
@@ -240,6 +240,12 @@ bool swayc_is_parent_of(swayc_t *parent, swayc_t *child);
  * Returns true if the child is a desecendant of the parent.
  */
 bool swayc_is_child_of(swayc_t *child, swayc_t *parent);
+
+/**
+ * Returns true if view is stacked or tabbed.
+ */
+bool swayc_is_tabbed_stacked(swayc_t *view);
+
 /**
  * Returns the gap (padding) of the container.
  *

--- a/include/container.h
+++ b/include/container.h
@@ -252,11 +252,6 @@ bool swayc_is_parent_of(swayc_t *parent, swayc_t *child);
 bool swayc_is_child_of(swayc_t *child, swayc_t *parent);
 
 /**
- * Returns true if view is stacked or tabbed.
- */
-bool swayc_is_tabbed_stacked(swayc_t *view);
-
-/**
  * Returns the top most tabbed or stacked parent container. Returns NULL if
  * view is not in a tabbed/stacked layout.
  */

--- a/include/container.h
+++ b/include/container.h
@@ -2,9 +2,12 @@
 #define _SWAY_CONTAINER_H
 #include <sys/types.h>
 #include <wlc/wlc.h>
+
+#include "list.h"
+
 typedef struct sway_container swayc_t;
 
-#include "layout.h"
+extern swayc_t root_container;
 
 /**
  * Different kinds of containers.
@@ -76,6 +79,12 @@ struct sway_container {
 	double x, y;
 
 	/**
+	 * Cached geometry used to store view/container geometry when switching
+	 * between tabbed/stacked and horizontal/vertical layouts.
+	 */
+	struct wlc_geometry cached_geometry;
+
+	/**
 	 * False if this view is invisible. It could be in the scratchpad or on a
 	 * workspace that is not shown.
 	 */
@@ -120,7 +129,7 @@ struct sway_container {
 	 * If this container is a view, this may be set to the window's decoration
 	 * buffer (or NULL).
 	 */
-	unsigned char *border;
+	struct border *border;
 	enum swayc_border_types border_type;
 	struct wlc_geometry border_geometry;
 	struct wlc_geometry title_bar_geometry;
@@ -246,6 +255,12 @@ bool swayc_is_child_of(swayc_t *child, swayc_t *parent);
  * Returns true if view is stacked or tabbed.
  */
 bool swayc_is_tabbed_stacked(swayc_t *view);
+
+/**
+ * Returns the top most tabbed or stacked parent container. Returns NULL if
+ * view is not in a tabbed/stacked layout.
+ */
+swayc_t *swayc_tabbed_stacked_parent(swayc_t *view);
 
 /**
  * Returns the gap (padding) of the container.

--- a/include/layout.h
+++ b/include/layout.h
@@ -67,4 +67,9 @@ void recursive_resize(swayc_t *container, double amount, enum wlc_resize_edge ed
 void layout_log(const swayc_t *c, int depth);
 void swayc_log(log_importance_t verbosity, swayc_t *cont, const char* format, ...) __attribute__((format(printf,3,4)));
 
+/**
+ * Get default layout.
+ */
+enum swayc_layouts default_layout(swayc_t *output);
+
 #endif

--- a/include/layout.h
+++ b/include/layout.h
@@ -7,8 +7,6 @@
 #include "container.h"
 #include "focus.h"
 
-extern swayc_t root_container;
-
 extern list_t *scratchpad;
 
 extern int min_sane_w;
@@ -55,6 +53,10 @@ void move_container_to(swayc_t* container, swayc_t* destination);
 void move_workspace_to(swayc_t* workspace, swayc_t* destination);
 
 // Layout
+/**
+ * Update child container geometries when switching between layouts.
+ */
+void update_layout_geometry(swayc_t *parent, enum swayc_layouts prev_layout);
 void update_geometry(swayc_t *view);
 void arrange_windows(swayc_t *container, double width, double height);
 

--- a/sway/border.c
+++ b/sway/border.c
@@ -237,7 +237,7 @@ void update_view_border(swayc_t *view) {
 
 	swayc_t *p = view->parent;
 
-	if (p->layout == L_TABBED || p->layout == L_STACKED) {
+	if (swayc_is_tabbed_stacked(view)) {
 		cr = create_border_buffer(view, view->border_geometry, &surface);
 		if (focused == view) {
 			render_borders(view, cr, &config->border_colors.focused, false);

--- a/sway/border.c
+++ b/sway/border.c
@@ -141,34 +141,22 @@ static void render_borders(swayc_t *view, cairo_t *cr, struct border_colors *col
 static void render_title_bar(swayc_t *view, cairo_t *cr, struct border_colors *colors) {
 	struct wlc_geometry *tb = &view->title_bar_geometry;
 	struct wlc_geometry *b = &view->border_geometry;
-	int title_y = MIN(view->actual_geometry.origin.y - (int)tb->size.h, 0);
+	int x = MIN(tb->origin.x, tb->origin.x - b->origin.x);
+	int y = MIN(tb->origin.y, tb->origin.y - b->origin.y);
 
-	// borders
-	/* render_borders(view, cr, colors); */
-
-	int x = tb->origin.x - b->origin.x;
-	int y = tb->origin.y - b->origin.y;
-
-	/* // title bar background */
-	/* cairo_set_source_u32(cr, colors->child_border); */
-	/* cairo_rectangle(cr, x, y, tb->size.w, tb->size.h); */
-	/* cairo_fill(cr); */
 	// title bar background
 	cairo_set_source_u32(cr, colors->background);
-	cairo_rectangle(cr, 0, title_y, tb->size.w, tb->size.h);
+	cairo_rectangle(cr, x, y, tb->size.w, tb->size.h);
 	cairo_fill(cr);
 
 	// header top line
-	/* render_sharp_line(cr, colors->border, x, y, tb->size.w, 1); */
-	render_sharp_line(cr, colors->border, 0, title_y, tb->size.w, 1);
+	render_sharp_line(cr, colors->border, x, y, tb->size.w, 1);
 
 	// text
 	if (view->name) {
 		int width, height;
 		get_text_size(cr, config->font, &width, &height, false, "%s", view->name);
-		int x_text = MIN(view->actual_geometry.origin.x, view->border_thickness);
-		int y_text = MIN(view->actual_geometry.origin.y - height - 2, 2);
-		cairo_move_to(cr, x_text, y_text);
+		cairo_move_to(cr, x + 2, y + 2);
 		cairo_set_source_u32(cr, colors->text);
 		pango_printf(cr, config->font, false, "%s", view->name);
 	}
@@ -192,13 +180,13 @@ static void render_title_bar(swayc_t *view, cairo_t *cr, struct border_colors *c
 	if ((uint32_t)(view->actual_geometry.origin.y - tb->origin.y) == tb->size.h) {
 		// header bottom line
 		render_sharp_line(cr, colors->border,
-				x + view->actual_geometry.origin.x - b->origin.x,
+				x + view->actual_geometry.origin.x - tb->origin.x,
 				y + tb->size.h - 1,
 				view->actual_geometry.size.w, 1);
 	} else {
 		// header bottom line
 		render_sharp_line(cr, colors->border, x,
-				title_y + tb->size.h - 1,
+				y + tb->size.h - 1,
 				tb->size.w, 1);
 	}
 }

--- a/sway/border.c
+++ b/sway/border.c
@@ -11,13 +11,13 @@
 #include <arpa/inet.h>
 
 void cairo_set_source_u32(cairo_t *cairo, uint32_t color) {
-    color = htonl(color);
+	color = htonl(color);
 
-    cairo_set_source_rgba(cairo,
-            (color >> (2*8) & 0xFF) / 255.0,
-            (color >> (1*8) & 0xFF) / 255.0,
-            (color >> (0*8) & 0xFF) / 255.0,
-            (color >> (3*8) & 0xFF) / 255.0);
+	cairo_set_source_rgba(cairo,
+		(color >> (2*8) & 0xFF) / 255.0,
+		(color >> (1*8) & 0xFF) / 255.0,
+		(color >> (0*8) & 0xFF) / 255.0,
+		(color >> (3*8) & 0xFF) / 255.0);
 }
 
 static cairo_t *create_border_buffer(swayc_t *view, struct wlc_geometry geo, cairo_surface_t **surface) {

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -1759,6 +1759,8 @@ static struct cmd_results *cmd_layout(int argc, char **argv) {
 		parent = parent->parent;
 	}
 
+	enum swayc_layouts old_layout = parent->layout;
+
 	if (strcasecmp(argv[0], "default") == 0) {
 		parent->layout = parent->prev_layout;
 		if (parent->layout == L_NONE) {
@@ -1794,6 +1796,8 @@ static struct cmd_results *cmd_layout(int argc, char **argv) {
 			}
 		}
 	}
+
+	update_layout_geometry(parent, old_layout);
 
 	arrange_windows(parent, parent->width, parent->height);
 
@@ -2032,6 +2036,7 @@ static struct cmd_results *_do_split(int argc, char **argv, int layout) {
 		/* regular case where new split container is build around focused container
 		 * or in case of workspace, container inherits its children */
 		sway_log(L_DEBUG, "Adding new container around current focused container");
+		sway_log(L_INFO, "FOCUSED SIZE: %.f %.f", focused->width, focused->height);
 		swayc_t *parent = new_container(focused, layout);
 		set_focused_container(focused);
 		arrange_windows(parent, -1, -1);

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -1,6 +1,7 @@
 #include <xkbcommon/xkbcommon.h>
 #include <xkbcommon/xkbcommon-names.h>
 #include <wlc/wlc.h>
+#include <wlc/wlc-render.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
@@ -2041,6 +2042,17 @@ static struct cmd_results *_do_split(int argc, char **argv, int layout) {
 		set_focused_container(focused);
 		arrange_windows(parent, -1, -1);
 	}
+
+	// update container title if tabbed/stacked
+	if (swayc_tabbed_stacked_parent(focused)) {
+		update_view_border(focused);
+		swayc_t *output = swayc_parent_by_type(focused, C_OUTPUT);
+		// schedule render to make changes take effect right away,
+		// otherwise we would have to wait for the view to render,
+		// which is unpredictable.
+		wlc_output_schedule_render(output->handle);
+	}
+
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -1760,29 +1760,38 @@ static struct cmd_results *cmd_layout(int argc, char **argv) {
 	}
 
 	if (strcasecmp(argv[0], "default") == 0) {
-		swayc_t *output = swayc_parent_by_type(parent, C_OUTPUT);
-		parent->layout = default_layout(output);
-	} else if (strcasecmp(argv[0], "tabbed") == 0) {
-		if (parent->type != C_CONTAINER) {
-			parent = new_container(parent, L_TABBED);
+		parent->layout = parent->prev_layout;
+		if (parent->layout == L_NONE) {
+			swayc_t *output = swayc_parent_by_type(parent, C_OUTPUT);
+			parent->layout = default_layout(output);
+		}
+	} else {
+		if (parent->layout != L_TABBED && parent->layout != L_STACKED) {
+			parent->prev_layout = parent->layout;
 		}
 
-		parent->layout = L_TABBED;
-	} else if (strcasecmp(argv[0], "stacking") == 0) {
-		if (parent->type != C_CONTAINER) {
-			parent = new_container(parent, L_STACKED);
-		}
+		if (strcasecmp(argv[0], "tabbed") == 0) {
+			if (parent->type != C_CONTAINER) {
+				parent = new_container(parent, L_TABBED);
+			}
 
-		parent->layout = L_STACKED;
-	} else if (strcasecmp(argv[0], "splith") == 0) {
-		parent->layout = L_HORIZ;
-	} else if (strcasecmp(argv[0], "splitv") == 0) {
-		parent->layout = L_VERT;
-	} else if (strcasecmp(argv[0], "toggle") == 0 && argc == 2 && strcasecmp(argv[1], "split") == 0) {
-		if (parent->layout == L_VERT) {
+			parent->layout = L_TABBED;
+		} else if (strcasecmp(argv[0], "stacking") == 0) {
+			if (parent->type != C_CONTAINER) {
+				parent = new_container(parent, L_STACKED);
+			}
+
+			parent->layout = L_STACKED;
+		} else if (strcasecmp(argv[0], "splith") == 0) {
 			parent->layout = L_HORIZ;
-		} else {
+		} else if (strcasecmp(argv[0], "splitv") == 0) {
 			parent->layout = L_VERT;
+		} else if (strcasecmp(argv[0], "toggle") == 0 && argc == 2 && strcasecmp(argv[1], "split") == 0) {
+			if (parent->layout == L_VERT) {
+				parent->layout = L_HORIZ;
+			} else {
+				parent->layout = L_VERT;
+			}
 		}
 	}
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -1764,8 +1764,16 @@ static struct cmd_results *cmd_layout(int argc, char **argv) {
 		// cmd_workspace_layout
 		parent->layout = L_HORIZ;
 	} else if (strcasecmp(argv[0], "tabbed") == 0) {
+		if (parent->type != C_CONTAINER) {
+			parent = new_container(parent, L_TABBED);
+		}
+
 		parent->layout = L_TABBED;
 	} else if (strcasecmp(argv[0], "stacking") == 0) {
+		if (parent->type != C_CONTAINER) {
+			parent = new_container(parent, L_STACKED);
+		}
+
 		parent->layout = L_STACKED;
 	} else if (strcasecmp(argv[0], "splith") == 0) {
 		parent->layout = L_HORIZ;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -1759,7 +1759,15 @@ static struct cmd_results *cmd_layout(int argc, char **argv) {
 		parent = parent->parent;
 	}
 
-	if (strcasecmp(argv[0], "splith") == 0) {
+	if (strcasecmp(argv[0], "default") == 0) {
+		// TODO: determine default from default_orientation and
+		// cmd_workspace_layout
+		parent->layout = L_HORIZ;
+	} else if (strcasecmp(argv[0], "tabbed") == 0) {
+		parent->layout = L_TABBED;
+	} else if (strcasecmp(argv[0], "stacking") == 0) {
+		parent->layout = L_STACKED;
+	} else if (strcasecmp(argv[0], "splith") == 0) {
 		parent->layout = L_HORIZ;
 	} else if (strcasecmp(argv[0], "splitv") == 0) {
 		parent->layout = L_VERT;
@@ -1770,6 +1778,7 @@ static struct cmd_results *cmd_layout(int argc, char **argv) {
 			parent->layout = L_VERT;
 		}
 	}
+
 	arrange_windows(parent, parent->width, parent->height);
 
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -1760,9 +1760,8 @@ static struct cmd_results *cmd_layout(int argc, char **argv) {
 	}
 
 	if (strcasecmp(argv[0], "default") == 0) {
-		// TODO: determine default from default_orientation and
-		// cmd_workspace_layout
-		parent->layout = L_HORIZ;
+		swayc_t *output = swayc_parent_by_type(parent, C_OUTPUT);
+		parent->layout = default_layout(output);
 	} else if (strcasecmp(argv[0], "tabbed") == 0) {
 		if (parent->type != C_CONTAINER) {
 			parent = new_container(parent, L_TABBED);

--- a/sway/config.c
+++ b/sway/config.c
@@ -160,7 +160,7 @@ static void config_defaults(struct sway_config *config) {
 	config->dragging_key = M_LEFT_CLICK;
 	config->resizing_key = M_RIGHT_CLICK;
 	config->floating_scroll = FSB_GAPS_INNER;
-	config->default_layout = L_HORIZ;
+	config->default_layout = L_NONE;
 	config->default_orientation = L_NONE;
 	config->font = strdup("monospace 10");
 	config->font_height = get_font_text_height(config->font);

--- a/sway/config.c
+++ b/sway/config.c
@@ -160,7 +160,7 @@ static void config_defaults(struct sway_config *config) {
 	config->dragging_key = M_LEFT_CLICK;
 	config->resizing_key = M_RIGHT_CLICK;
 	config->floating_scroll = FSB_GAPS_INNER;
-	config->default_layout = L_NONE;
+	config->default_layout = L_HORIZ;
 	config->default_orientation = L_NONE;
 	config->font = strdup("monospace 10");
 	config->font_height = get_font_text_height(config->font);

--- a/sway/container.c
+++ b/sway/container.c
@@ -218,6 +218,7 @@ swayc_t *new_container(swayc_t *child, enum swayc_layouts layout) {
 	cont->y = child->y;
 	cont->visible = child->visible;
 	cont->cached_geometry = child->cached_geometry;
+	cont->gaps = child->gaps;
 
 	/* Container inherits all of workspaces children, layout and whatnot */
 	if (child->type == C_WORKSPACE) {
@@ -680,7 +681,7 @@ bool swayc_is_child_of(swayc_t *child, swayc_t *parent) {
 }
 
 int swayc_gap(swayc_t *container) {
-	if (container->type == C_VIEW) {
+	if (container->type == C_VIEW || container->type == C_CONTAINER) {
 		return container->gaps >= 0 ? container->gaps : config->gaps_inner;
 	} else if (container->type == C_WORKSPACE) {
 		int base = container->gaps >= 0 ? container->gaps : config->gaps_outer;

--- a/sway/container.c
+++ b/sway/container.c
@@ -732,9 +732,6 @@ void update_visibility_output(swayc_t *container, wlc_handle output) {
 	if (container->type == C_VIEW) {
 		wlc_view_set_output(container->handle, output);
 		wlc_view_set_mask(container->handle, container->visible ? VISIBLE : 0);
-		if (!container->visible) {
-			wlc_view_send_to_back(container->handle);
-		}
 	}
 	// Update visibility for children
 	else {

--- a/sway/container.c
+++ b/sway/container.c
@@ -725,7 +725,7 @@ void update_visibility_output(swayc_t *container, wlc_handle output) {
 	if (parent->type == C_OUTPUT
 			|| parent->layout == L_TABBED
 			|| parent->layout == L_STACKED) {
-		container->visible = parent->focused == container;
+		container->visible = parent->focused == container && parent->visible;
 	}
 	// Set visibility and output for view
 	if (container->type == C_VIEW) {

--- a/sway/container.c
+++ b/sway/container.c
@@ -725,7 +725,8 @@ void update_visibility_output(swayc_t *container, wlc_handle output) {
 	swayc_t *parent = container->parent;
 	container->visible = parent->visible;
 	// special cases where visibility depends on focus
-	if (parent->type == C_OUTPUT || swayc_is_tabbed_stacked(container)) {
+	if (parent->type == C_OUTPUT || parent->layout == L_TABBED ||
+			parent->layout == L_STACKED) {
 		container->visible = parent->focused == container && parent->visible;
 	}
 	// Set visibility and output for view
@@ -811,11 +812,6 @@ static void close_view(swayc_t *container, void *data) {
 
 void close_views(swayc_t *container) {
 	container_map(container, close_view, NULL);
-}
-
-bool swayc_is_tabbed_stacked(swayc_t *view) {
-	return (view->parent->layout == L_TABBED
-			|| view->parent->layout == L_STACKED);
 }
 
 swayc_t *swayc_tabbed_stacked_parent(swayc_t *view) {

--- a/sway/container.c
+++ b/sway/container.c
@@ -163,16 +163,8 @@ swayc_t *new_workspace(swayc_t *output, const char *name) {
 	sway_log(L_DEBUG, "Added workspace %s for output %u", name, (unsigned int)output->handle);
 	swayc_t *workspace = new_swayc(C_WORKSPACE);
 
-	// TODO: default_layout
-	if (config->default_layout != L_NONE) {
-		workspace->layout = config->default_layout;
-	} else if (config->default_orientation != L_NONE) {
-		workspace->layout = config->default_orientation;
-	} else if (output->width >= output->height) {
-		workspace->layout = L_HORIZ;
-	} else {
-		workspace->layout = L_VERT;
-	}
+	workspace->layout = default_layout(output);
+
 	workspace->x = output->x;
 	workspace->y = output->y;
 	workspace->width = output->width;

--- a/sway/container.c
+++ b/sway/container.c
@@ -237,7 +237,7 @@ swayc_t *new_container(swayc_t *child, enum swayc_layouts layout) {
 		add_child(workspace, cont);
 		// give them proper layouts
 		cont->layout = workspace->layout;
-		workspace->layout = layout;
+		/* TODO: might break shit in move_container!!! workspace->layout = layout; */
 		set_focused_container_for(workspace, get_focused_view(workspace));
 	} else { // Or is built around container
 		swayc_t *parent = replace_child(child, cont);
@@ -722,9 +722,7 @@ void update_visibility_output(swayc_t *container, wlc_handle output) {
 	swayc_t *parent = container->parent;
 	container->visible = parent->visible;
 	// special cases where visibility depends on focus
-	if (parent->type == C_OUTPUT
-			|| parent->layout == L_TABBED
-			|| parent->layout == L_STACKED) {
+	if (parent->type == C_OUTPUT || swayc_is_tabbed_stacked(container)) {
 		container->visible = parent->focused == container && parent->visible;
 	}
 	// Set visibility and output for view
@@ -813,4 +811,9 @@ static void close_view(swayc_t *container, void *data) {
 
 void close_views(swayc_t *container) {
 	container_map(container, close_view, NULL);
+}
+
+bool swayc_is_tabbed_stacked(swayc_t *view) {
+	return (view->parent->layout == L_TABBED
+			|| view->parent->layout == L_STACKED);
 }

--- a/sway/container.c
+++ b/sway/container.c
@@ -163,6 +163,7 @@ swayc_t *new_workspace(swayc_t *output, const char *name) {
 	sway_log(L_DEBUG, "Added workspace %s for output %u", name, (unsigned int)output->handle);
 	swayc_t *workspace = new_swayc(C_WORKSPACE);
 
+	workspace->prev_layout = L_NONE;
 	workspace->layout = default_layout(output);
 
 	workspace->x = output->x;
@@ -203,6 +204,7 @@ swayc_t *new_container(swayc_t *child, enum swayc_layouts layout) {
 
 	sway_log(L_DEBUG, "creating container %p around %p", cont, child);
 
+	cont->prev_layout = L_NONE;
 	cont->layout = layout;
 	cont->width = child->width;
 	cont->height = child->height;
@@ -229,6 +231,7 @@ swayc_t *new_container(swayc_t *child, enum swayc_layouts layout) {
 		add_child(workspace, cont);
 		// give them proper layouts
 		cont->layout = workspace->layout;
+		cont->prev_layout = workspace->prev_layout;
 		/* TODO: might break shit in move_container!!! workspace->layout = layout; */
 		set_focused_container_for(workspace, get_focused_view(workspace));
 	} else { // Or is built around container

--- a/sway/debug_log.c
+++ b/sway/debug_log.c
@@ -38,6 +38,7 @@ static void container_log(const swayc_t *c, int depth) {
 			c->layout == L_HORIZ ? "Horiz":
 			c->layout == L_VERT ? "Vert":
 			c->layout == L_STACKED  ? "Stack":
+			c->layout == L_TABBED  ? "Tab":
 			c->layout == L_FLOATING ? "Float":
 			"Unknown");
 	fprintf(stderr, "w:%4.f|h:%4.f|", c->width, c->height);

--- a/sway/focus.c
+++ b/sway/focus.c
@@ -149,7 +149,7 @@ bool set_focused_container(swayc_t *c) {
 		}
 
 		// rearrange if parent container is tabbed/stacked
-		if (p->parent->layout == L_TABBED || p->parent->layout == L_STACKED) {
+		if (swayc_is_tabbed_stacked(p)) {
 			arrange_windows(p->parent, -1, -1);
 		}
 	} else if (p->type == C_WORKSPACE) {

--- a/sway/focus.c
+++ b/sway/focus.c
@@ -141,8 +141,16 @@ bool set_focused_container(swayc_t *c) {
 			// set focus if view_focus is unlocked
 			if (!locked_view_focus) {
 				wlc_view_focus(p->handle);
-				update_view_border(p);
+				if (p->parent->layout != L_TABBED
+					&& p->parent->layout != L_STACKED) {
+					update_view_border(p);
+				}
 			}
+		}
+
+		// rearrange if parent container is tabbed/stacked
+		if (p->parent->layout == L_TABBED || p->parent->layout == L_STACKED) {
+			arrange_windows(p->parent, -1, -1);
 		}
 	} else if (p->type == C_WORKSPACE) {
 		// remove previous focus if view_focus is unlocked

--- a/sway/focus.c
+++ b/sway/focus.c
@@ -149,8 +149,9 @@ bool set_focused_container(swayc_t *c) {
 		}
 
 		// rearrange if parent container is tabbed/stacked
-		if (swayc_is_tabbed_stacked(p)) {
-			arrange_windows(p->parent, -1, -1);
+		swayc_t *parent = swayc_tabbed_stacked_parent(p);
+		if (parent != NULL) {
+			arrange_windows(parent, -1, -1);
 		}
 	} else if (p->type == C_WORKSPACE) {
 		// remove previous focus if view_focus is unlocked

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -458,7 +458,7 @@ void update_geometry(swayc_t *container) {
 
 	// use parent size if window is in a stacked/tabbed layout
 	swayc_t *parent = container->parent;
-	if (parent->layout == L_STACKED || parent->layout == L_TABBED) {
+	if (swayc_is_tabbed_stacked(container)) {
 		width = parent->width;
 		height = parent->height;
 	}
@@ -833,6 +833,8 @@ static void arrange_windows_r(swayc_t *container, double width, double height) {
 			swayc_t *view = container->floating->items[i];
 			if (view->type == C_VIEW) {
 				update_geometry(view);
+				sway_log(L_DEBUG, "Set floating view to %.f x %.f @ %.f, %.f", view->width,
+						view->height, view->x, view->y);
 				if (swayc_is_fullscreen(view)) {
 					wlc_view_bring_to_front(view->handle);
 				} else if (!container->focused

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -993,3 +993,15 @@ void recursive_resize(swayc_t *container, double amount, enum wlc_resize_edge ed
 		}
 	}
 }
+
+enum swayc_layouts default_layout(swayc_t *output) {
+	if (config->default_layout != L_NONE) {
+		return config->default_layout;
+	} else if (config->default_orientation != L_NONE) {
+		return config->default_orientation;
+	} else if (output->width >= output->height) {
+		return L_HORIZ;
+	} else {
+		return L_VERT;
+	}
+}

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -244,7 +244,9 @@ void move_container(swayc_t *container, enum movement_direction dir) {
 	while (true) {
 		sway_log(L_DEBUG, "container:%p, parent:%p, child %p,",
 				container,parent,child);
-		if (parent->layout == layout) {
+		if (parent->layout == layout
+			|| (parent->layout == L_TABBED && layout == L_HORIZ)
+			|| (parent->layout == L_STACKED && layout == L_VERT)) {
 			int diff;
 			// If it has ascended (parent has moved up), no container is removed
 			// so insert it at index, or index+1.
@@ -264,9 +266,11 @@ void move_container(swayc_t *container, enum movement_direction dir) {
 					// Move container into sibling container
 					if (child->type == C_CONTAINER) {
 						parent = child;
-						// Insert it in first/last if matching layout,otherwise
+						// Insert it in first/last if matching layout, otherwise
 						// inesrt it next to focused container
-						if (parent->layout == layout) {
+						if (parent->layout == layout
+							|| (parent->layout == L_TABBED && layout == L_HORIZ)
+							|| (parent->layout == L_STACKED && layout == L_VERT)) {
 							desired = (diff < 0) * parent->children->length;
 						} else {
 							desired = index_child(child->focused);
@@ -300,7 +304,7 @@ void move_container(swayc_t *container, enum movement_direction dir) {
 		parent = child->parent;
 	}
 	// Dirty hack to fix a certain case
-	arrange_windows(parent, -1, -1);
+	/* arrange_windows(parent, -1, -1); */
 	arrange_windows(parent->parent, -1, -1);
 	set_focused_container_for(parent->parent, container);
 }

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -384,16 +384,14 @@ static void adjust_border_geometry(swayc_t *c, struct wlc_geometry *g,
 	g->size.w += left + right;
 	if (g->origin.x - left < 0) {
 		g->size.w += g->origin.x - left;
-	}
-	else if (g->origin.x + g->size.w - right > res->w) {
+	} else if (g->origin.x + g->size.w - right > res->w) {
 		g->size.w = res->w - g->origin.x + right;
 	}
 
 	g->size.h += top + bottom;
 	if (g->origin.y - top < 0) {
 		g->size.h += g->origin.y - top;
-	}
-	else if (g->origin.y + g->size.h - top > res->h) {
+	} else if (g->origin.y + g->size.h - top > res->h) {
 		g->size.h = res->h - g->origin.y + top;
 	}
 
@@ -425,11 +423,11 @@ static void update_border_geometry_floating(swayc_t *c, struct wlc_geometry *geo
 
 		struct wlc_geometry title_bar = {
 			.origin = {
-				.x = g.origin.x,
-				.y = g.origin.y
+				.x = c->actual_geometry.origin.x - c->border_thickness,
+				.y = c->actual_geometry.origin.y - title_bar_height
 			},
 			.size = {
-				.w = g.size.w,
+				.w = c->actual_geometry.size.w + (2 * c->border_thickness),
 				.h = title_bar_height
 			}
 		};

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -303,8 +303,6 @@ void move_container(swayc_t *container, enum movement_direction dir) {
 		child = parent;
 		parent = child->parent;
 	}
-	// Dirty hack to fix a certain case
-	/* arrange_windows(parent, -1, -1); */
 	arrange_windows(parent->parent, -1, -1);
 	set_focused_container_for(parent->parent, container);
 }

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -790,7 +790,8 @@ static void arrange_windows_r(swayc_t *container, double width, double height) {
 		y = container->y;
 
 		// add gaps to top level tapped/stacked container
-		if (container->layout == L_TABBED || container->layout == L_STACKED) {
+		if (container->parent->type == C_WORKSPACE &&
+			(container->layout == L_TABBED || container->layout == L_STACKED)) {
 			update_geometry(container);
 			width = container->border_geometry.size.w;
 			height = container->border_geometry.size.h;
@@ -799,13 +800,14 @@ static void arrange_windows_r(swayc_t *container, double width, double height) {
 		}
 
 		// update container size if it's a child in a tabbed/stacked layout
-		if (swayc_is_tabbed_stacked(container)) {
-			// Use parent border_geometry as a base for calculating
+		if (swayc_tabbed_stacked_parent(container) != NULL) {
+			// Use parent actual_geometry as a base for calculating
 			// container geometry
-			container->width = container->parent->border_geometry.size.w;
-			container->height = container->parent->border_geometry.size.h;
-			container->x = container->parent->border_geometry.origin.x;
-			container->y = container->parent->border_geometry.origin.y;
+			container->width = container->parent->actual_geometry.size.w;
+			container->height = container->parent->actual_geometry.size.h;
+			container->x = container->parent->actual_geometry.origin.x;
+			container->y = container->parent->actual_geometry.origin.y;
+
 			update_geometry(container);
 			width = container->width = container->actual_geometry.size.w;
 			height = container->height = container->actual_geometry.size.h;


### PR DESCRIPTION
This is now ready for review/merge.

There's one known bug in wlc, that causes views to become invisible when moved away from a tabbed/stacked layout in some cases. (Will be fixed separately, obviously).



---------------------------------------

This is just to let other people follow the progress and for me to have some sort of checklist for bugs I find.

Will update when ready for review.

#### Known issues

* [x] Nested containers does not work well with these layouts.
 * [x] VERT layout inside a tabbed/stacked layout behaves weird.
* [x] Does not work well with `gaps_inner` right now. (inner gaps are disabled in tabbed/stacked mode).
* [x] Default layout not correctly handled.
* [ ] Resize after rendering resulting in ugly flashes (relates to #220). 
* [x] move command does not work correctly with these layouts.
 * [ ] sometimes views get invisible when moving away from tabbed/stacked layout.
* [x] Add text title to container titlebars e.g. `sway: T[term term]`
* [x] Making a child of a tabbed/stacked container floating, does not work.
 * [ ] Floating is still a bit messed up in general.