### PR TITLE
add global `current_focus` pointer

### DIFF
--- a/include/sway/container.h
+++ b/include/sway/container.h
@@ -8,6 +8,7 @@
 typedef struct sway_container swayc_t;
 
 extern swayc_t root_container;
+extern swayc_t *current_focus;
 
 /**
  * Different kinds of containers.
@@ -16,11 +17,11 @@ extern swayc_t root_container;
  * it on this list.
  */
 enum swayc_types {
-	C_ROOT,				/**< The root container. Only one of these ever exists. */
-	C_OUTPUT,			/**< An output (aka monitor, head, etc). */
-	C_WORKSPACE,		/**< A workspace. */
-	C_CONTAINER,		/**< A manually created container. */
-	C_VIEW,				/**< A view (aka window). */
+	C_ROOT,		/**< The root container. Only one of these ever exists. */
+	C_OUTPUT,	/**< An output (aka monitor, head, etc). */
+	C_WORKSPACE,	/**< A workspace. */
+	C_CONTAINER,	/**< A manually created container. */
+	C_VIEW,		/**< A view (aka window). */
 	// Keep last
 	C_TYPES,
 };
@@ -29,20 +30,20 @@ enum swayc_types {
  * Different ways to arrange a container.
  */
 enum swayc_layouts {
-	L_NONE, 			/**< Used for containers that have no layout (views, root) */
+	L_NONE,		/**< Used for containers that have no layout (views, root) */
 	L_HORIZ,
 	L_VERT,
 	L_STACKED,
 	L_TABBED,
-	L_FLOATING,			/**< A psuedo-container, removed from the tree, to hold floating windows */
+	L_FLOATING,	/**< A psuedo-container, removed from the tree, to hold floating windows */
 	// Keep last
 	L_LAYOUTS,
 };
 
 enum swayc_border_types {
-	B_NONE,             /**< No border */
-	B_PIXEL,            /**< 1px border */
-	B_NORMAL            /**< Normal border with title bar */
+	B_NONE,		/**< No border */
+	B_PIXEL,	/**< 1px border */
+	B_NORMAL	/**< Normal border with title bar */
 };
 
 /**

--- a/sway/focus.c
+++ b/sway/focus.c
@@ -120,6 +120,10 @@ bool set_focused_container(swayc_t *c) {
 		// dispatch a window event
 		ipc_event_window(c, "focus");
 	}
+
+	// update the global pointer
+	current_focus = c;
+
 	// update container focus from here to root, making necessary changes along
 	// the way
 	swayc_t *p = c;

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -15,6 +15,7 @@
 #include "log.h"
 
 swayc_t root_container;
+swayc_t *current_focus;
 list_t *scratchpad;
 
 int min_sane_h = 60;
@@ -27,6 +28,7 @@ void init_layout(void) {
 	root_container.children = create_list();
 	root_container.handle = -1;
 	root_container.visible = true;
+	current_focus = &root_container;
 	scratchpad = create_list();
 }
 


### PR DESCRIPTION
Based on some test logging I think setting this pointer in `set_focused_container()` should be sufficient. I also set it to the root container in `init_layout()`; I do not know if that is a useful thing to do.