### PR TITLE
sway/config.c: Initialise struct value

### DIFF
--- a/sway/config.c
+++ b/sway/config.c
@@ -1035,6 +1035,7 @@ struct bar_config *default_bar_config(void) {
 	bar->strip_workspace_numbers = false;
 	bar->binding_mode_indicator = true;
 	bar->tray_padding = 2;
+	bar->verbose = false;
 	bar->pid = 0;
 	// set default colors
 	strcpy(bar->colors.background, "#000000ff");


### PR DESCRIPTION
`bar->verbose` never gets initialised which causes Valgrind to complain with the following message:

```
Conditional jump or move depends on uninitialised value(s)
==13873==    at 0x5531358: ??? (in /usr/lib/libjson-c.so.2.0.1)
==13873==    by 0x55318C4: ??? (in /usr/lib/libjson-c.so.2.0.1)
==13873==    by 0x553172B: json_object_to_json_string_ext (in /usr/lib/libjson-c.so.2.0.1)
==13873==    by 0x41F3E9: ipc_client_handle_command (ipc-server.c:472)
==13873==    by 0x41E538: ipc_client_handle_readable (ipc-server.c:209)
==13873==    by 0x5742831: wl_event_loop_dispatch (in /usr/lib/libwayland-server.so.0.1.0)
==13873==    by 0x5740EE4: wl_display_run (in /usr/lib/libwayland-server.so.0.1.0)
==13873==    by 0x4E6085B: wlc_run (in /usr/lib/libwlc.so.0.0.2)
==13873==    by 0x424C56: main (main.c:224)
==13873==  Uninitialised value was created by a heap allocation
==13873==    at 0x4C2ABD0: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==13873==    by 0x415E0B: default_bar_config (config.c:1021)
==13873==    by 0x40E3FF: cmd_bar (commands.c:1895)
==13873==    by 0x412E69: config_command (commands.c:3318)
==13873==    by 0x41434B: read_config (config.c:459)
==13873==    by 0x413DBD: load_config (config.c:310)
==13873==    by 0x413EFC: load_main_config (config.c:345)
==13873==    by 0x424C1A: main (main.c:213)
 ```