### PR TITLE
Clarify which tabbed/stacked container we want (fixes #751)

### DIFF
--- a/include/container.h
+++ b/include/container.h
@@ -262,6 +262,12 @@ bool swayc_is_empty_workspace(swayc_t *container);
  * Returns the top most tabbed or stacked parent container. Returns NULL if
  * view is not in a tabbed/stacked layout.
  */
+swayc_t *swayc_tabbed_stacked_ancestor(swayc_t *view);
+
+/**
+ * Returns the immediate tabbed or stacked parent container. Returns NULL if
+ * view is not directly in a tabbed/stacked layout.
+ */
 swayc_t *swayc_tabbed_stacked_parent(swayc_t *view);
 
 /**

--- a/sway/border.c
+++ b/sway/border.c
@@ -318,7 +318,7 @@ void update_view_border(swayc_t *view) {
 	// for tabbed/stacked layouts the focused view has to draw all the
 	// titlebars of the hidden views.
 	swayc_t *p = NULL;
-	if (view->parent->focused == view && (p = swayc_tabbed_stacked_parent(view))) {
+	if (view->parent->focused == view && (p = swayc_tabbed_stacked_ancestor(view))) {
 		struct wlc_geometry g = {
 			.origin = {
 				.x = p->x,

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -2315,7 +2315,7 @@ static struct cmd_results *_do_split(int argc, char **argv, int layout) {
 	}
 
 	// update container title if tabbed/stacked
-	if (swayc_tabbed_stacked_parent(focused)) {
+	if (swayc_tabbed_stacked_ancestor(focused)) {
 		update_view_border(focused);
 		swayc_t *output = swayc_parent_by_type(focused, C_OUTPUT);
 		// schedule render to make changes take effect right away,

--- a/sway/container.c
+++ b/sway/container.c
@@ -878,7 +878,7 @@ void close_views(swayc_t *container) {
 	container_map(container, close_view, NULL);
 }
 
-swayc_t *swayc_tabbed_stacked_parent(swayc_t *view) {
+swayc_t *swayc_tabbed_stacked_ancestor(swayc_t *view) {
 	swayc_t *parent = NULL;
 	if (!ASSERT_NONNULL(view)) {
 		return NULL;
@@ -891,4 +891,14 @@ swayc_t *swayc_tabbed_stacked_parent(swayc_t *view) {
 	}
 
 	return parent;
+}
+
+swayc_t *swayc_tabbed_stacked_parent(swayc_t *con) {
+	if (!ASSERT_NONNULL(con)) {
+		return NULL;
+	}
+	if (con->parent && (con->parent->layout == L_TABBED || con->parent->layout == L_STACKED)) {
+		return con->parent;
+	}
+	return NULL;
 }

--- a/sway/focus.c
+++ b/sway/focus.c
@@ -152,7 +152,7 @@ bool set_focused_container(swayc_t *c) {
 		}
 
 		// rearrange if parent container is tabbed/stacked
-		swayc_t *parent = swayc_tabbed_stacked_parent(p);
+		swayc_t *parent = swayc_tabbed_stacked_ancestor(p);
 		if (parent != NULL) {
 			arrange_windows(parent, -1, -1);
 		}

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -523,8 +523,9 @@ static void handle_view_properties_updated(wlc_handle view, uint32_t mask) {
 			if (!c->name || strcmp(c->name, new_name) != 0) {
 				free(c->name);
 				c->name = strdup(new_name);
-				swayc_t *p = swayc_tabbed_stacked_parent(c);
+				swayc_t *p = swayc_tabbed_stacked_ancestor(c);
 				if (p) {
+					// TODO: we only got the topmost tabbed/stacked container, update borders of all containers on the path
 					update_view_border(get_focused_view(p));
 				} else if (c->border_type == B_NORMAL) {
 					update_view_border(c);

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -538,7 +538,7 @@ void update_geometry(swayc_t *container) {
 	int gap = 0;
 
 	// apply inner gaps to non-tabbed/stacked containers
-	swayc_t *p = swayc_tabbed_stacked_parent(container);
+	swayc_t *p = swayc_tabbed_stacked_ancestor(container);
 	if (p == NULL) {
 		gap = update_gap_geometry(container, &geometry);
 	}
@@ -803,7 +803,7 @@ static void arrange_windows_r(swayc_t *container, double width, double height) {
 			y = container->border_geometry.origin.y;
 		}
 
-		// update container size if it's a child in a tabbed/stacked layout
+		// update container size if it's a direct child in a tabbed/stacked layout
 		if (swayc_tabbed_stacked_parent(container) != NULL) {
 			// Use parent actual_geometry as a base for calculating
 			// container geometry


### PR DESCRIPTION
Refactored swayc_tabbed_stacked_parent into 2 functions - one returns the root tabbed/stacked ancestor (which was how the original function worked), the other return just the immediate tabbed/stacked parent.