### PR TITLE
Remove dead global locked_view_focus

### DIFF
--- a/include/focus.h
+++ b/include/focus.h
@@ -33,7 +33,6 @@ bool set_focused_container_for(swayc_t *ancestor, swayc_t *container);
 // and unlocked when they are destroyed
 
 extern bool locked_container_focus;
-extern bool locked_view_focus;
 
 // Prevents wss from being destroyed on focus switch
 extern bool suspend_workspace_cleanup;

--- a/sway/focus.c
+++ b/sway/focus.c
@@ -10,7 +10,6 @@
 #include "border.h"
 
 bool locked_container_focus = false;
-bool locked_view_focus = false;
 bool suspend_workspace_cleanup = false;
 
 // switches parent focus to c. will switch it accordingly
@@ -151,12 +150,9 @@ bool set_focused_container(swayc_t *c) {
 			wlc_view_set_state(c->handle, WLC_BIT_ACTIVATED, true);
 		}
 		// set focus if view_focus is unlocked
-		if (!locked_view_focus) {
-			wlc_view_focus(c->handle);
-			if (c->parent->layout != L_TABBED
-					&& c->parent->layout != L_STACKED) {
-				update_container_border(c);
-			}
+		wlc_view_focus(c->handle);
+		if (c->parent->layout != L_TABBED && c->parent->layout != L_STACKED) {
+			update_container_border(c);
 		}
 
 		// rearrange if parent container is tabbed/stacked
@@ -167,10 +163,8 @@ bool set_focused_container(swayc_t *c) {
 		}
 	} else if (c->type == C_WORKSPACE) {
 		// remove previous focus if view_focus is unlocked
-		if (!locked_view_focus) {
-			update_container_border(c);
-			wlc_view_focus(0);
-		}
+		update_container_border(c);
+		wlc_view_focus(0);
 	}
 
 	if (active_ws != workspace) {

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -343,7 +343,6 @@ static bool handle_view_created(wlc_handle handle) {
 	// Dmenu keeps viewfocus, but others with this flag don't, for now simulate
 	// dmenu
 	case WLC_BIT_OVERRIDE_REDIRECT:
-	// locked_view_focus = true;
 		wlc_view_focus(handle);
 		wlc_view_set_state(handle, WLC_BIT_ACTIVATED, true);
 		wlc_view_bring_to_front(handle);
@@ -437,7 +436,6 @@ static void handle_view_destroyed(wlc_handle handle) {
 	// DMENU has this flag, and takes view_focus, but other things with this
 	// flag don't
 	case WLC_BIT_OVERRIDE_REDIRECT:
-// 		locked_view_focus = false;
 		break;
 	case WLC_BIT_OVERRIDE_REDIRECT|WLC_BIT_UNMANAGED:
 		locked_container_focus = false;
@@ -643,10 +641,6 @@ static bool handle_key(wlc_handle view, uint32_t time, const struct wlc_modifier
 		uint32_t key, enum wlc_key_state state) {
 
 	if (desktop_shell.is_locked) {
-		return EVENT_PASSTHROUGH;
-	}
-
-	if (locked_view_focus && state == WLC_KEY_STATE_PRESSED) {
 		return EVENT_PASSTHROUGH;
 	}
 


### PR DESCRIPTION
The value of `locked_view_focus` is always false. Remove dead code associated
with this variable to simplify things.