### PR TITLE
I think this fixes #678

### DIFF
--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -149,6 +149,7 @@ static void handle_output_pre_render(wlc_handle output) {
 
 static void handle_output_post_render(wlc_handle output) {
 	ipc_get_pixels(output);
+	arrange_windows(swayc_by_handle(output), -1, -1);
 }
 
 static void handle_view_pre_render(wlc_handle view) {


### PR DESCRIPTION
This adds an `arrange_windows()` call in `handle_output_post_render()` which seems to have fixed #678 for me.