### PR TITLE
fix regression in hide_edge_borders

### DIFF
--- a/sway/layout.c
+++ b/sway/layout.c
@@ -576,7 +576,7 @@ void update_geometry(swayc_t *container) {
 					border_left = 0;
 				}
 
-				if (geometry.origin.x + geometry.size.w == workspace->width) {
+				if (geometry.size.w == workspace->width) {
 					border_right = 0;
 				}
 			}
@@ -586,7 +586,7 @@ void update_geometry(swayc_t *container) {
 					border_top = 0;
 				}
 
-				if (geometry.origin.y + geometry.size.h == workspace->height) {
+				if (geometry.size.h == workspace->height) {
 					border_bottom = 0;
 				}
 			}


### PR DESCRIPTION
origin x & y are not needed because this is the only child in the workspace. if swaybar location is top, view's y is not zero, so y + view's height > workspace height.