### PR TITLE
Always terminate ipc path

### DIFF
--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -66,6 +66,7 @@ void ipc_init(void) {
 	// We want to use socket name set by user, not existing socket from another sway instance.
 	if (getenv("SWAYSOCK") != NULL && access(getenv("SWAYSOCK"), F_OK) == -1) {
 		strncpy(ipc_sockaddr->sun_path, getenv("SWAYSOCK"), sizeof(ipc_sockaddr->sun_path));
+		ipc_sockaddr->sun_path[sizeof(ipc_sockaddr->sun_path) - 1] = 0;
 	}
 
 	unlink(ipc_sockaddr->sun_path);


### PR DESCRIPTION
`strncpy()` makes sure to not overflow the buffer, but doesn't terminate it if the max size was reached.