### PR TITLE
Add get_log_level() to encapsulate v (current log level)

### DIFF
--- a/common/log.c
+++ b/common/log.c
@@ -12,9 +12,9 @@
 #include <string.h>
 #include <stringop.h>
 
-int colored = 1;
-log_importance_t loglevel_default = L_ERROR;
-log_importance_t v = L_SILENT;
+static int colored = 1;
+static log_importance_t loglevel_default = L_ERROR;
+static log_importance_t v = L_SILENT;
 
 static const char *verbosity_colors[] = {
 	[L_SILENT] = "",
@@ -36,6 +36,10 @@ void init_log(log_importance_t verbosity) {
 
 void set_log_level(log_importance_t verbosity) {
 	v = verbosity;
+}
+
+log_importance_t get_log_level(void) {
+        return v;
 }
 
 void reset_log_level(void) {

--- a/include/log.h
+++ b/include/log.h
@@ -11,6 +11,7 @@ typedef enum {
 
 void init_log(log_importance_t verbosity);
 void set_log_level(log_importance_t verbosity);
+log_importance_t get_log_level(void);
 void reset_log_level(void);
 // returns whether debug logging is on after switching.
 bool toggle_debug_logging(void);

--- a/sway/debug_log.c
+++ b/sway/debug_log.c
@@ -12,8 +12,6 @@
 #include <stringop.h>
 #include "workspace.h"
 
-extern log_importance_t v;
-
 /* XXX:DEBUG:XXX */
 static void container_log(const swayc_t *c, int depth) {
 	fprintf(stderr, "focus:%c",
@@ -49,7 +47,7 @@ static void container_log(const swayc_t *c, int depth) {
 	fprintf(stderr, "name:%.16s\n", c->name);
 }
 void layout_log(const swayc_t *c, int depth) {
-	if (L_DEBUG > v) return;
+	if (L_DEBUG > get_log_level()) return;
 	int i, d;
 	int e = c->children ? c->children->length : 0;
 	container_log(c, depth);


### PR DESCRIPTION
This patch also makes all global variable in log.c static.