### PR TITLE
Implement `focus child` command

### DIFF
--- a/include/focus.h
+++ b/include/focus.h
@@ -5,7 +5,8 @@ enum movement_direction {
 	MOVE_RIGHT,
 	MOVE_UP,
 	MOVE_DOWN,
-	MOVE_PARENT
+	MOVE_PARENT,
+	MOVE_CHILD
 };
 
 #include "container.h"

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -864,6 +864,8 @@ static struct cmd_results *cmd_focus(int argc, char **argv) {
 		move_focus(MOVE_DOWN);
 	} else if (strcasecmp(argv[0], "parent") == 0) {
 		move_focus(MOVE_PARENT);
+	} else if (strcasecmp(argv[0], "child") == 0) {
+		move_focus(MOVE_CHILD);
 	} else if (strcasecmp(argv[0], "mode_toggle") == 0) {
 		int i;
 		swayc_t *workspace = swayc_active_workspace();
@@ -903,7 +905,7 @@ static struct cmd_results *cmd_focus(int argc, char **argv) {
 		}
 	} else {
 		return cmd_results_new(CMD_INVALID, "focus",
-				"Expected 'focus <direction|parent|mode_toggle>' or 'focus output <direction|name>'");
+				"Expected 'focus <direction|parent|child|mode_toggle>' or 'focus output <direction|name>'");
 	}
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/focus.c
+++ b/sway/focus.c
@@ -72,7 +72,7 @@ bool move_focus(enum movement_direction direction) {
 		return false;
 	} else if (new_view->type == C_OUTPUT) {
 		return set_focused_container(swayc_active_workspace_for(new_view));
-	} else if (direction == MOVE_PARENT) {
+	} else if (direction == MOVE_PARENT || direction == MOVE_CHILD) {
 		return set_focused_container(new_view);
 	} else if (config->mouse_warping) {
 		swayc_t *old_op = old_view->type == C_OUTPUT ?

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -1009,6 +1009,10 @@ static swayc_t *get_swayc_in_output_direction(swayc_t *output, enum movement_dir
 }
 
 swayc_t *get_swayc_in_direction_under(swayc_t *container, enum movement_direction dir, swayc_t *limit) {
+	if (dir == MOVE_CHILD) {
+		return container->focused;
+	}
+
 	swayc_t *parent = container->parent;
 	if (dir == MOVE_PARENT) {
 		if (parent->type == C_OUTPUT) {

--- a/sway/sway.5.txt
+++ b/sway/sway.5.txt
@@ -59,8 +59,8 @@ They are expected to be used with **bindsym** or at runtime through **swaymsg**(
 	Make focused view floating, non-floating, or the opposite of what it is now.
 
 **focus** <direction>::
-	Direction may be one of _up_, _down_, _left_, _right_, or _parent_. The
-	directional focus commands will move the focus in that direction. The parent
+	Direction may be one of _up_, _down_, _left_, _right_, _parent_, or _child_.
+	The directional focus commands will move the focus in that direction. The parent
 	focus command will change the focus to the parent of the currently focused
 	container, which is useful, for example, to open a sibling of the parent
 	container, or to move the entire container around.


### PR DESCRIPTION
The `focus child` command focuses the child container within the selected
container.