### PR TITLE
swaylock: Fix swaylock.pam

### DIFF
--- a/swaylock/pam/swaylock
+++ b/swaylock/pam/swaylock
@@ -1,6 +1,6 @@
 #
 # PAM configuration file for the swaylock screen locker. By default, it includes
-# the 'system-auth' configuration file (see /etc/pam.d/login)
+# the 'login' configuration file (see /etc/pam.d/login)
 #
 
-auth include system-auth
+auth include login


### PR DESCRIPTION
Change swaylock.pam to make it work on Debian-based systems also.

Reference: https://github.com/i3/i3lock/blob/master/i3lock.pam