### PR TITLE
Implement focus handling for containers

### DIFF
--- a/include/border.h
+++ b/include/border.h
@@ -22,7 +22,6 @@ void border_clear(struct border *border);
 void update_container_border(swayc_t *container);
 
 void render_view_borders(wlc_handle view);
-void update_view_border(swayc_t *view);
 void map_update_view_border(swayc_t *view, void *data);
 int get_font_text_height(const char *font);
 bool should_hide_top_border(swayc_t *con, double y);

--- a/include/border.h
+++ b/include/border.h
@@ -16,6 +16,11 @@ struct border {
  */
 void border_clear(struct border *border);
 
+/**
+ * Recursively update all of the borders within a container.
+ */
+void update_container_border(swayc_t *container);
+
 void render_view_borders(wlc_handle view);
 void update_view_border(swayc_t *view);
 void map_update_view_border(swayc_t *view, void *data);

--- a/sway/border.c
+++ b/sway/border.c
@@ -201,12 +201,6 @@ static void render_title_bar(swayc_t *view, cairo_t *cr, struct wlc_geometry *b,
 	}
 }
 
-void map_update_view_border(swayc_t *view, void *data) {
-	if (view->type == C_VIEW) {
-		update_view_border(view);
-	}
-}
-
 /**
  * Generate nested container title for tabbed/stacked layouts
  */
@@ -293,7 +287,7 @@ void update_tabbed_stacked_titlebars(swayc_t *c, cairo_t *cr, struct wlc_geometr
 	}
 }
 
