### PR TITLE
swaylock: fix double free

### DIFF
--- a/swaylock/main.c
+++ b/swaylock/main.c
@@ -90,7 +90,7 @@ int function_conversation(int num_msg, const struct pam_message **msg,
 }
 
 /**
- * password will be zeroed out.
+ * Note: PAM will free() 'password' during the process
  */
 bool verify_password() {
 	struct passwd *passwd = getpwuid(getuid());
@@ -131,7 +131,6 @@ void notify_key(enum wl_keyboard_key_state state, xkb_keysym_t sym, uint32_t cod
 			redraw_screen = 1;
 
 			password_size = 1024;
-			free(password);
 			password = malloc(password_size);
 			password[0] = '\0';
 			break;


### PR DESCRIPTION
PAM will free() the password buffer during the authentication process so swaylock is causing a double-free when the entered password is invalid.