### PR TITLE
Fix bindcode by offsetting xkb keycode by 8

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -335,7 +335,7 @@ static struct cmd_results *cmd_bindcode(int argc, char **argv) {
 			return error;
 		}
 		xkb_keycode_t *key = malloc(sizeof(xkb_keycode_t));
-		*key = keycode;
+		*key = keycode - 8;
 		list_add(binding->keys, key);
 	}
 	free_flat_list(split);


### PR DESCRIPTION
The bindcode has to be offset by 8 to match the keycode we get from wlc.

https://github.com/xkbcommon/libxkbcommon/blob/master/xkbcommon/xkbcommon.h#L160