### PR TITLE
Fix switch to prev ws on handle_view_created

### DIFF
--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -410,7 +410,7 @@ static bool handle_view_created(wlc_handle handle) {
 	}
 	wlc_view_set_mask(handle, VISIBLE);
 
-	if (return_to_workspace && current_ws) {
+	if (return_to_workspace && current_ws != swayc_active_workspace()) {
 		// we were on one workspace, switched to another to add this view,
 		// now let's return to where we were
 		workspace_switch(current_ws);


### PR DESCRIPTION
Switching back to original workspace should be done only if workspace
was switched while appending new view.