### PR TITLE
set focus on fullscreen view when changing focus

### DIFF
--- a/sway/focus.c
+++ b/sway/focus.c
@@ -88,7 +88,7 @@ swayc_t *get_focused_container(swayc_t *parent) {
 	if (!parent) {
 		return swayc_active_workspace();
 	}
-	// get focusde container
+	// get focused container
 	while (!parent->is_focused && parent->focused) {
 		parent = parent->focused;
 	}
@@ -112,7 +112,9 @@ bool set_focused_container(swayc_t *c) {
 	swayc_t *focused = get_focused_view(workspace);
 	// if the workspace we are changing focus to has a fullscreen view return
 	if (swayc_is_fullscreen(focused) && focused != c) {
-		return false;
+		// if switching to a workspace with a fullscreen view,
+		// focus on the fullscreen view
+		c = focused;
 	}
 
 	// update container focus from here to root, making necessary changes along
@@ -192,7 +194,7 @@ bool set_focused_container_for(swayc_t *a, swayc_t *c) {
 		return false;
 	}
 
-	// Check if we changing a parent container that will see chnage
+	// Check if we are changing a parent container that will see change
 	bool effective = true;
 	while (find != &root_container) {
 		if (find->parent->focused != find) {


### PR DESCRIPTION
Please note this will require careful review; I'm just learning C and also I'm pretty sure the way I did this is really dumb. I'm not familiar enough with the codebase to know if it will break other things.

Assume the following view/monitor setup:

      monitor 1       monitor 2
    +-----------+   +-----------+
    |A          |   |D          |
    |           |   |           |
    +-----+-----+   |           |
    |B    |C    |   |           |
    |     |     |   |           |
    +-----+-----+   +-----------+

If view A is set to full screen, and focus is on view D, `focus left` will not change focus to A - instead Sway will attempt to focus on C, find that A is full screen, and return without changing focus.

This patch changes the behavior of `set_focused_container()` so that when focus is shifted to a workspace with a full screen view, that view will be focused; in this example, `focus left` will move from view D to view A (which is full screen).

(I also fixed a couple typos in unrelated comments.)

