### PR TITLE
Variables related fixes

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -2152,6 +2152,10 @@ static struct cmd_results *cmd_set(int argc, char **argv) {
 		return error;
 	}
 
+    if (argv[0][0] != '$') {
+        return cmd_results_new(CMD_FAILURE, "set", "Malformed variable assignment, name has to start with $");
+    }
+
 	struct sway_variable *var = NULL;
 	// Find old variable if it exists
 	int i;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -2152,9 +2152,9 @@ static struct cmd_results *cmd_set(int argc, char **argv) {
 		return error;
 	}
 
-    if (argv[0][0] != '$') {
-        return cmd_results_new(CMD_FAILURE, "set", "Malformed variable assignment, name has to start with $");
-    }
+	if (argv[0][0] != '$') {
+		return cmd_results_new(CMD_FAILURE, "set", "Malformed variable assignment, name has to start with $");
+	}
 
 	struct sway_variable *var = NULL;
 	// Find old variable if it exists

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -1632,7 +1632,7 @@ static struct cmd_results *cmd_output(int argc, char **argv) {
 			}
 			char *src = join_args(argv + i, argc - i - 1);
 			char *mode = argv[argc - 1];
-			if (wordexp(src, &p, 0) != 0) {
+			if (wordexp(src, &p, 0) != 0 || p.we_wordv[0] == NULL) {
 				return cmd_results_new(CMD_INVALID, "output", "Invalid syntax (%s)", src);
 			}
 			free(src);

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -2146,6 +2146,8 @@ static int compare_set_qsort(const void *_l, const void *_r) {
 }
 
 static struct cmd_results *cmd_set(int argc, char **argv) {
+	char *tmp;
+	int size;
 	struct cmd_results *error = NULL;
 	if (!config->reading) return cmd_results_new(CMD_FAILURE, "set", "Can only be used in config file.");
 	if ((error = checkarg(argc, "set", EXPECTED_AT_LEAST, 2))) {
@@ -2153,7 +2155,15 @@ static struct cmd_results *cmd_set(int argc, char **argv) {
 	}
 
 	if (argv[0][0] != '$') {
-		return cmd_results_new(CMD_FAILURE, "set", "Malformed variable assignment, name has to start with $");
+		sway_log(L_INFO, "Warning: variable '%s' doesn't start with $", argv[0]);
+
+		size = asprintf(&tmp, "%s%s", "$", argv[0]);
+		if (size == -1) {
+			return cmd_results_new(CMD_FAILURE, "set", "Not possible to create variable $'%s'", argv[0]);
+		}
+
+		argv[0] = strdup(tmp);
+		free(tmp);
 	}
 
 	struct sway_variable *var = NULL;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -3047,7 +3047,7 @@ static struct cmd_results *bar_cmd_swaybar_command(int argc, char **argv) {
 }
 
 static struct cmd_results *bar_cmd_tray_output(int argc, char **argv) {
-	sway_log(L_ERROR, "warning: tray_output is not supported on wayland");
+	sway_log(L_ERROR, "Warning: tray_output is not supported on wayland");
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }
 


### PR DESCRIPTION
This includes the check of the $ for the variable assigned.
So set something /home generates an error, since the correct syntax must be set $something /home.
This also should fix partially the issue #681 since now it handles the undefined behavior of p.we_wordv.