### PR TITLE
Implement configurable floating scroll behavior

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -167,10 +167,9 @@ enum edge_border_types {
 };
 
 enum floating_scroll_behavior {
-    FSB_GAPS_OUTER,     /**< Adjust outer gaps */
-    FSB_GAPS_INNER      /**< Adjust inner gaps */
-    // Note: in the future I expect to see more things you can do with the scroll
-    // wheel than maniuplating gaps
+	FSB_GAPS_OUTER,     /**< Adjust outer gaps */
+	FSB_GAPS_INNER,     /**< Adjust inner gaps */
+	FSB_CUSTOM          /**< Perform a user-defined action */
 };
 
 /**
@@ -191,7 +190,9 @@ struct sway_config {
 	uint32_t floating_mod;
 	uint32_t dragging_key;
 	uint32_t resizing_key;
-    enum floating_scroll_behavior floating_scroll; // TODO: command to set this
+	enum floating_scroll_behavior floating_scroll;
+    	char *fsb_up;
+	char *fsb_down;
 	enum swayc_layouts default_orientation;
 	enum swayc_layouts default_layout;
 	char *font;

--- a/include/config.h
+++ b/include/config.h
@@ -166,12 +166,6 @@ enum edge_border_types {
 	E_BOTH		/**< hide vertical and horizontal edge borders */
 };
 
-enum floating_scroll_behavior {
-	FSB_GAPS_OUTER,     /**< Adjust outer gaps */
-	FSB_GAPS_INNER,     /**< Adjust inner gaps */
-	FSB_CUSTOM          /**< Perform a user-defined action */
-};
-
 /**
  * The configuration struct. The result of loading a config file.
  */
