### PR TITLE
added get_inputs hint to man 5 sway-input

### DIFF
--- a/sway/sway-input.5.txt
+++ b/sway/sway-input.5.txt
@@ -12,7 +12,8 @@ Description
 -----------
 
 Sway allows for configuration of libinput devices through _input { }_ blocks in
-your config file.
+your config file. To obtain a list of available devices, run **swaymsg -t
+get_inputs**.
 
 Commands
 --------


### PR DESCRIPTION
Making it more obvious where to get the proper input device names.