-void update_view_border(swayc_t *view) {
+static void update_view_border(swayc_t *view) {
 	if (!view->visible) {
 		return;
 	}
@@ -414,6 +408,12 @@ void update_container_border(swayc_t *container) {
 		for (int i = 0; i < container->children->length; ++i) {
 			update_container_border(container->children->items[i]);
 		}
+	}
+}
+
+void map_update_view_border(swayc_t *view, void *data) {
+	if (view->type == C_VIEW) {
+		update_view_border(view);
 	}
 }
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -2340,7 +2340,7 @@ static struct cmd_results *_do_split(int argc, char **argv, int layout) {
 
 	// update container title if tabbed/stacked
 	if (swayc_tabbed_stacked_ancestor(focused)) {
-		update_view_border(focused);
+		update_container_border(focused);
 		swayc_t *output = swayc_parent_by_type(focused, C_OUTPUT);
 		// schedule render to make changes take effect right away,
 		// otherwise we would have to wait for the view to render,

--- a/sway/focus.c
+++ b/sway/focus.c
@@ -115,7 +115,7 @@ bool set_focused_container(swayc_t *c) {
 
 	// Get workspace for c, get that workspaces current focused container.
 	swayc_t *workspace = swayc_active_workspace_for(c);
-	swayc_t *focused = get_focused_view(workspace);
+	swayc_t *focused = get_focused_container(workspace);
 
 	if (swayc_is_fullscreen(focused) && focused != c) {
 		// if switching to a workspace with a fullscreen view,
@@ -140,33 +140,32 @@ bool set_focused_container(swayc_t *c) {
 	}
 
 	// get new focused view and set focus to it.
-	p = get_focused_view(c);
-	if (p->type == C_VIEW && !(wlc_view_get_type(p->handle) & WLC_BIT_POPUP)) {
+	if (c->type == C_CONTAINER || (c->type == C_VIEW && !(wlc_view_get_type(p->handle) & WLC_BIT_POPUP))) {
 		// unactivate previous focus
 		if (focused->type == C_VIEW) {
 			wlc_view_set_state(focused->handle, WLC_BIT_ACTIVATED, false);
-			update_view_border(focused);
 		}
+		update_container_border(focused);
 		// activate current focus
-		if (p->type == C_VIEW) {
-			wlc_view_set_state(p->handle, WLC_BIT_ACTIVATED, true);
-			// set focus if view_focus is unlocked
-			if (!locked_view_focus) {
-				wlc_view_focus(p->handle);
-				if (p->parent->layout != L_TABBED
-					&& p->parent->layout != L_STACKED) {
-					update_view_border(p);
-				}
+		if (c->type == C_VIEW) {
+			wlc_view_set_state(c->handle, WLC_BIT_ACTIVATED, true);
+		}
+		// set focus if view_focus is unlocked
+		if (!locked_view_focus) {
+			wlc_view_focus(c->handle);
+			if (c->parent->layout != L_TABBED
+					&& c->parent->layout != L_STACKED) {
+				update_container_border(c);
 			}
 		}
 
 		// rearrange if parent container is tabbed/stacked
-		swayc_t *parent = swayc_tabbed_stacked_ancestor(p);
+		swayc_t *parent = swayc_tabbed_stacked_ancestor(c);
 		if (parent != NULL) {
 			arrange_backgrounds();
 			arrange_windows(parent, -1, -1);
 		}
-	} else if (p->type == C_WORKSPACE) {
+	} else if (c->type == C_WORKSPACE) {
 		// remove previous focus if view_focus is unlocked
 		if (!locked_view_focus) {
 			wlc_view_focus(0);

--- a/sway/focus.c
+++ b/sway/focus.c
@@ -168,6 +168,7 @@ bool set_focused_container(swayc_t *c) {
 	} else if (c->type == C_WORKSPACE) {
 		// remove previous focus if view_focus is unlocked
 		if (!locked_view_focus) {
+			update_container_border(c);
 			wlc_view_focus(0);
 		}
 	}

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -553,9 +553,9 @@ static void handle_view_properties_updated(wlc_handle view, uint32_t mask) {
 				swayc_t *p = swayc_tabbed_stacked_ancestor(c);
 				if (p) {
 					// TODO: we only got the topmost tabbed/stacked container, update borders of all containers on the path
-					update_view_border(get_focused_view(p));
+					update_container_border(get_focused_view(p));
 				} else if (c->border_type == B_NORMAL) {
-					update_view_border(c);
+					update_container_border(c);
 				}
 				ipc_event_window(c, "title");
 			}

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -415,7 +415,7 @@ static bool handle_view_created(wlc_handle handle) {
 		// we were on one workspace, switched to another to add this view,
 		// now let's return to where we were
 		workspace_switch(current_ws);
-		set_focused_container(current_ws->focused);
+		set_focused_container(get_focused_container(current_ws));
 	}
 
 	suspend_workspace_cleanup = false;

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -441,7 +441,7 @@ static void update_border_geometry_floating(swayc_t *c, struct wlc_geometry *geo
 	c->border_geometry = g;
 	*geometry = c->actual_geometry;
 
-	update_view_border(c);
+	update_container_border(c);
 }
 
 void update_layout_geometry(swayc_t *parent, enum swayc_layouts prev_layout) {
@@ -688,7 +688,7 @@ void update_geometry(swayc_t *container) {
 		container->actual_geometry = geometry;
 
 		if (container->type == C_VIEW) {
-			update_view_border(container);
+			update_container_border(container);
 		}
 	}
 
@@ -867,7 +867,7 @@ static void arrange_windows_r(swayc_t *container, double width, double height) {
 			// update focused view border last because it may
 			// depend on the title bar geometry of its siblings.
 			if (focused && container->children->length > 1) {
-				update_view_border(focused);
+				update_container_border(focused);
 			}
 		}
 		break;
@@ -911,7 +911,7 @@ static void arrange_windows_r(swayc_t *container, double width, double height) {
 			// update focused view border last because it may
 			// depend on the title bar geometry of its siblings.
 			if (focused && container->children->length > 1) {
-				update_view_border(focused);
+				update_container_border(focused);
 			}
 		}
 		break;


### PR DESCRIPTION
The previous implementation of focus handling assumed that only views can be
focused. Containers can also be focused with a command like `focus parent` or
`focus child`.

Change `set_focused_container()` to handle the case of the given container
being a container with children and update borders accordingly.