### PR TITLE
Minor cleanup in log.c

### DIFF
--- a/common/log.c
+++ b/common/log.c
@@ -8,8 +8,6 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <signal.h>
-#include <errno.h>
-#include <string.h>
 #include <stringop.h>
 
 int colored = 1;
@@ -82,32 +80,6 @@ void _sway_log(const char *filename, int line, log_importance_t verbosity, const
 		va_start(args, format);
 		vfprintf(stderr, format, args);
 		va_end(args);
-
-		if (colored && isatty(STDERR_FILENO)) {
-			fprintf(stderr, "\x1B[0m");
-		}
-		fprintf(stderr, "\n");
-	}
-}
-
-void sway_log_errno(log_importance_t verbosity, char* format, ...) {
-	if (verbosity <= v) {
-		unsigned int c = verbosity;
-		if (c > sizeof(verbosity_colors) / sizeof(char *) - 1) {
-			c = sizeof(verbosity_colors) / sizeof(char *) - 1;
-		}
-
-		if (colored && isatty(STDERR_FILENO)) {
-			fprintf(stderr, "%s", verbosity_colors[c]);
-		}
-
-		va_list args;
-		va_start(args, format);
-		vfprintf(stderr, format, args);
-		va_end(args);
-
-		fprintf(stderr, ": ");
-		fprintf(stderr, "%s", strerror(errno));
 
 		if (colored && isatty(STDERR_FILENO)) {
 			fprintf(stderr, "\x1B[0m");

--- a/common/log.c
+++ b/common/log.c
@@ -10,9 +10,9 @@
 #include <signal.h>
 #include <stringop.h>
 
-int colored = 1;
-log_importance_t loglevel_default = L_ERROR;
-log_importance_t v = L_SILENT;
+static int colored = 1;
+static log_importance_t loglevel_default = L_ERROR;
+static log_importance_t v = L_SILENT;
 
 static const char *verbosity_colors[] = {
 	[L_SILENT] = "",
@@ -34,6 +34,10 @@ void init_log(log_importance_t verbosity) {
 
 void set_log_level(log_importance_t verbosity) {
 	v = verbosity;
+}
+
+log_importance_t get_log_level(void) {
+        return v;
 }
 
 void reset_log_level(void) {

--- a/include/log.h
+++ b/include/log.h
@@ -1,6 +1,8 @@
 #ifndef _SWAY_LOG_H
 #define _SWAY_LOG_H
 #include <stdbool.h>
+#include <errno.h>
+#include <string.h>
 
 typedef enum {
 	L_SILENT = 0,
@@ -15,7 +17,6 @@ void reset_log_level(void);
 // returns whether debug logging is on after switching.
 bool toggle_debug_logging(void);
 void sway_log_colors(int mode);
-void sway_log_errno(log_importance_t verbosity, char* format, ...) __attribute__((format(printf,2,3)));
 void sway_abort(const char* format, ...) __attribute__((format(printf,1,2)));
 
 bool _sway_assert(bool condition, const char* format, ...) __attribute__((format(printf,2,3)));
@@ -31,6 +32,9 @@ void _sway_log(const char *filename, int line, log_importance_t verbosity, const
 #define sway_log(VERBOSITY, FMT, ...) \
 	_sway_log(NULL, 0, VERBOSITY, FMT, ##__VA_ARGS__)
 #endif
+
+#define sway_log_errno(VERBOSITY, FMT, ...) \
+        _sway_log(NULL, 0, VERBOSITY, FMT ": %s", ##__VA_ARGS__, strerror(errno))
 
 void error_handler(int sig);
 

--- a/include/log.h
+++ b/include/log.h
@@ -13,6 +13,7 @@ typedef enum {
 
 void init_log(log_importance_t verbosity);
 void set_log_level(log_importance_t verbosity);
+log_importance_t get_log_level(void);
 void reset_log_level(void);
 // returns whether debug logging is on after switching.
 bool toggle_debug_logging(void);

--- a/sway/debug_log.c
+++ b/sway/debug_log.c
@@ -12,8 +12,6 @@
 #include <stringop.h>
 #include "workspace.h"
 
-extern log_importance_t v;
-
 /* XXX:DEBUG:XXX */
 static void container_log(const swayc_t *c, int depth) {
 	fprintf(stderr, "focus:%c",
@@ -49,7 +47,7 @@ static void container_log(const swayc_t *c, int depth) {
 	fprintf(stderr, "name:%.16s\n", c->name);
 }
 void layout_log(const swayc_t *c, int depth) {
-	if (L_DEBUG > v) return;
+	if (L_DEBUG > get_log_level()) return;
 	int i, d;
 	int e = c->children ? c->children->length : 0;
 	container_log(c, depth);


### PR DESCRIPTION
Implement sway_log_errno using _sway_log to reduce code duplication. I'm not sure how you feel about adding additional headers (string.h and errno.h) to include/log.h. Tested by temporarily adding a call to sway_log_errno in main() and ensured that the log output was the same as before the change.