### PR TITLE
sway/container.c: fix segfault where view is assigned prematurely

### DIFF
--- a/sway/container.c
+++ b/sway/container.c
@@ -820,10 +820,10 @@ swayc_t *swayc_tabbed_stacked_parent(swayc_t *view) {
 		return NULL;
 	}
 	do {
-		view = view->parent;
 		if (view->layout == L_TABBED || view->layout == L_STACKED) {
 			parent = view;
 		}
+		view = view->parent;
 	} while (view && view->type != C_WORKSPACE);
 
 	return parent;


### PR DESCRIPTION
When trying to split with an empty workspace, it segfaults on `view->layout` because `view->parent` becomes null.

This should fix #640, thanks to @jpml-