### PR TITLE
swaybar: Only establish a single connection with sway

### DIFF
--- a/include/client/window.h
+++ b/include/client/window.h
@@ -42,5 +42,6 @@ struct window *window_setup(struct registry *registry, uint32_t width, uint32_t 
 void window_teardown(struct window *state);
 int window_prerender(struct window *state);
 int window_render(struct window *state);
+void window_make_shell(struct window *window);
 
 #endif

--- a/include/extensions.h
+++ b/include/extensions.h
@@ -11,6 +11,8 @@ struct background_config {
         wlc_resource surface;
         // we need the wl_resource of the surface in the destructor
         struct wl_resource *wl_surface_res;
+        // used to determine if client is a background
+        struct wl_client *client;
 };
 
 struct panel_config {
@@ -21,6 +23,8 @@ struct panel_config {
         // we need the wl_resource of the surface in the destructor
         struct wl_resource *wl_surface_res;
         enum desktop_shell_panel_position panel_position;
+        // used to determine if client is a panel
+        struct wl_client *client;
 };
 
 struct desktop_shell_state {

--- a/sway/extensions.c
+++ b/sway/extensions.c
@@ -73,6 +73,7 @@ static void set_background(struct wl_client *client, struct wl_resource *resourc
 	}
 	sway_log(L_DEBUG, "Setting surface %p as background for output %d", surface, (int)output);
 	struct background_config *config = malloc(sizeof(struct background_config));
+        config->client = client;
 	config->output = output;
 	config->surface = wlc_resource_from_wl_surface_resource(surface);
 	config->wl_surface_res = surface;
@@ -91,6 +92,7 @@ static void set_panel(struct wl_client *client, struct wl_resource *resource,
 	sway_log(L_DEBUG, "Setting surface %p as panel for output %d (wl_resource: %p)", surface, (int)output, resource);
 	struct panel_config *config = find_or_create_panel_config(resource);
 	config->output = output;
+        config->client = client;
 	config->surface = wlc_resource_from_wl_surface_resource(surface);
 	config->wl_surface_res = surface;
 	wl_resource_set_destructor(surface, panel_surface_destructor);

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -175,6 +175,30 @@ static void handle_output_focused(wlc_handle output, bool focus) {
 	}
 }
 
+static bool client_is_background(struct wl_client *client)
+{
+        int i;
+	for (i = 0; i < desktop_shell.backgrounds->length; i++) {
+		struct background_config *config = desktop_shell.backgrounds->items[i];
+                if (config->client == client) {
+                        return true;
+                }
+        }
+        return false;
+}
+
+static bool client_is_panel(struct wl_client *client)
+{
+        int i;
+	for (i = 0; i < desktop_shell.panels->length; i++) {
+		struct panel_config *config = desktop_shell.panels->items[i];
+                if (config->client == client) {
+                        return true;
+                }
+        }
+        return false;
+}
+
 static bool handle_view_created(wlc_handle handle) {
 	// if view is child of another view, the use that as focused container
 	wlc_handle parent = wlc_view_get_parent(handle);
@@ -184,6 +208,10 @@ static bool handle_view_created(wlc_handle handle) {
 	bool return_to_workspace = false;
 	struct wl_client *client = wlc_view_get_wl_client(handle);
 	pid_t pid;
+
+        if (client_is_background(client) || client_is_panel(client)) {
+                return true;
+        }
 
 	// Get parent container, to add view in
 	if (parent) {

--- a/swaybar/bar.c
+++ b/swaybar/bar.c
@@ -80,12 +80,14 @@ void bar_setup(struct bar *bar, const char *socket_path, const char *bar_id) {
 
 		struct output_state *output = bar_output->registry->outputs->items[bar_output->idx];
 
-		bar_output->window = window_setup(bar_output->registry, output->width, 30, false);
+		bar_output->window = window_setup(bar_output->registry, output->width, 60, false);
 		if (!bar_output->window) {
 			sway_abort("Failed to create window.");
 		}
 		desktop_shell_set_panel(bar_output->registry->desktop_shell, output->output, bar_output->window->surface);
 		desktop_shell_set_panel_position(bar_output->registry->desktop_shell, bar->config->position);
+
+                window_make_shell(bar_output->window);
 
 		/* set font */
 		bar_output->window->font = bar->config->font;

--- a/swaybg/main.c
+++ b/swaybg/main.c
@@ -54,6 +54,7 @@ int main(int argc, const char **argv) {
 		sway_abort("Failed to create surfaces.");
 	}
 	desktop_shell_set_background(registry->desktop_shell, output->output, window->surface);
+        window_make_shell(window);
 	list_add(surfaces, window);
 
 #ifdef WITH_GDK_PIXBUF

--- a/wayland/window.c
+++ b/wayland/window.c
@@ -59,6 +59,13 @@ static const struct wl_shell_surface_listener surface_listener = {
 	.configure = shell_surface_configure
 };
 
+void window_make_shell(struct window *window)
+{
+        window->shell_surface = wl_shell_get_shell_surface(window->registry->shell, window->surface);
+        wl_shell_surface_add_listener(window->shell_surface, &surface_listener, window);
+        wl_shell_surface_set_toplevel(window->shell_surface);
+}
+
 struct window *window_setup(struct registry *registry, uint32_t width, uint32_t height, bool shell_surface) {
 	struct window *window = malloc(sizeof(struct window));
 	memset(window, 0, sizeof(struct window));
@@ -69,9 +76,7 @@ struct window *window_setup(struct registry *registry, uint32_t width, uint32_t 
 
 	window->surface = wl_compositor_create_surface(registry->compositor);
 	if (shell_surface) {
-		window->shell_surface = wl_shell_get_shell_surface(registry->shell, window->surface);
-		wl_shell_surface_add_listener(window->shell_surface, &surface_listener, window);
-		wl_shell_surface_set_toplevel(window->shell_surface);
+                window_make_shell(window);
 	}
 	if (registry->pointer) {
 		wl_pointer_add_listener(registry->pointer, &pointer_listener, window);


### PR DESCRIPTION
Swaybar opened the socket (sway --get-socketpath) to communicate with
sway twice and kept the two file descriptors in ipc_event_socketfd and
ipc_socketfd respectively. Opening the socket once suffice, hence deleting
ipc_event_socketfd.