### PR TITLE
Update container geometry on layout switch

### DIFF
--- a/sway/commands.c
+++ b/sway/commands.c
@@ -1998,6 +1998,7 @@ static struct cmd_results *cmd_layout(int argc, char **argv) {
 	}
 
 	update_layout_geometry(parent, old_layout);
+	update_geometry(parent);
 
 	arrange_windows(parent, parent->width, parent->height);
 


### PR DESCRIPTION
Deeply nested containers which had their layouts changed didn't update
their actual_geometry, this messed up their child containers. Those got
width and height of 0, which was then decreased for stacked/tabbed
containers by title height. Underflow ensued, these containers suddenly
had height 4294967273. In short, not updating actual_geometry didn't
play nicely with nested containers.