### PR TITLE
Create .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# For the full list of code style requirements, see CONTRIBUTING.md
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+
+[*.{c,h,cmake,txt}]
+indent_style = tab
+indent_size = 4
+
+[*.{xml,yml}]
+indent_style = space
+indent_size = 2
+
+[config]
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
This file can help people working on the project to adhere to the coding style without changing their global editor configuration. It also makes GitHub render tabs as specified by `indent_size`.

I've set the rules pretty conservatively, not assuming anything and just going by the existing formatting. You might want to move the rules for `*.{c,h,cmake,txt}` to apply to everything instead; the files currently in the worktree that would be affected are the zsh completion files. You might also want to set `trim_trailing_whitespace` and `insert_final_newline` for (more) files.

See <http://editorconfig.org/> for more information.