### PR TITLE
Fix to make ipc client code FreeBSD compatible.

### DIFF
--- a/common/ipc-client.c
+++ b/common/ipc-client.c
@@ -34,7 +34,7 @@ int ipc_open_socket(const char *socket_path) {
 	addr.sun_family = AF_UNIX;
 	strncpy(addr.sun_path, socket_path, sizeof(addr.sun_path));
 	addr.sun_path[sizeof(addr.sun_path) - 1] = 0;
-	int l = sizeof(addr.sun_family) + strlen(addr.sun_path);
+	int l = sizeof(struct sockaddr_un);
 	if (connect(socketfd, (struct sockaddr *)&addr, l) == -1) {
 		sway_abort("Unable to connect to %s", socket_path);
 	}


### PR DESCRIPTION
Calculating size of struct using "sizeof(addr.sun_family) + strlen(addr.sun_path)" is not valid on FreeBSD. 