### PR TITLE
common: use strtoul in parse_color to avoid clamp

### DIFF
--- a/common/util.c
+++ b/common/util.c
@@ -104,7 +104,7 @@ uint32_t parse_color(const char *color) {
 		sway_log(L_DEBUG, "Invalid color %s, defaulting to color 0xFFFFFFFF", color);
 		return 0xFFFFFFFF;
 	}
-	uint32_t res = (uint32_t)strtol(color + 1, NULL, 16);
+	uint32_t res = (uint32_t)strtoul(color + 1, NULL, 16);
 	if (strlen(color) == 7) {
 		res = (res << 8) | 0xFF;
 	}


### PR DESCRIPTION
Some implementations of strtol may clamp the values to LONG_MAX instead of
wrapping around to negative values, so use strtoul instead to parse colors.

(Mentioned in #343)