### PR TITLE
couple small fixes

### DIFF
--- a/common/util.c
+++ b/common/util.c
@@ -70,7 +70,7 @@ int get_modifier_names(const char **names, uint32_t modifier_masks) {
 }
 
 pid_t get_parent_pid(pid_t child) {
-	pid_t parent;
+	pid_t parent = -1;
 	char file_name[100];
 	char *buffer = NULL;
 	char *token = NULL;
@@ -79,15 +79,19 @@ pid_t get_parent_pid(pid_t child) {
 
 	sprintf(file_name, "/proc/%d/stat", child);
 
-	if ((stat = fopen(file_name, "r")) && (buffer = read_line(stat))) {
+	if ((stat = fopen(file_name, "r"))) {
+		if ((buffer = read_line(stat))) {
+			token = strtok(buffer, sep); // pid
+			token = strtok(NULL, sep);   // executable name
+			token = strtok(NULL, sep);   // state
+			token = strtok(NULL, sep);   // parent pid
+			parent = strtol(token, NULL, 10);
+		}
+
 		fclose(stat);
+	}
 
-		token = strtok(buffer, sep); // pid
-		token = strtok(NULL, sep);   // executable name
-		token = strtok(NULL, sep);   // state
-		token = strtok(NULL, sep);   // parent pid
-
-		parent = strtol(token, NULL, 10);
+	if (parent) {
 		return (parent == child) ? -1 : parent;
 	}
 

--- a/sway/config.c
+++ b/sway/config.c
@@ -101,6 +101,7 @@ static void pid_workspace_cleanup() {
 		pw = config->pid_workspaces->items[i];
 
 		if (difftime(ts.tv_sec, *pw->time_added) >= PID_WORKSPACE_TIMEOUT) {
+			free_pid_workspace(config->pid_workspaces->items[i]);
 			list_del(config->pid_workspaces, i);
 		}
 	}
@@ -126,6 +127,7 @@ void pid_workspace_add(struct pid_workspace *pw) {
 		list_pw = config->pid_workspaces->items[i];
 
 		if (pw->pid == list_pw->pid) {
+			free_pid_workspace(config->pid_workspaces->items[i]);
 			list_del(config->pid_workspaces, i);
 		}
 	}


### PR DESCRIPTION
Sorry for the post-merge update but I found a couple small things that needed to be fixed. In util.c, if `fopen()` worked but `read_line()` failed, the file wouldn't get closed. And in the `config->pid_workspaces` cleanup, I forgot to free the items before deleting them from the list.