### PR TITLE
Added a null check in tabbed_stacked_parent

### DIFF
--- a/sway/container.c
+++ b/sway/container.c
@@ -853,12 +853,12 @@ swayc_t *swayc_tabbed_stacked_parent(swayc_t *view) {
 	if (!ASSERT_NONNULL(view)) {
 		return NULL;
 	}
-	do {
+	while (view->type != C_WORKSPACE && view->parent) {
 		view = view->parent;
 		if (view->layout == L_TABBED || view->layout == L_STACKED) {
 			parent = view;
 		}
-	} while (view && view->type != C_WORKSPACE);
+	}
 
 	return parent;
 }


### PR DESCRIPTION
This fixes a segfault, when trying to get parent of the workspace/root container/(?), as it is not assuered that the view's parent node is not null in the loop.

For example, when performing `split` on a workspace.