### PR TITLE
bugfix: invisible windows on empty workspace with tabbed/stacked layout

### DIFF
--- a/sway/layout.c
+++ b/sway/layout.c
@@ -799,7 +799,9 @@ static void arrange_windows_r(swayc_t *container, double width, double height) {
 		}
 
 		// update container size if it's a direct child in a tabbed/stacked layout
-		if (swayc_tabbed_stacked_parent(container) != NULL) {
+		// if parent is a workspace, its actual_geometry won't be initialized
+		if (swayc_tabbed_stacked_parent(container) != NULL &&
+			container->parent->type != C_WORKSPACE) {
 			// Use parent actual_geometry as a base for calculating
 			// container geometry
 			container->width = container->parent->actual_geometry.size.w;


### PR DESCRIPTION
This commit just fixes the bug that sometimes made initial workspace_layout unusable.

Sway is actually quite different in how workspace_layout functions, compared to i3. The i3 behavior isn't exactly logical, so I raised an issue in https://github.com/i3/i3/issues/2402.  When I get some response over in the i3 repo, I'll try to match its correct functionality.