### PR TITLE
Enable windows to register to get notified of pointer button events

### DIFF
--- a/include/client/window.h
+++ b/include/client/window.h
@@ -12,19 +12,19 @@
 struct window;
 
 struct buffer {
-        struct wl_buffer *buffer;
-        cairo_surface_t *surface;
-        cairo_t *cairo;
-        PangoContext *pango;
-        uint32_t width, height;
-        bool busy;
+	struct wl_buffer *buffer;
+	cairo_surface_t *surface;
+	cairo_t *cairo;
+	PangoContext *pango;
+	uint32_t width, height;
+	bool busy;
 };
 
 struct cursor {
-        struct wl_surface *surface;
-        struct wl_cursor_theme *cursor_theme;
-        struct wl_cursor *cursor;
-        struct wl_poitner *pointer;
+	struct wl_surface *surface;
+	struct wl_cursor_theme *cursor_theme;
+	struct wl_cursor *cursor;
+	struct wl_poitner *pointer;
 };
 
 struct pointer_input {
@@ -35,16 +35,16 @@ struct pointer_input {
 };
 
 struct window {
-        struct registry *registry;
-        struct buffer buffers[2];
-        struct buffer *buffer;
-        struct wl_surface *surface;
-        struct wl_shell_surface *shell_surface;
-        struct wl_callback *frame_cb;
-        struct cursor cursor;
-        uint32_t width, height;
-        char *font;
-        cairo_t *cairo;
+	struct registry *registry;
+	struct buffer buffers[2];
+	struct buffer *buffer;
+	struct wl_surface *surface;
+	struct wl_shell_surface *shell_surface;
+	struct wl_callback *frame_cb;
+	struct cursor cursor;
+	uint32_t width, height;
+	char *font;
+	cairo_t *cairo;
 	struct pointer_input pointer_input;
 };
 

--- a/include/client/window.h
+++ b/include/client/window.h
@@ -9,6 +9,8 @@
 #include "list.h"
 #include "client/registry.h"
 
+struct window;
+
 struct buffer {
         struct wl_buffer *buffer;
         cairo_surface_t *surface;
@@ -25,6 +27,13 @@ struct cursor {
         struct wl_poitner *pointer;
 };
 
+struct pointer_input {
+	wl_fixed_t last_x;
+	wl_fixed_t last_y;
+
+	void (*notify)(struct window *window, wl_fixed_t x, wl_fixed_t y, uint32_t button);
+};
+
 struct window {
         struct registry *registry;
         struct buffer buffers[2];
@@ -36,6 +45,7 @@ struct window {
         uint32_t width, height;
         char *font;
         cairo_t *cairo;
+	struct pointer_input pointer_input;
 };
 
 struct window *window_setup(struct registry *registry, uint32_t width, uint32_t height, bool shell_surface);

--- a/wayland/window.c
+++ b/wayland/window.c
@@ -30,10 +30,20 @@ static void pointer_handle_leave(void *data, struct wl_pointer *pointer,
 
 static void pointer_handle_motion(void *data, struct wl_pointer *pointer,
 		      uint32_t time, wl_fixed_t sx_w, wl_fixed_t sy_w) {
+	struct window *window = data;
+
+	window->pointer_input.last_x = sx_w;
+	window->pointer_input.last_y = sy_w;
 }
 
 static void pointer_handle_button(void *data, struct wl_pointer *pointer, uint32_t serial,
 		      uint32_t time, uint32_t button, uint32_t state_w) {
+	struct window *window = data;
+	struct pointer_input *input = &window->pointer_input;
+
+	if (window->pointer_input.notify) {
+		window->pointer_input.notify(window, input->last_x, input->last_y, button);
+	}
 }
 
 static void pointer_handle_axis(void *data, struct wl_pointer *pointer,


### PR DESCRIPTION
Tested the keyboard related changes by running swaylock and making sure I could unlock the screen. (As far as I can tell, swaylock seems to be the only client that handles keyboard events.)