### PR TITLE
Fix tabbed/stacked corner case #742

### DIFF
--- a/include/container.h
+++ b/include/container.h
@@ -254,6 +254,11 @@ bool swayc_is_parent_of(swayc_t *parent, swayc_t *child);
 bool swayc_is_child_of(swayc_t *child, swayc_t *parent);
 
 /**
+ * Returns true if this container is an empty workspace.
+ */
+bool swayc_is_empty_workspace(swayc_t *container);
+
+/**
  * Returns the top most tabbed or stacked parent container. Returns NULL if
  * view is not in a tabbed/stacked layout.
  */

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -1950,13 +1950,13 @@ static struct cmd_results *cmd_layout(int argc, char **argv) {
 		}
 
 		if (strcasecmp(argv[0], "tabbed") == 0) {
-			if (parent->type != C_CONTAINER) {
+			if (parent->type != C_CONTAINER && !swayc_is_empty_workspace(parent)){
 				parent = new_container(parent, L_TABBED);
 			}
 
 			parent->layout = L_TABBED;
 		} else if (strcasecmp(argv[0], "stacking") == 0) {
-			if (parent->type != C_CONTAINER) {
+			if (parent->type != C_CONTAINER && !swayc_is_empty_workspace(parent)) {
 				parent = new_container(parent, L_STACKED);
 			}
 

--- a/sway/container.c
+++ b/sway/container.c
@@ -740,6 +740,10 @@ bool swayc_is_child_of(swayc_t *child, swayc_t *parent) {
 	return swayc_is_parent_of(parent, child);
 }
 
+bool swayc_is_empty_workspace(swayc_t *container) {
+	return container->type == C_WORKSPACE && container->children->length == 0;
+}
+
 int swayc_gap(swayc_t *container) {
 	if (container->type == C_VIEW || container->type == C_CONTAINER) {
 		return container->gaps >= 0 ? container->gaps : config->gaps_inner;
@@ -879,7 +883,7 @@ swayc_t *swayc_tabbed_stacked_parent(swayc_t *view) {
 	if (!ASSERT_NONNULL(view)) {
 		return NULL;
 	}
-	while (view->type != C_WORKSPACE && view->parent) {
+	while (view->type != C_WORKSPACE && view->parent && view->parent->type != C_WORKSPACE) {
 		view = view->parent;
 		if (view->layout == L_TABBED || view->layout == L_STACKED) {
 			parent = view;

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -318,6 +318,16 @@ static bool handle_view_created(wlc_handle handle) {
 		if (workspace && workspace->fullscreen) {
 			set_focused_container(workspace->fullscreen);
 		}
+
+		// if parent container is a workspace, newview its only child and
+		// layout is tabbed/stacked, add a container around newview
+		swayc_t *parent_container = newview->parent;
+		if (parent_container->type == C_WORKSPACE && parent_container->children->length == 1 &&
+				(parent_container->layout == L_TABBED || parent_container->layout == L_STACKED)) {
+			swayc_t *container = new_container(newview, parent_container->layout);
+			set_focused_container(newview);
+			arrange_windows(container, -1, -1);
+		}
 	} else {
 		swayc_t *output = swayc_parent_by_type(focused, C_OUTPUT);
 		wlc_handle *h = malloc(sizeof(wlc_handle));


### PR DESCRIPTION
Tabbed/stacked containers are now created only if a view is present on
the workspace. If a view is created on previously empty tabbed/stacked
workspace, it gets wrapped in a container.

I might have broken something with the change in container.c/swayc_tabbed_stacked_parent, as it's used in some other places, though it seems to work.