### PR TITLE
Rearrange output when setting background

### DIFF
--- a/sway/extensions.c
+++ b/sway/extensions.c
@@ -78,6 +78,7 @@ static void set_background(struct wl_client *client, struct wl_resource *resourc
 	config->wl_surface_res = surface;
 	list_add(desktop_shell.backgrounds, config);
 	wl_resource_set_destructor(surface, background_surface_destructor);
+	arrange_windows(swayc_by_handle(output), -1, -1);
 	wlc_output_schedule_render(config->output);
 }
 

--- a/sway/extensions.c
+++ b/sway/extensions.c
@@ -83,7 +83,7 @@ static void set_background(struct wl_client *client, struct wl_resource *resourc
 }
 
 static void set_panel(struct wl_client *client, struct wl_resource *resource,
-			  struct wl_resource *_output, struct wl_resource *surface) {
+		struct wl_resource *_output, struct wl_resource *surface) {
 	wlc_handle output = wlc_handle_from_wl_output_resource(_output);
 	if (!output) {
 		return;


### PR DESCRIPTION
When setting the background we need to rearrange the output otherwise the swaybar won't be arranged as it should.

Fix #659