### PR TITLE
clang-format configuration for Sway's style as detailed in CONTRIBUTI…

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,7 @@
+BasedOnStyle: LLVM
+IndentWidth: 8
+UseTab: Always
+BreakBeforeBraces: Attach
+AllowShortIfStatementsOnASingleLine: false
+IndentCaseLabels: false
+ColumnLimit: 0


### PR DESCRIPTION
…NG.md

CONTRIBUTING.md says use kernel style, "but all braces go on the same line". The
kernel uses a column limit of 80 characters. The de facto syle in Sway is to
allow for wider lines so this format file does not enforce an 80 column limit.