### PR TITLE
Update swaylock zsh completion

### DIFF
--- a/completions/zsh/_swaylock
+++ b/completions/zsh/_swaylock
@@ -6,7 +6,9 @@
 _arguments -s \
     '(-v --version)'{-v,--version}'[Show the version number and quit]' \
     '(-h --help)'{-h,--help}'[Show help message and quit]' \
+    '(-f --daemonize)'{-f, --daemonize}'[Detach from the controlling terminal]\
     '(-c --color)'{-c,--color}'[Specify a color (rrggbb) instead of white]' \
     '(-i --image)'{-i,--image}'[Display an image]:files:_files' \
     '(-s --scaling)'{-s,--scaling}'[Scaling mode]:mode:(stretch fill fit center tile)' \
     '(-u --no-unlock-indicator)'{-u,--no-unlock-indicator}'[Disable the unlock indicator]'
+    '(--socket)'{--socket}'[Use the specified socket path.]:files:_files' \


### PR DESCRIPTION
added new option of daemonize (-f --daemonize) that was added to swaylock in https://github.com/SirCmpwn/sway/pull/750 and added socket completion upon reading more into swaylock/main.c  (it also is in the usage help but never had it in completion)