### PR TITLE
bugfix: set focus to workspace of an output

### DIFF
--- a/sway/focus.c
+++ b/sway/focus.c
@@ -67,9 +67,11 @@ bool move_focus(enum movement_direction direction) {
 	swayc_t *new_view = get_swayc_in_direction(old_view, direction);
 	if (!new_view) {
 		return false;
-	} else if (new_view->type == C_ROOT || new_view->type == C_OUTPUT) {
+	} else if (new_view->type == C_ROOT) {
 		sway_log(L_DEBUG, "Not setting focus above the workspace level");
 		return false;
+	} else if (new_view->type == C_OUTPUT) {
+		return set_focused_container(swayc_active_workspace_for(new_view));
 	} else if (direction == MOVE_PARENT) {
 		return set_focused_container(new_view);
 	} else if (config->mouse_warping) {


### PR DESCRIPTION
In `move_focus()`, when given an output, set the focus to the workspace of that
output instead of the output itself.

This fixes a bug that did not allow users to switch between outputs introduced
in afc6ad6.

It also fixes other issues before that commit when a workspace with children
was selected and the user tried to switch focus in the direction of another
output.