### PR TITLE
implement "focused container" option for swaygrab

### DIFF
--- a/include/swaygrab/json.h
+++ b/include/swaygrab/json.h
@@ -1,0 +1,10 @@
+#include <json-c/json.h>
+#include "wlc/wlc.h"
+
+void init_json_tree(int socketfd);
+void free_json_tree();
+char *get_focused_output();
+char *create_payload(const char *output, struct wlc_geometry *g);
+struct wlc_geometry *get_container_geometry(json_object *container);
+json_object *get_focused_container();
+json_object *get_output_container(const char *output);

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -169,7 +169,6 @@ static void ipc_json_describe_view(swayc_t *c, json_object *object) {
 	json_object_object_add(object, "percent", (percent > 0) ? json_object_new_double(percent) : NULL);
 	// TODO: make urgency actually work once Sway supports it
 	json_object_object_add(object, "urgent", json_object_new_boolean(false));
-
 	json_object_object_add(object, "layout",
 		(strcmp(layout, "null") == 0) ? NULL : json_object_new_string(layout));
 	json_object_object_add(object, "last_split_layout",

--- a/swaygrab/CMakeLists.txt
+++ b/swaygrab/CMakeLists.txt
@@ -6,6 +6,7 @@ include_directories(
 
 add_executable(swaygrab
 	main.c
+	json.c
 )
 
 target_link_libraries(swaygrab

--- a/swaygrab/json.c
+++ b/swaygrab/json.c
@@ -1,0 +1,123 @@
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "ipc-client.h"
+#include "swaygrab/json.h"
+
+static json_object *tree;
+
+void init_json_tree(int socketfd) {
+	uint32_t len = 0;
+	char *res = ipc_single_command(socketfd, IPC_GET_TREE, NULL, &len);
+	tree = json_tokener_parse(res);
+}
+
+void free_json_tree() {
+	json_object_put(tree);
+}
+
+static bool is_focused(json_object *c) {
+	json_object *focused;
+	json_object_object_get_ex(c, "focused", &focused);
+	return json_object_get_boolean(focused);
+}
+
+static json_object *get_focused_container_r(json_object *c) {
+	json_object *name;
+	json_object_object_get_ex(c, "name", &name);
+	if (is_focused(c)) {
+		return c;
+	} else {
+		json_object *nodes, *node, *child;
+		json_object_object_get_ex(c, "nodes", &nodes);
+		int i;
+		for (i = 0; i < json_object_array_length(nodes); i++) {
+			node = json_object_array_get_idx(nodes, i);
+
+			if ((child = get_focused_container_r(node))) {
+				return child;
+			}
+		}
+
+		json_object_object_get_ex(c, "floating_nodes", &nodes);
+		for (i = 0; i < json_object_array_length(nodes); i++) {
+			node = json_object_array_get_idx(nodes, i);
+
+			if ((child = get_focused_container_r(node))) {
+				return child;
+			}
+		}
+
+	}
+
+	return NULL;
+}
+
+json_object *get_focused_container() {
+	return get_focused_container_r(tree);
+}
+
+char *get_focused_output() {
+	json_object *outputs, *output, *name;
+	json_object_object_get_ex(tree, "nodes", &outputs);
+
+	for (int i = 0; i < json_object_array_length(outputs); i++) {
+		output = json_object_array_get_idx(outputs, i);
+
+		if (get_focused_container_r(output)) {
+			json_object_object_get_ex(output, "name", &name);
+			return strdup(json_object_get_string(name));
+		}
+	}
+
+	return NULL;
+}
+
+char *create_payload(const char *output, struct wlc_geometry *g) {
+	char *payload_str = malloc(256);
+	json_object *payload = json_object_new_object();
+
+	json_object_object_add(payload, "output", json_object_new_string(output));
+	json_object_object_add(payload, "x", json_object_new_int(g->origin.x));
+	json_object_object_add(payload, "y", json_object_new_int(g->origin.y));
+	json_object_object_add(payload, "w", json_object_new_int(g->size.w));
+	json_object_object_add(payload, "h", json_object_new_int(g->size.h));
+
+	snprintf(payload_str, 256, "%s", json_object_to_json_string(payload));
+	return strdup(payload_str);
+}
+
+struct wlc_geometry *get_container_geometry(json_object *container) {
+	struct wlc_geometry *geo = malloc(sizeof(struct wlc_geometry));
+	json_object *rect, *x, *y, *w, *h;
+
+	json_object_object_get_ex(container, "rect", &rect);
+	json_object_object_get_ex(rect, "x", &x);
+	json_object_object_get_ex(rect, "y", &y);
+	json_object_object_get_ex(rect, "width", &w);
+	json_object_object_get_ex(rect, "height", &h);
+
+	geo->origin.x = json_object_get_int(x);
+	geo->origin.y = json_object_get_int(y);
+	geo->size.w = json_object_get_int(w);
+	geo->size.h = json_object_get_int(h);
+
+	return geo;
+}
+
+json_object *get_output_container(const char *output) {
+	json_object *outputs, *json_output, *name;
+	json_object_object_get_ex(tree, "nodes", &outputs);
+
+	for (int i = 0; i < json_object_array_length(outputs); i++) {
+		json_output = json_object_array_get_idx(outputs, i);
+		json_object_object_get_ex(json_output, "name", &name);
+
+		if (strcmp(json_object_get_string(name), output) == 0) {
+			return json_output;
+		}
+	}
+
+	return NULL;
+}


### PR DESCRIPTION
`swaygrab -f` will grab only the focused container instead of the whole output. Tested with both the image and video options. Requires [this WLC commit](https://github.com/Cloudef/wlc/commit/5c4528bd3ff7e4bdcd7356b5f902b10d5be9a27f), otherwise the geometry gets wonky.