### PR TITLE
2 minor things

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ available for you to install:
 
 * [Arch Linux](https://www.archlinux.org/packages/?q=sway)
 * [Gentoo](https://packages.gentoo.org/packages/dev-libs/sway)
+* [openSUSE Tumbleweed](https://software.opensuse.org/package/sway)
 
 For other distros, [see this wiki page](https://github.com/SirCmpwn/sway/wiki/Install-on-other-distros).
 If you're interested in packaging Sway for your distribution, stop by the IRC

--- a/include/commands.h
+++ b/include/commands.h
@@ -59,6 +59,6 @@ void free_cmd_results(struct cmd_results *results);
  */
 const char *cmd_results_to_json(struct cmd_results *results);
 
-void remove_view_from_scratchpad();
+void remove_view_from_scratchpad(swayc_t *);
 
 #endif


### PR DESCRIPTION
1. add openSUSE into README.md
2. header contained `remove_view_from_scratchpad()` with wrong prototype
