### PR TITLE
Bug fix: Add missing header file, unistd.h

### DIFF
--- a/swaylock/main.c
+++ b/swaylock/main.c
@@ -11,6 +11,7 @@
 #include <getopt.h>
 #include <signal.h>
 #include <stdbool.h>
+#include <unistd.h>
 
 #include "client/window.h"
 #include "client/registry.h"


### PR DESCRIPTION
Without unistd.h the following functions getuid, alarm and
close are implicitly declared causing compilation to fail due to
-Werror=implicit-function-declaration