### PR TITLE
Use i3bar format for markup field.

### DIFF
--- a/swaybar/status_line.c
+++ b/swaybar/status_line.c
@@ -141,7 +141,11 @@ static void parse_json(struct bar *bar, const char *text) {
 		}
 
 		if (markup) {
-			new->markup = json_object_get_boolean(markup);
+			new->markup = false;
+			const char *markup_str = json_object_get_string(markup);
+			if (strcmp(markup_str, "pango") == 0) {
+				new->markup = true;
+			}
 		}
 
 		if (separator) {


### PR DESCRIPTION
In the i3bar protocol the value of the markup field is a string: "pango"
or "none" rather than a bool. This patch makes swaybar compatible with that.

http://i3wm.org/docs/i3bar-protocol.html