@@ -190,9 +184,8 @@ struct sway_config {
 	uint32_t floating_mod;
 	uint32_t dragging_key;
 	uint32_t resizing_key;
-	enum floating_scroll_behavior floating_scroll;
-    	char *fsb_up;
-	char *fsb_down;
+    	char *floating_scroll_up_cmd;
+	char *floating_scroll_down_cmd;
 	enum swayc_layouts default_orientation;
 	enum swayc_layouts default_layout;
 	char *font;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -711,34 +711,19 @@ static struct cmd_results *cmd_floating_scroll(int argc, char **argv) {
 	if ((error = checkarg(argc, "floating_scroll", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
-	if (!strcasecmp("behavior", argv[0])) {
+	if (!strcasecmp("up", argv[0])) {
+		free(config->floating_scroll_up_cmd);
 		if (argc < 2) {
-			error = cmd_results_new(CMD_INVALID, "floating_scroll", "Insufficient parameters given");
-			return error;
-		}
-		if (!strcasecmp("gaps_inner", argv[1])) {
-			config->floating_scroll = FSB_GAPS_INNER;
-		} else if (!strcasecmp("gaps_outer", argv[1])) {
-			config->floating_scroll = FSB_GAPS_OUTER;
-		} else if (!strcasecmp("custom", argv[1])) {
-			config->floating_scroll = FSB_CUSTOM;
+			config->floating_scroll_up_cmd = strdup("");
 		} else {
-			error = cmd_results_new(CMD_INVALID, "floating_scroll", "Unknown behavior: '%s'", argv[1]);
-			return error;
-		}
-	} else if (!strcasecmp("up", argv[0])) {
-		free(config->fsb_up);
-		if (argc < 2) {
-			config->fsb_up = strdup("");
-		} else {
-			config->fsb_up = join_args(argv + 1, argc - 1);
+			config->floating_scroll_up_cmd = join_args(argv + 1, argc - 1);
 		}
 	} else if (!strcasecmp("down", argv[0])) {
-		free(config->fsb_down);
+		free(config->floating_scroll_down_cmd);
 		if (argc < 2) {
-			config->fsb_down = strdup("");
+			config->floating_scroll_down_cmd = strdup("");
 		} else {
-			config->fsb_down = join_args(argv + 1, argc - 1);
+			config->floating_scroll_down_cmd = join_args(argv + 1, argc - 1);
 		}
 	} else {
 		error = cmd_results_new(CMD_INVALID, "floating_scroll", "Unknown command: '%s'", argv[0]);

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -58,6 +58,7 @@ static sway_cmd cmd_exec_always;
 static sway_cmd cmd_exit;
 static sway_cmd cmd_floating;
 static sway_cmd cmd_floating_mod;
+static sway_cmd cmd_floating_scroll;
 static sway_cmd cmd_focus;
 static sway_cmd cmd_focus_follows_mouse;
 static sway_cmd cmd_font;
@@ -701,6 +702,47 @@ static struct cmd_results *cmd_floating_mod(int argc, char **argv) {
 			error = cmd_results_new(CMD_INVALID, "floating_modifier", "Invalid definition %s", argv[1]);
 			return error;
 		}
+	}
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}
+
+static struct cmd_results *cmd_floating_scroll(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "floating_scroll", EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+	if (!strcasecmp("behavior", argv[0])) {
+		if (argc < 2) {
+			error = cmd_results_new(CMD_INVALID, "floating_scroll", "Insufficient parameters given");
+			return error;
+		}
+		if (!strcasecmp("gaps_inner", argv[1])) {
+			config->floating_scroll = FSB_GAPS_INNER;
+		} else if (!strcasecmp("gaps_outer", argv[1])) {
+			config->floating_scroll = FSB_GAPS_OUTER;
+		} else if (!strcasecmp("custom", argv[1])) {
+			config->floating_scroll = FSB_CUSTOM;
+		} else {
+			error = cmd_results_new(CMD_INVALID, "floating_scroll", "Unknown behavior: '%s'", argv[1]);
+			return error;
+		}
+	} else if (!strcasecmp("up", argv[0])) {
+		free(config->fsb_up);
+		if (argc < 2) {
+			config->fsb_up = strdup("");
+		} else {
+			config->fsb_up = join_args(argv + 1, argc - 1);
+		}
+	} else if (!strcasecmp("down", argv[0])) {
+		free(config->fsb_down);
+		if (argc < 2) {
+			config->fsb_down = strdup("");
+		} else {
+			config->fsb_down = join_args(argv + 1, argc - 1);
+		}
+	} else {
+		error = cmd_results_new(CMD_INVALID, "floating_scroll", "Unknown command: '%s'", argv[0]);
+		return error;
 	}
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }
@@ -2377,6 +2419,7 @@ static struct cmd_handler handlers[] = {
 	{ "exit", cmd_exit },
 	{ "floating", cmd_floating },
 	{ "floating_modifier", cmd_floating_mod },
+	{ "floating_scroll", cmd_floating_scroll },
 	{ "focus", cmd_focus },
 	{ "focus_follows_mouse", cmd_focus_follows_mouse },
 	{ "font", cmd_font },

--- a/sway/config.c
+++ b/sway/config.c
@@ -131,6 +131,8 @@ void free_config(struct sway_config *config) {
 	list_free(config->active_bar_modifiers);
 	free_flat_list(config->config_chain);
 	free(config->font);
+	free(config->fsb_up);
+	free(config->fsb_down);
 	free(config);
 }
 
@@ -160,6 +162,8 @@ static void config_defaults(struct sway_config *config) {
 	config->dragging_key = M_LEFT_CLICK;
 	config->resizing_key = M_RIGHT_CLICK;
 	config->floating_scroll = FSB_GAPS_INNER;
+	config->fsb_up = strdup("");
+	config->fsb_down = strdup("");
 	config->default_layout = L_NONE;
 	config->default_orientation = L_NONE;
 	config->font = strdup("monospace 10");

--- a/sway/config.c
+++ b/sway/config.c
@@ -131,8 +131,8 @@ void free_config(struct sway_config *config) {
 	list_free(config->active_bar_modifiers);
 	free_flat_list(config->config_chain);
 	free(config->font);
-	free(config->fsb_up);
-	free(config->fsb_down);
+	free(config->floating_scroll_up_cmd);
+	free(config->floating_scroll_down_cmd);
 	free(config);
 }
 
@@ -161,9 +161,8 @@ static void config_defaults(struct sway_config *config) {
 	config->floating_mod = 0;
 	config->dragging_key = M_LEFT_CLICK;
 	config->resizing_key = M_RIGHT_CLICK;
-	config->floating_scroll = FSB_GAPS_INNER;
-	config->fsb_up = strdup("");
-	config->fsb_down = strdup("");
+	config->floating_scroll_up_cmd = strdup("");
+	config->floating_scroll_down_cmd = strdup("");
 	config->default_layout = L_NONE;
 	config->default_orientation = L_NONE;
 	config->font = strdup("monospace 10");

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -723,36 +723,11 @@ static bool handle_pointer_button(wlc_handle view, uint32_t time, const struct w
 bool handle_pointer_scroll(wlc_handle view, uint32_t time, const struct wlc_modifiers* modifiers,
 		uint8_t axis_bits, double _amount[2]) {
 	if (!(modifiers->mods ^ config->floating_mod)) {
-		switch (config->floating_scroll) {
-		case FSB_GAPS_INNER:
-		case FSB_GAPS_OUTER:
-			{
-				int amount = (int)_amount[0];
-				int i,j;
-				for (i = 0; i < root_container.children->length; ++i) {
-					swayc_t *op = root_container.children->items[i];
-					for (j = 0; j < op->children->length; ++j) {
-						swayc_t *ws = op->children->items[j];
-						if (config->floating_scroll == FSB_GAPS_INNER) {
-							container_map(ws, add_gaps, &amount);
-						} else {
-							ws->gaps += amount;
-						}
-					}
-				}
-				arrange_windows(&root_container, -1, -1);
-				break;
-			}
-		case FSB_CUSTOM:
-			{
-				int amount = (int)_amount[0];
-				if (amount > 0) {
-					handle_command(config->fsb_up);
-				} else if (amount < 0) {
-					handle_command(config->fsb_down);
-				}
-				break;
-			}
+		int amount = (int)_amount[0];
+		if (amount > 0) {
+			handle_command(config->floating_scroll_up_cmd);
+		} else if (amount < 0) {
+			handle_command(config->floating_scroll_down_cmd);
 		}
 	}
 	return EVENT_PASSTHROUGH;

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -743,6 +743,16 @@ bool handle_pointer_scroll(wlc_handle view, uint32_t time, const struct wlc_modi
 				arrange_windows(&root_container, -1, -1);
 				break;
 			}
+		case FSB_CUSTOM:
+			{
+				int amount = (int)_amount[0];
+				if (amount > 0) {
+					handle_command(config->fsb_up);
+				} else if (amount < 0) {
+					handle_command(config->fsb_down);
+				}
+				break;
+			}
 		}
 	}
 	return EVENT_PASSTHROUGH;

--- a/sway/sway.5.txt
+++ b/sway/sway.5.txt
@@ -156,17 +156,10 @@ or triggered at runtime.
 	enabled, left click is used for resizing and right click for dragging. The
 	mode paramenter is optional and defaults to _normal_ if it isn't defined.
 
-**floating_scroll** behavior <gaps_inner|gaps_outer|custom>::
-	If set to _gaps_inner_, adjusts inner gaps of the windows on scrolling
-	while holding the floating modifier. If set to _gaps_outer_, adjusts
-	outer gaps. If set to _custom_, performs user-defined commands,
-	specified in *floating_scroll up|down*.
-
 **floating_scroll** <up|down> [command]::
 	Sets the command to be executed on scrolling up and down
-	(respectively) while holding the floating modifier, when
-	*floating_scroll behavior* is set to _custom_. Resets the command,
-	when given none.
+	(respectively) while holding the floating modifier. Resets the
+	command, when given no arguments.
 
 **focus_follows_mouse** <yes|no>::
 	If set to _yes_, the currently focused view will change as you move your

--- a/sway/sway.5.txt
+++ b/sway/sway.5.txt
@@ -156,6 +156,18 @@ or triggered at runtime.
 	enabled, left click is used for resizing and right click for dragging. The
 	mode paramenter is optional and defaults to _normal_ if it isn't defined.
 
+**floating_scroll** behavior <gaps_inner|gaps_outer|custom>::
+	If set to _gaps_inner_, adjusts inner gaps of the windows on scrolling
+	while holding the floating modifier. If set to _gaps_outer_, adjusts
+	outer gaps. If set to _custom_, performs user-defined commands,
+	specified in *floating_scroll up|down*.
+
+**floating_scroll** <up|down> [command]::
+	Sets the command to be executed on scrolling up and down
+	(respectively) while holding the floating modifier, when
+	*floating_scroll behavior* is set to _custom_. Resets the command,
+	when given none.
+
 **focus_follows_mouse** <yes|no>::
 	If set to _yes_, the currently focused view will change as you move your
 	mouse around the screen to the view that ends up underneath your mouse.


### PR DESCRIPTION
This PR implements configurable floating scroll behavior (it adds a command to set it, and additionally it adds another possible behavior to existant ones: run a user-defined sway command).
I'm having trouble documenting it according to the conventions though: I have know idea how shall the specification look like.
The command is 'floating_scroll', and it accepts three possible parameters: behavior, to set behavior, up and down, to set a command to run.