### PR TITLE
Initial work for floating view with sane values

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -226,6 +226,12 @@ struct sway_config {
 		struct border_colors placeholder;
 		uint32_t background;
 	} border_colors;
+
+	// floating view minimum
+	int32_t floating_maximum_width;
+	int32_t floating_maximum_height;
+	int32_t floating_minimum_width;
+	int32_t floating_minimum_height;
 };
 
 /**

--- a/include/container.h
+++ b/include/container.h
@@ -168,6 +168,8 @@ swayc_t *new_view(swayc_t *sibling, wlc_handle handle);
  */
 swayc_t *new_floating_view(wlc_handle handle);
 
+void floating_view_sane_size(swayc_t *view);
+
 /**
  * Frees an output's container.
  */

--- a/sway/config.c
+++ b/sway/config.c
@@ -172,6 +172,12 @@ static void config_defaults(struct sway_config *config) {
 	config->font = strdup("monospace 10");
 	config->font_height = get_font_text_height(config->font);
 
+	// floating view
+	config->floating_maximum_width = -1;
+	config->floating_maximum_height = -1;
+	config->floating_minimum_width = 75;
+	config->floating_minimum_height = 50;
+
 	// Flags
 	config->focus_follows_mouse = true;
 	config->mouse_warping = true;

--- a/sway/container.c
+++ b/sway/container.c
@@ -328,6 +328,31 @@ swayc_t *new_floating_view(wlc_handle handle) {
 	return view;
 }
 
+void floating_view_sane_size(swayc_t *view) {
+	if (config->floating_minimum_height != -1 &&
+		view->desired_height < config->floating_minimum_height) {
+		view->desired_height = config->floating_minimum_height;
+	}
+	if (config->floating_minimum_width != -1 &&
+		view->desired_width < config->floating_minimum_width) {
+		view->desired_width = config->floating_minimum_width;
+	}
+
+	if (config->floating_maximum_height != -1 &&
+		view->desired_height > config->floating_maximum_height) {
+		view->desired_height = config->floating_maximum_height;
+	}
+	if (config->floating_maximum_width != -1 &&
+		view->desired_width > config->floating_maximum_width) {
+		view->desired_width = config->floating_maximum_width;
+	}
+	sway_log(L_DEBUG, "Sane values for view to %d x %d @ %.f, %.f", 
+		view->desired_width, view->desired_height, view->x, view->y);
+
+	return;
+}
+
+
 // Destroy container
 
 swayc_t *destroy_output(swayc_t *output) {

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -350,6 +350,7 @@ static void handle_view_geometry_request(wlc_handle handle, const struct wlc_geo
 		view->desired_height = geometry->size.h;
 
 		if (view->is_floating) {
+			floating_view_sane_size(view);
 			view->width = view->desired_width;
 			view->height = view->desired_height;
 			view->x = geometry->origin.x;


### PR DESCRIPTION
This patch includes a initial work for these options:
floating_maximum_width
floating_maximum_height
floating_minimum_width
floating_minimum_height

It also sets sane values for the floating windows, avoiding 1x1 windows caused by wlc.