### PR TITLE
Refactor logic to determine if stacked/tabbed con

### DIFF
--- a/include/container.h
+++ b/include/container.h
@@ -142,6 +142,11 @@ enum visibility_mask {
 } visible;
 
 /**
+ * Whether this con is tabbed or stacked
+ */
+bool swayc_is_tabbed_or_stacked(swayc_t *container);
+
+/**
  * Allocates a new output container.
  */
 swayc_t *new_output(wlc_handle handle);

--- a/sway/border.c
+++ b/sway/border.c
@@ -425,7 +425,7 @@ void render_view_borders(wlc_handle view) {
 	// if we are not the only child in the container, always draw borders,
 	// regardless of the border setting on the individual view
 	if (!c || (c->border_type == B_NONE
-			&& !((c->parent->layout == L_TABBED || c->parent->layout == L_STACKED)
+			&& !(swayc_is_tabbed_or_stacked(c->parent)
 				&& c->parent->children->length > 1))) {
 		return;
 	}
@@ -440,7 +440,7 @@ bool should_hide_top_border(swayc_t *con, double y) {
 	// sharing top border with tabbed titlebar
 	swayc_t *par = con->parent;
 	while (par->type != C_WORKSPACE) {
-		if (par->layout == L_TABBED || par->layout == L_STACKED) {
+		if (swayc_is_tabbed_or_stacked(par)) {
 			return con->y == y;
 		}
 		con = par;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -1968,7 +1968,7 @@ static struct cmd_results *cmd_layout(int argc, char **argv) {
 			parent->layout = default_layout(output);
 		}
 	} else {
-		if (parent->layout != L_TABBED && parent->layout != L_STACKED) {
+		if (!swayc_is_tabbed_or_stacked(parent)) {
 			parent->prev_layout = parent->layout;
 		}
 

--- a/sway/container.c
+++ b/sway/container.c
@@ -99,6 +99,14 @@ static void update_root_geometry() {
 	root_container.height = height;
 }
 
+bool swayc_is_tabbed_or_stacked(swayc_t *container) {
+	if (!ASSERT_NONNULL(container)) {
+		return false;
+	}
+
+	return container->layout == L_STACKED || container->layout == L_TABBED;
+}
+
 // New containers
 
 swayc_t *new_output(wlc_handle handle) {
@@ -682,7 +690,7 @@ swayc_t *container_under_pointer(void) {
 		int len;
 		// if tabbed/stacked go directly to focused container, otherwise search
 		// children
-		if (lookup->layout == L_TABBED || lookup->layout == L_STACKED) {
+		if (swayc_is_tabbed_or_stacked(lookup)) {
 			lookup = lookup->focused;
 			continue;
 		}
@@ -888,7 +896,7 @@ swayc_t *swayc_tabbed_stacked_ancestor(swayc_t *view) {
 	}
 	while (view->type != C_WORKSPACE && view->parent && view->parent->type != C_WORKSPACE) {
 		view = view->parent;
-		if (view->layout == L_TABBED || view->layout == L_STACKED) {
+		if (swayc_is_tabbed_or_stacked(view)) {
 			parent = view;
 		}
 	}
@@ -900,7 +908,7 @@ swayc_t *swayc_tabbed_stacked_parent(swayc_t *con) {
 	if (!ASSERT_NONNULL(con)) {
 		return NULL;
 	}
-	if (con->parent && (con->parent->layout == L_TABBED || con->parent->layout == L_STACKED)) {
+	if (con->parent && swayc_is_tabbed_or_stacked(con->parent)) {
 		return con->parent;
 	}
 	return NULL;

--- a/sway/focus.c
+++ b/sway/focus.c
@@ -151,7 +151,7 @@ bool set_focused_container(swayc_t *c) {
 		}
 		// set focus if view_focus is unlocked
 		wlc_view_focus(c->handle);
-		if (c->parent->layout != L_TABBED && c->parent->layout != L_STACKED) {
+		if (!swayc_is_tabbed_or_stacked(c->parent)) {
 			update_container_border(c);
 		}
 

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -396,7 +396,7 @@ static bool handle_view_created(wlc_handle handle) {
 		// layout is tabbed/stacked, add a container around newview
 		swayc_t *parent_container = newview->parent;
 		if (parent_container->type == C_WORKSPACE && parent_container->children->length == 1 &&
-				(parent_container->layout == L_TABBED || parent_container->layout == L_STACKED)) {
+				swayc_is_tabbed_or_stacked(parent_container)) {
 			swayc_t *container = new_container(newview, parent_container->layout);
 			set_focused_container(newview);
 			arrange_windows(container, -1, -1);

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -793,8 +793,7 @@ static void arrange_windows_r(swayc_t *container, double width, double height) {
 		y = container->y;
 
 		// add gaps to top level tapped/stacked container
-		if (container->parent->type == C_WORKSPACE &&
-			(container->layout == L_TABBED || container->layout == L_STACKED)) {
+		if (container->parent->type == C_WORKSPACE && swayc_is_tabbed_or_stacked(container)) {
 			update_geometry(container);
 			width = container->border_geometry.size.w;
 			height = container->border_geometry.size.h;


### PR DESCRIPTION
Add a new function `swayc_is_tabbed_or_stacked()` to determine whether or not
the given container has layout of stacked or tabbed. This is done commonly
enough that it should have its own method to help readability and code quality.

No logic changes.