### PR TITLE
Refactor preprocessor logic out of _sway_log()

### DIFF
--- a/common/log.c
+++ b/common/log.c
@@ -61,11 +61,7 @@ void sway_abort(const char *format, ...) {
 	sway_terminate(EXIT_FAILURE);
 }
 
-#ifndef NDEBUG
 void _sway_log(const char *filename, int line, log_importance_t verbosity, const char* format, ...) {
-#else
-void _sway_log(log_importance_t verbosity, const char* format, ...) {
-#endif
 	if (verbosity <= v) {
 		unsigned int c = verbosity;
 		if (c > sizeof(verbosity_colors) / sizeof(char *) - 1) {
@@ -76,13 +72,14 @@ void _sway_log(log_importance_t verbosity, const char* format, ...) {
 			fprintf(stderr, "%s", verbosity_colors[c]);
 		}
 
+		if (filename && line) {
+			char *file = strdup(filename);
+			fprintf(stderr, "[%s:%d] ", basename(file), line);
+			free(file);
+		}
+
 		va_list args;
 		va_start(args, format);
-#ifndef NDEBUG
-		char *file = strdup(filename);
-		fprintf(stderr, "[%s:%d] ", basename(file), line);
-		free(file);
-#endif
 		vfprintf(stderr, format, args);
 		va_end(args);
 

--- a/include/log.h
+++ b/include/log.h
@@ -22,14 +22,14 @@ bool _sway_assert(bool condition, const char* format, ...) __attribute__((format
 #define sway_assert(COND, FMT, ...) \
 	_sway_assert(COND, "%s:" FMT, __PRETTY_FUNCTION__, ##__VA_ARGS__)
 
-#ifndef NDEBUG
 void _sway_log(const char *filename, int line, log_importance_t verbosity, const char* format, ...) __attribute__((format(printf,4,5)));
+
+#ifndef NDEBUG
 #define sway_log(VERBOSITY, FMT, ...) \
 	_sway_log(__FILE__, __LINE__, VERBOSITY, FMT, ##__VA_ARGS__)
 #else
-void _sway_log(log_importance_t verbosity, const char* format, ...) __attribute__((format(printf,2,3)));
 #define sway_log(VERBOSITY, FMT, ...) \
-	_sway_log(VERBOSITY, FMT, ##__VA_ARGS__)
+	_sway_log(NULL, 0, VERBOSITY, FMT, ##__VA_ARGS__)
 #endif
 
 void error_handler(int sig);


### PR DESCRIPTION
This removes most preprocessor logic, leaving it only it the header, which I find cleaner.
I won't be offended if you prefer the old code and don't want my patch, so feel free to just tell me so :stuck_out_tongue_winking_eye: