### PR TITLE
Hide edge borders fix

### DIFF
--- a/sway/layout.c
+++ b/sway/layout.c
@@ -522,8 +522,8 @@ void update_geometry(swayc_t *container) {
 		return;
 	}
 
-	swayc_t *ws = swayc_parent_by_type(container, C_WORKSPACE);
-	swayc_t *op = ws->parent;
+	swayc_t *workspace = swayc_parent_by_type(container, C_WORKSPACE);
+	swayc_t *op = workspace->parent;
 	swayc_t *parent = container->parent;
 
 	struct wlc_geometry geometry = {
@@ -552,7 +552,7 @@ void update_geometry(swayc_t *container) {
 		geometry.origin.y = 0;
 		geometry.size.w = size->w;
 		geometry.size.h = size->h;
-		if (op->focused == ws) {
+		if (op->focused == workspace) {
 			wlc_view_bring_to_front(container->handle);
 		}
 
@@ -570,23 +570,23 @@ void update_geometry(swayc_t *container) {
 		int border_right = container->border_thickness;
 
 		// handle hide_edge_borders
-		if (config->hide_edge_borders != E_NONE && (gap <= 0 || (config->smart_gaps && ws->children->length == 1))) {
+		if (config->hide_edge_borders != E_NONE && (gap <= 0 || (config->smart_gaps && workspace->children->length == 1))) {
 			if (config->hide_edge_borders == E_HORIZONTAL || config->hide_edge_borders == E_BOTH) {
-				if (geometry.origin.x == ws->x) {
+				if (geometry.origin.x == workspace->x) {
 					border_left = 0;
 				}
 
-				if (geometry.origin.x + geometry.size.w == ws->width) {
+				if (geometry.origin.x + geometry.size.w == workspace->width) {
 					border_right = 0;
 				}
 			}
 
 			if (config->hide_edge_borders == E_VERTICAL || config->hide_edge_borders == E_BOTH) {
-				if (geometry.origin.y == ws->y) {
+				if (geometry.origin.y == workspace->y) {
 					border_top = 0;
 				}
 
-				if (geometry.origin.y + geometry.size.h == ws->height) {
+				if (geometry.origin.y + geometry.size.h == workspace->height) {
 					border_bottom = 0;
 				}
 			}

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -571,29 +571,22 @@ void update_geometry(swayc_t *container) {
 
 		// handle hide_edge_borders
 		if (config->hide_edge_borders != E_NONE && (gap <= 0 || (config->smart_gaps && ws->children->length == 1))) {
-			swayc_t *output = swayc_parent_by_type(container, C_OUTPUT);
-			const struct wlc_size *size = wlc_output_get_resolution(output->handle);
-
 			if (config->hide_edge_borders == E_HORIZONTAL || config->hide_edge_borders == E_BOTH) {
-				if (geometry.origin.x == 0 || geometry.origin.x == container->x) {
-					// should work for swaybar at left
+				if (geometry.origin.x == ws->x) {
 					border_left = 0;
 				}
 
-				if (geometry.origin.x + geometry.size.w == size->w || geometry.size.w == container->width) {
-					// should work for swaybar at right
+				if (geometry.origin.x + geometry.size.w == ws->width) {
 					border_right = 0;
 				}
 			}
 
 			if (config->hide_edge_borders == E_VERTICAL || config->hide_edge_borders == E_BOTH) {
-				if (geometry.origin.y == 0 || geometry.origin.y == container->y) {
-					// this works for swaybar at top
+				if (geometry.origin.y == ws->y) {
 					border_top = 0;
 				}
 
-				if (geometry.origin.y + geometry.size.h == size->h || geometry.size.h == container->height) {
-					// this works for swaybar at bottom
+				if (geometry.origin.y + geometry.size.h == ws->height) {
 					border_bottom = 0;
 				}
 			}


### PR DESCRIPTION
With hide_edge_borders option on, borders were hidden even where they shouldn't been.

Since containers can only be inside workspaces, workspace geometry is used for determining edge borders (instead of output, which might also contain swaybar).