### PR TITLE
Plug two memory leaks

### DIFF
--- a/sway/border.c
+++ b/sway/border.c
@@ -86,6 +86,8 @@ int get_font_text_height(const char *font) {
 	cairo_t *cr = cairo_create(surface);
 	int width, height;
 	get_text_size(cr, font, &width, &height, "Gg");
+	cairo_surface_destroy(surface);
+	cairo_destroy(cr);
 	return height;
 }
 

--- a/sway/container.c
+++ b/sway/container.c
@@ -64,6 +64,7 @@ static void free_swayc(swayc_t *cont) {
 	if (cont->bg_pid != 0) {
 		terminate_swaybg(cont->bg_pid);
 	}
+	free(cont->border);
 	free(cont);
 }
 


### PR DESCRIPTION
I have been observing increased memory usage with the latest git version of sway.

The best way to reproduce this is to open, say 200 terminal windows and close them, and observe that sway has shown drastically increased memory usage. This would suggest that sway has leaked memory somewhere.

I did a git bisect and found the first bad commit to be a8e084433d, which introduced window borders.

This pull request fixes two of the memory leaks I have found. However there still seem to be more memory leaks lurking somewhere as even after applying this I am still seeing increased memory usage even after all windows are closed. It may be worthwhile to do a stress test of both stability and memory usage. <del>This was due to a mistake in the previous attempt to fix this.</del> It wasn't. It's still there.