### PR TITLE
properly hide bottom and right borders

### DIFF
--- a/sway/layout.c
+++ b/sway/layout.c
@@ -576,7 +576,7 @@ void update_geometry(swayc_t *container) {
 					border_left = 0;
 				}
 
-				if (geometry.size.w == workspace->width) {
+				if (geometry.origin.x + geometry.size.w == workspace->x + workspace->width) {
 					border_right = 0;
 				}
 			}
@@ -586,7 +586,7 @@ void update_geometry(swayc_t *container) {
 					border_top = 0;
 				}
 
-				if (geometry.size.h == workspace->height) {
+				if (geometry.origin.y + geometry.size.h == workspace->y + workspace->height) {
 					border_bottom = 0;
 				}
 			}


### PR DESCRIPTION
Prior to this commit, only windows that are as high or as wide as the workspace had hidden bottom or right borders. I hope we'll get it right this time :D 