### PR TITLE
Remove premature break in workspace_next_name

### DIFF
--- a/sway/workspace.c
+++ b/sway/workspace.c
@@ -100,10 +100,9 @@ char *workspace_next_name(const char *output_name) {
 
 			if (binding->order < order) {
 				order = binding->order;
+				free(target);
 				target = _target;
 				sway_log(L_DEBUG, "Workspace: Found free name %s", _target);
-				free(dup);
-				break;
 			}
 		}
 		free(dup);


### PR DESCRIPTION
I was a bit too quick to merge #616 which introduced a bug.

This should fix that.