### PR TITLE
Properly construct event bitmasks

### DIFF
--- a/include/ipc.h
+++ b/include/ipc.h
@@ -12,14 +12,14 @@ enum ipc_command_type {
 	IPC_GET_VERSION = 7,
 	IPC_GET_INPUTS = 8,
 	// Events send from sway to clients. Events have the highest bits set.
-	IPC_EVENT_WORKSPACE = (1 << (31 - 0)),
-	IPC_EVENT_OUTPUT = (1 << (31 - 1)),
-	IPC_EVENT_MODE = (1 << (31 - 2)),
-	IPC_EVENT_WINDOW = (1 << (32 - 3)),
-	IPC_EVENT_BARCONFIG_UPDATE = (1 << (31 - 4)),
-	IPC_EVENT_BINDING = (1 << (31 - 5)),
-	IPC_EVENT_MODIFIER = (1 << (31 - 6)),
-	IPC_EVENT_INPUT = (1 << (31 - 7)),
+	IPC_EVENT_WORKSPACE = ((1<<31) | 0),
+	IPC_EVENT_OUTPUT = ((1<<31) | 1),
+	IPC_EVENT_MODE = ((1<<31) | 2),
+	IPC_EVENT_WINDOW = ((1<<31) | 3),
+	IPC_EVENT_BARCONFIG_UPDATE = ((1<<31) | 4),
+	IPC_EVENT_BINDING = ((1<<31) | 5),
+	IPC_EVENT_MODIFIER = ((1<<31) | 6),
+	IPC_EVENT_INPUT = ((1<<31) | 7),
 	IPC_SWAY_GET_PIXELS = 0x81
 };
 


### PR DESCRIPTION
For reference, https://i3wm.org/docs/ipc.html#_events