### PR TITLE
wayland/registry.c: free() registry at registry_teardown

### DIFF
--- a/wayland/registry.c
+++ b/wayland/registry.c
@@ -258,4 +258,5 @@ void registry_teardown(struct registry *registry) {
 	if (registry->outputs) {
 		free_flat_list(registry->outputs);
 	}
+	free(registry);
 }


### PR DESCRIPTION
registry wasn't freed anywhere, and thus memleaked.