### PR TITLE
Handle output disabling during runtime

### DIFF
--- a/sway/config.c
+++ b/sway/config.c
@@ -859,6 +859,11 @@ void apply_input_config(struct input_config *ic, struct libinput_device *dev) {
 }
 
 void apply_output_config(struct output_config *oc, swayc_t *output) {
+	if (oc->enabled == 0) {
+		destroy_output(output);
+		return;
+	}
+
 	if (oc && oc->width > 0 && oc->height > 0) {
 		output->width = oc->width;
 		output->height = oc->height;


### PR DESCRIPTION
Output now gets disabled if disable command is invoked via bindsym or
IPC.