### PR TITLE
Don't init desired width/height on new_view

### DIFF
--- a/sway/container.c
+++ b/sway/container.c
@@ -265,13 +265,10 @@ swayc_t *new_view(swayc_t *sibling, wlc_handle handle) {
 	view->visible = true;
 	view->is_focused = true;
 	view->sticky = false;
-	// Setup geometry
-	struct wlc_geometry geometry;
-	wlc_view_get_visible_geometry(handle, &geometry);
 	view->width = 0;
 	view->height = 0;
-	view->desired_width = geometry.size.w;
-	view->desired_height = geometry.size.h;
+	view->desired_width = -1;
+	view->desired_height = -1;
 	// setup border
 	view->border_type = config->border;
 	view->border_thickness = config->border_thickness;

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -354,7 +354,7 @@ static void handle_view_geometry_request(wlc_handle handle, const struct wlc_geo
 			view->height = view->desired_height;
 			view->x = geometry->origin.x;
 			view->y = geometry->origin.y;
-			arrange_windows(view->parent, -1, -1);
+			update_geometry(view);
 		}
 	}
 }


### PR DESCRIPTION
When creating a new view, wlc usually returns an initial visible geometry with
size 1x1. Setting those values as desired width/height causes a problem
for some windows (QT5) because they don't request a new geometry for
instance when made floating, so the floating window becomes 1x1.

To fix this problem we can just omit setting the desired width/height on
new_view and instead let the clients request a certain size if they feel
like it. e.i. gnome-calculator.

Fix #578

I have also included a related patch that just updates the geometry of a single floating window instead of the entire workspace on `view_geometry_request`, eliminating redundant updates in the layout.