### PR TITLE
border: clear buffer on fullscreen views

### DIFF
--- a/include/border.h
+++ b/include/border.h
@@ -3,10 +3,18 @@
 #include <wlc/wlc.h>
 #include "container.h"
 
+/**
+ * Border pixel buffer and corresponding geometry.
+ */
 struct border {
 	unsigned char *buffer;
 	struct wlc_geometry geometry;
 };
+
+/**
+ * Clear border buffer.
+ */
+void border_clear(struct border *border);
 
 void render_view_borders(wlc_handle view);
 void update_view_border(swayc_t *view);

--- a/sway/border.c
+++ b/sway/border.c
@@ -315,8 +315,8 @@ void update_view_border(swayc_t *view) {
 
 	// for tabbed/stacked layouts the focused view has to draw all the
 	// titlebars of the hidden views.
-	swayc_t *p = swayc_tabbed_stacked_parent(view);
-	if (p && view->parent->focused == view) {
+	swayc_t *p = NULL;
+	if (view->parent->focused == view && (p = swayc_tabbed_stacked_parent(view))) {
 		struct wlc_geometry g = {
 			.origin = {
 				.x = p->x,

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -555,6 +555,7 @@ void update_geometry(swayc_t *container) {
 
 		container->border_geometry = wlc_geometry_zero;
 		container->title_bar_geometry = wlc_geometry_zero;
+		border_clear(container->border);
 	} else if (container->is_floating) { // allocate border for floating window
 		update_border_geometry_floating(container, &geometry);
 	} else if (!container->is_floating) { // allocate border for titled window


### PR DESCRIPTION
This patch makes sure to clear the border buffer of fullscreen view so
the border doesn't get drawn behind a fullscreen view, which would be
visible if the view was transparent.


(I also sneaked in a commit addressing this [comment](https://github.com/SirCmpwn/sway/pull/566#discussion_r60936168)).