### PR TITLE
enforce workspace output assignents

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -2325,7 +2325,7 @@ static struct cmd_results *cmd_workspace(int argc, char **argv) {
 		// Handle workspace next/prev
 		swayc_t *ws = NULL;
 		if (argc == 2) {
-			if (!(ws=workspace_by_number(argv[1]))) {
+			if (!(ws = workspace_by_number(argv[1]))) {
 				ws = workspace_create(argv[1]);
 			}
 		} else if (strcasecmp(argv[0], "next") == 0) {

--- a/sway/focus.c
+++ b/sway/focus.c
@@ -110,7 +110,7 @@ bool set_focused_container(swayc_t *c) {
 	// Get workspace for c, get that workspaces current focused container.
 	swayc_t *workspace = swayc_active_workspace_for(c);
 	swayc_t *focused = get_focused_view(workspace);
-	// if the workspace we are changing focus to has a fullscreen view return
+
 	if (swayc_is_fullscreen(focused) && focused != c) {
 		// if switching to a workspace with a fullscreen view,
 		// focus on the fullscreen view


### PR DESCRIPTION
This solves a pain point I have. I assign workspaces 1-6 to my left monitor, 7-12 to my right. When I turn my monitors back on after being off, all workspaces end up on my left monitor, even 7-12. This commit changes the `new_output()` function so that when an output is being created, if there are workspaces that are assigned to that output on some other output, they are moved to the new (assigned) output.

(also included is a minor formatting fix and removal of a comment that is no longer applicable - neither is related to the aforementioned functionality)