### PR TITLE
messy start of a fix for #462

### DIFF
--- a/common/util.c
+++ b/common/util.c
@@ -74,30 +74,22 @@ pid_t get_parent_pid(pid_t child) {
 	char file_name[100];
 	char *buffer = NULL;
 	char *token = NULL;
-	const char sep[2] = " ";
+	const char *sep = " ";
 	FILE *stat = NULL;
-
-	sway_log(L_DEBUG, "trying to get parent pid for child pid %d", child);
 
 	sprintf(file_name, "/proc/%d/stat", child);
 
-	if (!(stat = fopen(file_name, "r")) || !(buffer = read_line(stat))) {
-		return -1;
+	if ((stat = fopen(file_name, "r")) && (buffer = read_line(stat))) {
+		fclose(stat);
+
+		token = strtok(buffer, sep); // pid
+		token = strtok(NULL, sep);   // executable name
+		token = strtok(NULL, sep);   // state
+		token = strtok(NULL, sep);   // parent pid
+
+		parent = strtol(token, NULL, 10);
+		return (parent == child) ? -1 : parent;
 	}
 
-	fclose(stat);
-
-	sway_log(L_DEBUG, "buffer string is %s", buffer);
-
-	token = strtok(buffer, sep);
-
-	for (int i = 0; i < 3; i++) {
-		token = strtok(NULL, sep);
-	}
-
-	parent = strtol(token, NULL, 10);
-
-	sway_log(L_DEBUG, "found parent pid %d for child pid %d", parent, child);
-
-	return (parent == child) ? -1 : parent;
+	return -1;
 }

--- a/include/config.h
+++ b/include/config.h
@@ -92,6 +92,13 @@ struct workspace_output {
 	char *workspace;
 };
 
+struct pid_workspace {
+	pid_t *pid;
+	char *workspace;
+};
+
+void free_pid_workspace(struct pid_workspace *pw);
+
 struct bar_config {
 	/**
 	 * One of "dock", "hide", "invisible"
@@ -175,6 +182,7 @@ struct sway_config {
 	list_t *bars;
 	list_t *cmd_queue;
 	list_t *workspace_outputs;
+	list_t *pid_workspaces;
 	list_t *output_configs;
 	list_t *input_configs;
 	list_t *criteria;

--- a/include/config.h
+++ b/include/config.h
@@ -1,11 +1,14 @@
 #ifndef _SWAY_CONFIG_H
 #define _SWAY_CONFIG_H
 
+#define PID_WORKSPACE_TIMEOUT 60
+
 #include <libinput.h>
 #include <stdint.h>
 #include <wlc/geometry.h>
 #include <wlc/wlc.h>
 #include <xkbcommon/xkbcommon.h>
+#include <time.h>
 #include "wayland-desktop-shell-server-protocol.h"
 #include "list.h"
 #include "layout.h"
@@ -95,8 +98,10 @@ struct workspace_output {
 struct pid_workspace {
 	pid_t *pid;
 	char *workspace;
+	time_t *time_added;
 };
 
+void pid_workspace_add(struct pid_workspace *pw);
 void free_pid_workspace(struct pid_workspace *pw);
 
 struct bar_config {

--- a/include/util.h
+++ b/include/util.h
@@ -2,6 +2,7 @@
 #define _SWAY_UTIL_H
 
 #include <stdint.h>
+#include <unistd.h>
 #include <wlc/wlc.h>
 #include <xkbcommon/xkbcommon.h>
 
@@ -35,5 +36,12 @@ const char *get_modifier_name_by_mask(uint32_t modifier);
  * Populates the names array and return the number of names added.
  */
 int get_modifier_names(const char **names, uint32_t modifier_masks);
+
+/**
+ * Get the pid of a parent process given the pid of a child process.
+ *
+ * Returns the parent pid or NULL if the parent pid cannot be determined.
+ */
+pid_t get_parent_pid(pid_t pid);
 
 #endif

--- a/include/workspace.h
+++ b/include/workspace.h
@@ -2,6 +2,7 @@
 #define _SWAY_WORKSPACE_H
 
 #include <wlc/wlc.h>
+#include <unistd.h>
 #include "list.h"
 #include "layout.h"
 
@@ -16,5 +17,6 @@ swayc_t *workspace_output_next();
 swayc_t *workspace_next();
 swayc_t *workspace_output_prev();
 swayc_t *workspace_prev();
+swayc_t *workspace_for_pid(pid_t pid);
 
 #endif

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -555,7 +555,7 @@ static struct cmd_results *cmd_exec_always(int argc, char **argv) {
 		struct pid_workspace *pw = malloc(sizeof(struct pid_workspace));
 		pw->pid = child;
 		pw->workspace = strdup(ws->name);
-		list_add(config->pid_workspaces, pw);
+		pid_workspace_add(pw);
 		// TODO: keep track of this pid and open the corresponding view on the current workspace
 		// blocked pending feature in wlc
 	} else {

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -549,12 +549,19 @@ static struct cmd_results *cmd_exec_always(int argc, char **argv) {
 	close(fd[0]);
 	// cleanup child process
 	wait(0);
-	if (*child > 0) {
-		sway_log(L_DEBUG, "Child process created with pid %d", *child);
+	swayc_t *ws = swayc_active_workspace();
+	if (*child > 0 && ws) {
+		sway_log(L_DEBUG, "Child process created with pid %d for workspace %s", *child, ws->name);
+		struct pid_workspace *pw = malloc(sizeof(struct pid_workspace));
+		pw->pid = child;
+		pw->workspace = strdup(ws->name);
+		list_add(config->pid_workspaces, pw);
 		// TODO: keep track of this pid and open the corresponding view on the current workspace
 		// blocked pending feature in wlc
+	} else {
+		free(child);
 	}
-	free(child);
+
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }
 

--- a/sway/config.c
+++ b/sway/config.c
@@ -89,6 +89,15 @@ static void free_workspace_output(struct workspace_output *wo) {
 	free(wo);
 }
 
+void free_pid_workspace(struct pid_workspace *pw) {
+	if (!pw) {
+		return;
+	}
+	free(pw->pid);
+	free(pw->workspace);
+	free(pw);
+}
+
 void free_config(struct sway_config *config) {
 	int i;
 	for (i = 0; i < config->symbols->length; ++i) {
@@ -112,6 +121,11 @@ void free_config(struct sway_config *config) {
 		free_workspace_output(config->workspace_outputs->items[i]);
 	}
 	list_free(config->workspace_outputs);
+
+	for (i = 0; i < config->pid_workspaces->length; ++i) {
+		free_pid_workspace(config->pid_workspaces->items[i]);
+	}
+	list_free(config->pid_workspaces);
 
 	for (i = 0; i < config->criteria->length; ++i) {
 		free_criteria(config->criteria->items[i]);
@@ -148,6 +162,7 @@ static void config_defaults(struct sway_config *config) {
 	config->modes = create_list();
 	config->bars = create_list();
 	config->workspace_outputs = create_list();
+	config->pid_workspaces = create_list();
 	config->criteria = create_list();
 	config->input_configs = create_list();
 	config->output_configs = create_list();

--- a/sway/workspace.c
+++ b/sway/workspace.c
@@ -322,7 +322,7 @@ swayc_t *workspace_for_pid(pid_t pid) {
 	// sway_log(L_DEBUG, "all pid_workspaces");
 	// for (int k = 0; k < config->pid_workspaces->length; k++) {
 	// 	pw = config->pid_workspaces->items[k];
-	// 	sway_log(L_DEBUG, "pid %d workspace %s", *pw->pid, pw->workspace);
+	// 	sway_log(L_DEBUG, "pid %d workspace %s time_added %li", *pw->pid, pw->workspace, *pw->time_added);
 	// }
 
 	do {
@@ -352,13 +352,12 @@ swayc_t *workspace_for_pid(pid_t pid) {
 		ws = workspace_by_name(pw->workspace);
 
 		if (!ws) {
-			sway_log(L_DEBUG, "creating workspace %s because it disappeared", pw->workspace);
+			sway_log(L_DEBUG, "Creating workspace %s for pid %d because it disappeared", pw->workspace, pid);
 			ws = workspace_create(pw->workspace);
 		}
 
 		list_del(config->pid_workspaces, i);
 	}
 
-	free_pid_workspace(pw);
 	return ws;
 }

--- a/sway/workspace.c
+++ b/sway/workspace.c
@@ -5,6 +5,7 @@
 #include <wlc/wlc.h>
 #include <string.h>
 #include <strings.h>
+#include <sys/types.h>
 #include "ipc-server.h"
 #include "workspace.h"
 #include "layout.h"
@@ -308,4 +309,56 @@ bool workspace_switch(swayc_t *workspace) {
 	swayc_t *output = swayc_parent_by_type(workspace, C_OUTPUT);
 	arrange_windows(output, -1, -1);
 	return true;
+}
+
+swayc_t *workspace_for_pid(pid_t pid) {
+	int i;
+	swayc_t *ws = NULL;
+	struct pid_workspace *pw = NULL;
+
+	sway_log(L_DEBUG, "looking for workspace for pid %d", pid);
+
+	// leaving this here as it's useful for debugging
+	// sway_log(L_DEBUG, "all pid_workspaces");
+	// for (int k = 0; k < config->pid_workspaces->length; k++) {
+	// 	pw = config->pid_workspaces->items[k];
+	// 	sway_log(L_DEBUG, "pid %d workspace %s", *pw->pid, pw->workspace);
+	// }
+
+	do {
+		for (i = 0; i < config->pid_workspaces->length; i++) {
+			pw = config->pid_workspaces->items[i];
+			pid_t *pw_pid = pw->pid;
+
+			if (pid == *pw_pid) {
+				sway_log(L_DEBUG, "found pid_workspace for pid %d, workspace %s", pid, pw->workspace);
+				break; // out of for loop
+			}
+
+			pw = NULL;
+		}
+
+		if (pw) {
+			break; // out of do-while loop
+		}
+
+		pid = get_parent_pid(pid);
+		// no sense in looking for matches for pid 0.
+		// also, if pid == getpid(), that is the compositor's
+		// pid, which definitely isn't helpful
+	} while (pid > 0 && pid != getpid());
+
+	if (pw) {
+		ws = workspace_by_name(pw->workspace);
+
+		if (!ws) {
+			sway_log(L_DEBUG, "creating workspace %s because it disappeared", pw->workspace);
+			ws = workspace_create(pw->workspace);
+		}
+
+		list_del(config->pid_workspaces, i);
+	}
+
+	free_pid_workspace(pw);
+	return ws;
 }


### PR DESCRIPTION
This PR is mostly for discussion - it still needs work even if you want to merge it. This is a (very messy) start on a potential fix for #462, however the problem is it's not that useful for two reasons:

1. If the app is a client-server-style app, like gnome-terminal for example, the pid we get from the view is probably the pid of the client, but the pid we're looking for is that of the original process, which could be the server.
2. This only works on Wayland apps. [`wl_client_get_credentials()`](https://people.freedesktop.org/~whot/wayland-doxygen/wayland/Server/structwl__client.html#a82a97cb3a66c1c56826a09a7b42453d9) returns the pid of the compositor if the forked process is connected through `socketpair()`, which is how WLC handles xwayland processes. Obviously the compositor's pid is not going to match anything.

This clearly needs some cleanup, and I need to add some code to keep focus on whatever it's on if we've changed workspaces, but it's a start.