### PR TITLE
Close all focused container's child views on cmd_kill

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -1925,8 +1925,8 @@ static struct cmd_results *cmd_kill(int argc, char **argv) {
 	if (config->reading) return cmd_results_new(CMD_FAILURE, "kill", "Can't be used in config file.");
 	if (!config->active) return cmd_results_new(CMD_FAILURE, "kill", "Can only be used when sway is running.");
 
-	swayc_t *view = get_focused_container(&root_container);
-	wlc_view_close(view->handle);
+	swayc_t *container = get_focused_container(&root_container);
+	close_views(container);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }
 


### PR DESCRIPTION
Previously, cmd_kill only closed a focused view, while containers were
not affected. Now it closes all views that are children of the focused
container.