### PR TITLE
Fix swaybar when running on named outputs.

### DIFF
--- a/sway/config.c
+++ b/sway/config.c
@@ -936,9 +936,6 @@ void apply_output_config(struct output_config *oc, swayc_t *output) {
 			execvp(cmd[0], cmd);
 		}
 	}
-
-	// reload swaybars
-	load_swaybars();
 }
 
 char *do_var_replacement(char *str) {

--- a/sway/container.c
+++ b/sway/container.c
@@ -156,6 +156,7 @@ swayc_t *new_output(wlc_handle handle) {
 
 	apply_output_config(oc, output);
 	add_child(&root_container, output);
+	load_swaybars();
 
 	// Create workspace
 	char *ws_name = NULL;

--- a/swaybar/ipc.c
+++ b/swaybar/ipc.c
@@ -278,7 +278,7 @@ void ipc_bar_init(struct bar *bar, const char *bar_id) {
 		} else {
 			int j = 0;
 			for (j = 0; j < bar->config->outputs->length; ++j) {
-				const char *conf_name = bar->config->outputs->items[i];
+				const char *conf_name = bar->config->outputs->items[j];
 				if (strcasecmp(name, conf_name) == 0) {
 					use_output = true;
 					break;


### PR DESCRIPTION
When using a bar on a named output, load_swaybars() requires the
output to be active (ie. in the root container), but this is not the case if
the bar is added to the last output. To fix this, load_swaybars() is now
called after the output has been added to the root container.

After fixing that, swaybar would segfault due to using the wrong index
variable when loading outputs and config.