### PR TITLE
Fix swaybar take 2

### DIFF
--- a/include/bar/ipc.h
+++ b/include/bar/ipc.h
@@ -13,6 +13,10 @@ void ipc_bar_init(struct bar *bar, const char *bar_id);
  */
 bool handle_ipc_event(struct bar *bar);
 
+/**
+ * Tell Sway to rearrange layout (after Swaybar has rendered itself).
+ */
+void ipc_send_arrange_command();
 
 /**
  * Send workspace command to sway
@@ -20,4 +24,3 @@ bool handle_ipc_event(struct bar *bar);
 void ipc_send_workspace_command(const char *workspace_name);
 
 #endif /* _SWAYBAR_IPC_H */
-

--- a/include/config.h
+++ b/include/config.h
@@ -136,7 +136,7 @@ struct bar_config {
 	int height; // -1 not defined
 	int tray_padding;
 	bool workspace_buttons;
-    bool wrap_scroll;
+	bool wrap_scroll;
 	char *separator_symbol;
 	bool strip_workspace_numbers;
 	bool binding_mode_indicator;

--- a/include/ipc.h
+++ b/include/ipc.h
@@ -11,6 +11,7 @@ enum ipc_command_type {
 	IPC_GET_BAR_CONFIG = 6,
 	IPC_GET_VERSION = 7,
 	IPC_GET_INPUTS = 8,
+	IPC_ARRANGE_LAYOUT = 9,
 	// Events send from sway to clients. Events have the highest bits set.
 	IPC_EVENT_WORKSPACE = ((1<<31) | 0),
 	IPC_EVENT_OUTPUT = ((1<<31) | 1),

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -477,7 +477,6 @@ void ipc_client_handle_command(struct ipc_client *client) {
 
 	case IPC_ARRANGE_LAYOUT:
 	{
-		sway_log(L_DEBUG, "received arrange command");
 		arrange_windows(&root_container, -1, -1);
 		ipc_send_reply(client, "{\"success\": true}", 17);
 		goto exit_cleanup;

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -471,6 +471,14 @@ void ipc_client_handle_command(struct ipc_client *client) {
 		goto exit_cleanup;
 	}
 
+	case IPC_ARRANGE_LAYOUT:
+	{
+		sway_log(L_DEBUG, "received arrange command");
+		arrange_windows(&root_container, -1, -1);
+		ipc_send_reply(client, "{\"success\": true}", 17);
+		goto exit_cleanup;
+	}
+
 	default:
 		sway_log(L_INFO, "Unknown IPC command type %i", client->current_command);
 		goto exit_cleanup;

--- a/swaybar/bar.c
+++ b/swaybar/bar.c
@@ -202,6 +202,8 @@ void bar_run(struct bar *bar) {
 					render(output, bar->config, bar->status);
 					window_render(output->window);
 					wl_display_flush(output->registry->display);
+					sway_log(L_DEBUG, "sending arrange command");
+					ipc_send_arrange_command();
 				}
 			}
 		}

--- a/swaybar/bar.c
+++ b/swaybar/bar.c
@@ -202,7 +202,6 @@ void bar_run(struct bar *bar) {
 					render(output, bar->config, bar->status);
 					window_render(output->window);
 					wl_display_flush(output->registry->display);
-					sway_log(L_DEBUG, "sending arrange command");
 					ipc_send_arrange_command();
 				}
 			}

--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -7,6 +7,17 @@
 #include "bar/config.h"
 #include "bar/ipc.h"
 
+void ipc_send_arrange_command() {
+	sway_log(L_DEBUG, "sending arrange command");
+	sway_log(L_DEBUG, "socketfd is -> %d", swaybar.ipc_socketfd);
+	sway_log(L_DEBUG, "command is -> %d", IPC_ARRANGE_LAYOUT);
+
+	char *cmd = strdup("");
+	uint32_t len = strlen(cmd);
+	char *r = ipc_single_command(swaybar.ipc_socketfd, IPC_ARRANGE_LAYOUT, cmd, &len);
+	sway_log(L_DEBUG, "arrange command response is -> %s", r);
+}
+
 void ipc_send_workspace_command(const char *workspace_name) {
 	uint32_t size = strlen("workspace ") + strlen(workspace_name) + 1;
 

--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -8,14 +8,9 @@
 #include "bar/ipc.h"
 
 void ipc_send_arrange_command() {
-	sway_log(L_DEBUG, "sending arrange command");
-	sway_log(L_DEBUG, "socketfd is -> %d", swaybar.ipc_socketfd);
-	sway_log(L_DEBUG, "command is -> %d", IPC_ARRANGE_LAYOUT);
-
 	char *cmd = strdup("");
 	uint32_t len = strlen(cmd);
-	char *r = ipc_single_command(swaybar.ipc_socketfd, IPC_ARRANGE_LAYOUT, cmd, &len);
-	sway_log(L_DEBUG, "arrange command response is -> %s", r);
+	ipc_single_command(swaybar.ipc_socketfd, IPC_ARRANGE_LAYOUT, cmd, &len);
 }
 
 void ipc_send_workspace_command(const char *workspace_name) {


### PR DESCRIPTION
A less CPU-intensive ;) fix for #678. Since Swaybar renders itself, Sway doesn't know when that has happened. This PR adds a signal Swaybar can send after it has rendered itself so Sway knows to adjust the layout.