### PR TITLE
Misc border fix

### DIFF
--- a/include/border.h
+++ b/include/border.h
@@ -20,5 +20,6 @@ void render_view_borders(wlc_handle view);
 void update_view_border(swayc_t *view);
 void map_update_view_border(swayc_t *view, void *data);
 int get_font_text_height(const char *font);
+bool should_hide_top_border(swayc_t *con, double y);
 
 #endif

--- a/sway/border.c
+++ b/sway/border.c
@@ -332,10 +332,12 @@ void update_view_border(swayc_t *view) {
 			}
 		};
 		cr = create_border_buffer(view, g, &surface);
+
+		bool render_top = !should_hide_top_border(view, view->y);
 		if (view == focused) {
-			render_borders(view, cr, &config->border_colors.focused, false);
+			render_borders(view, cr, &config->border_colors.focused, render_top);
 		} else {
-			render_borders(view, cr, &config->border_colors.focused_inactive, false);
+			render_borders(view, cr, &config->border_colors.focused_inactive, render_top);
 		}
 
 		// generate container titles
@@ -417,4 +419,18 @@ void render_view_borders(wlc_handle view) {
 	if (c->border && c->border->buffer) {
 		wlc_pixels_write(WLC_RGBA8888, &c->border->geometry, c->border->buffer);
 	}
+}
+
+bool should_hide_top_border(swayc_t *con, double y) {
+	// returns true if container is child of tabbed/stacked layout and is
+	// sharing top border with tabbed titlebar
+	swayc_t *par = con->parent;
+	while (par->type != C_WORKSPACE) {
+		if (par->layout == L_TABBED || par->layout == L_STACKED) {
+			return con->y == y;
+		}
+		con = par;
+		par = par->parent;
+	}
+	return false;
 }

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -579,9 +579,7 @@ void update_geometry(swayc_t *container) {
 					border_left = 0;
 				}
 
-				if (geometry.origin.x + geometry.size.w == size.w ||
-						geometry.size.w == container->x + container->width) {
-					// should work for swaybar at right
+				if (geometry.origin.x + geometry.size.w == workspace->x + workspace->width) {
 					border_right = 0;
 				}
 			}
@@ -591,9 +589,7 @@ void update_geometry(swayc_t *container) {
 					border_top = 0;
 				}
 
-				if (geometry.origin.y + geometry.size.h == size.h ||
-						geometry.size.h == container->y + container->height) {
-					// this works for swaybar at bottom
+				if (geometry.origin.y + geometry.size.h == workspace->y + workspace->height) {
 					border_bottom = 0;
 				}
 			}

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -587,7 +587,7 @@ void update_geometry(swayc_t *container) {
 			}
 
 			if (config->hide_edge_borders == E_VERTICAL || config->hide_edge_borders == E_BOTH) {
-				if (geometry.origin.y == workspace->y) {
+				if (geometry.origin.y == workspace->y || should_hide_top_border(container, geometry.origin.y)) {
 					border_top = 0;
 				}
 


### PR DESCRIPTION
 - properly hide top border inside tabbed/stacked

When titlebar is hidden, top border of the topmost view inside
tabbed/stacked container will not be drawn. This is changed in layout.c

On the other hand, top border should be drawn sometimes, for example
when titlebar is hidden on a view that is not the topmost inside
tabbed/stacked container. This is changed in border.c

 - second commit is just a revert of some changes in 6ea02f30, which didn't incorporate some more recent fixes