### PR TITLE
Fix borders for tabbed and stacked containers when children have 'border none' set.

### DIFF
--- a/sway/border.c
+++ b/sway/border.c
@@ -402,7 +402,13 @@ void update_view_border(swayc_t *view) {
 void render_view_borders(wlc_handle view) {
 	swayc_t *c = swayc_by_handle(view);
 
-	if (!c || c->border_type == B_NONE) {
+
+	// emulate i3 behavior for drawing borders for tabbed and stacked layouts:
+	// if we are not the only child in the container, always draw borders,
+	// regardless of the border setting on the individual view
+	if (!c || (c->border_type == B_NONE
+			&& !((c->parent->layout == L_TABBED || c->parent->layout == L_STACKED)
+				&& c->parent->children->length > 1))) {
 		return;
 	}
 

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -594,7 +594,7 @@ void update_geometry(swayc_t *container) {
 
 		int title_bar_height = config->font_height + 4; //borders + padding
 
-		if (parent->layout == L_TABBED) {
+		if (parent->layout == L_TABBED && parent->children->length > 1) {
 			int i, x = 0, w, l, r;
 			l = parent->children->length;
 			w = geometry.size.w / l;
@@ -625,7 +625,7 @@ void update_geometry(swayc_t *container) {
 			geometry.size.w -= (border_left + border_right);
 			geometry.size.h -= (border_bottom + title_bar.size.h);
 			container->title_bar_geometry = title_bar;
-		} else if (parent->layout == L_STACKED) {
+		} else if (parent->layout == L_STACKED && parent->children->length > 1) {
 			int i, y = 0;
 			for (i = 0; i < parent->children->length; ++i) {
 				swayc_t *view = parent->children->items[i];


### PR DESCRIPTION
Borders are now drawn correctly (same behavior as i3) for tabbed and
stacked containers, when the children have 'border none' set.

Closes #661 
