### PR TITLE
parse pango markup in workspace names (and bugfix)

### DIFF
--- a/swaybar/render.c
+++ b/swaybar/render.c
@@ -205,7 +205,7 @@ void workspace_button_size(struct window *window, const char *workspace_name, in
 	const char *stripped_name = strip_workspace_name(swaybar.config->strip_workspace_numbers, workspace_name);
 
 	get_text_size(window->cairo, window->font, width, height,
-			window->scale, false, "%s", stripped_name);
+			window->scale, true, "%s", stripped_name);
 	*width += 2 * ws_horizontal_padding;
 	*height += 2 * ws_vertical_padding;
 }
@@ -241,7 +241,7 @@ static void render_workspace_button(struct window *window, struct config *config
 	cairo_set_source_u32(window->cairo, box_colors.text);
 	cairo_move_to(window->cairo, (int)*x + ws_horizontal_padding, margin);
 	pango_printf(window->cairo, window->font, window->scale,
-			false, "%s", stripped_name);
+			true, "%s", stripped_name);
 
 	*x += width + ws_spacing;
 }

--- a/wayland/pango.c
+++ b/wayland/pango.c
@@ -11,9 +11,10 @@ PangoLayout *get_pango_layout(cairo_t *cairo, const char *font, const char *text
 		int32_t scale, bool markup) {
 	PangoLayout *layout = pango_cairo_create_layout(cairo);
 	PangoAttrList *attrs = pango_attr_list_new();
+	char *buf = malloc(2048);
 	if (markup) {
-		pango_parse_markup(text, -1, 0, &attrs, NULL, NULL, NULL);
-		pango_layout_set_markup(layout, text, -1);
+		pango_parse_markup(text, -1, 0, &attrs, &buf, NULL, NULL);
+		pango_layout_set_markup(layout, buf, -1);
 	} else {
 		pango_layout_set_text(layout, text, -1);
 	}
@@ -24,6 +25,7 @@ PangoLayout *get_pango_layout(cairo_t *cairo, const char *font, const char *text
 	pango_layout_set_attributes(layout, attrs);
 	pango_attr_list_unref(attrs);
 	pango_font_description_free(desc);
+	free(buf);
 	return layout;
 }
 


### PR DESCRIPTION
Fixes #897. This change allows using numeric character references in workspace names
- for example &#230; which stands for sharp s. A fix was necessary in
get_pango_layout, since markup and parsed markup had different width.