### PR TITLE
Add input cmd for setting pointer accel profile.

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -52,6 +52,8 @@ struct sway_mode {
  */
 struct input_config {
 	char *identifier;
+
+	int accel_profile;
 	int click_method;
 	int drag_lock;
 	int dwt;

--- a/sway/config.c
+++ b/sway/config.c
@@ -562,6 +562,9 @@ void merge_input_config(struct input_config *dst, struct input_config *src) {
 		}
 		dst->identifier = strdup(src->identifier);
 	}
+	if (src->accel_profile != INT_MIN) {
+		dst->accel_profile = src->accel_profile;
+	}
 	if (src->click_method != INT_MIN) {
 		dst->click_method = src->click_method;
 	}
@@ -735,6 +738,10 @@ void apply_input_config(struct input_config *ic, struct libinput_device *dev) {
 			ic->identifier);
 	}
 
+	if (ic && ic->accel_profile != INT_MIN) {
+		sway_log(L_DEBUG, "apply_input_config(%s) accel_set_profile(%d)", ic->identifier, ic->accel_profile);
+		libinput_device_config_accel_set_profile(dev, ic->accel_profile);
+	}
 	if (ic && ic->click_method != INT_MIN) {
 		sway_log(L_DEBUG, "apply_input_config(%s) click_set_method(%d)", ic->identifier, ic->click_method);
 		libinput_device_config_click_set_method(dev, ic->click_method);

--- a/sway/input.c
+++ b/sway/input.c
@@ -21,6 +21,7 @@ struct input_config *new_input_config(const char* identifier) {
 	input->click_method = INT_MIN;
 	input->middle_emulation = INT_MIN;
 	input->natural_scroll = INT_MIN;
+	input->accel_profile = INT_MIN;
 	input->pointer_accel = FLT_MIN;
 	input->scroll_method = INT_MIN;
 

--- a/sway/sway-input.5.txt
+++ b/sway/sway-input.5.txt
@@ -17,6 +17,9 @@ your config file.
 Commands
 --------
 
+**input** <identifier> accel_profile <adaptive|flat>::
+	Sets the pointer acceleration profile for the specified input device.
+
 **input** <identifier> click_method <none|button_areas|clickfinger>::
 	Changes the click method for the specified device.
 


### PR DESCRIPTION
Implement a new sway input command for setting the libinput pointer acceleration profile.

Closes #576 .