### PR TITLE
bugfix: focus container on output when focused

### DIFF
--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -226,7 +226,7 @@ static void handle_output_focused(wlc_handle output, bool focus) {
 		handle_output_created(output);
 	}
 	if (focus) {
-		set_focused_container(c);
+		set_focused_container(get_focused_container(c));
 	}
 }
 


### PR DESCRIPTION
Focus the container on the output (not the output itself) when an output is
focused.

This is intended to fix a bug where borders are not updated correctly when
switching the vt away/back to sway.