### PR TITLE
Fixes dealing with workspace_layout and related bugs [rfc]

### DIFF
--- a/include/sway/container.h
+++ b/include/sway/container.h
@@ -68,6 +68,7 @@ struct sway_container {
 	enum swayc_types type;
 	enum swayc_layouts layout;
 	enum swayc_layouts prev_layout;
+	enum swayc_layouts workspace_layout;
 
 	/**
 	 * Width and height of this container, without borders or gaps.
@@ -320,5 +321,11 @@ void update_visibility(swayc_t *container);
  * Close all child views of container
  */
 void close_views(swayc_t *container);
+
+/**
+ * Assign layout to a container. Needed due to workspace container specifics.
+ * Workspace always needs L_HORIZ layout.
+ */
+swayc_t *swayc_change_layout(swayc_t *container, enum swayc_layouts layout);
 
 #endif

--- a/sway/commands/layout.c
+++ b/sway/commands/layout.c
@@ -22,10 +22,10 @@ struct cmd_results *cmd_layout(int argc, char **argv) {
 	enum swayc_layouts old_layout = parent->layout;
 
 	if (strcasecmp(argv[0], "default") == 0) {
-		parent->layout = parent->prev_layout;
+		swayc_change_layout(parent, parent->prev_layout);
 		if (parent->layout == L_NONE) {
 			swayc_t *output = swayc_parent_by_type(parent, C_OUTPUT);
-			parent->layout = default_layout(output);
+			swayc_change_layout(parent, default_layout(output));
 		}
 	} else {
 		if (parent->layout != L_TABBED && parent->layout != L_STACKED) {
@@ -37,22 +37,22 @@ struct cmd_results *cmd_layout(int argc, char **argv) {
 				parent = new_container(parent, L_TABBED);
 			}
 
-			parent->layout = L_TABBED;
+			swayc_change_layout(parent, L_TABBED);
 		} else if (strcasecmp(argv[0], "stacking") == 0) {
 			if (parent->type != C_CONTAINER && !swayc_is_empty_workspace(parent)) {
 				parent = new_container(parent, L_STACKED);
 			}
 
-			parent->layout = L_STACKED;
+			swayc_change_layout(parent, L_STACKED);
 		} else if (strcasecmp(argv[0], "splith") == 0) {
-			parent->layout = L_HORIZ;
+			swayc_change_layout(parent, L_HORIZ);
 		} else if (strcasecmp(argv[0], "splitv") == 0) {
-			parent->layout = L_VERT;
+			swayc_change_layout(parent, L_VERT);
 		} else if (strcasecmp(argv[0], "toggle") == 0 && argc == 2 && strcasecmp(argv[1], "split") == 0) {
 			if (parent->layout == L_VERT) {
-				parent->layout = L_HORIZ;
+				swayc_change_layout(parent, L_HORIZ);
 			} else {
-				parent->layout = L_VERT;
+				swayc_change_layout(parent, L_VERT);
 			}
 		}
 	}

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -37,7 +37,7 @@ struct cmd_results *cmd_move(int argc, char **argv) {
 				if (!view->children || view->children->length == 0) {
 					return cmd_results_new(CMD_FAILURE, "move", "Cannot move an empty workspace");
 				}
-				view = new_container(view, view->layout);
+				view = new_container(view, view->workspace_layout);
 			} if (view->type != C_CONTAINER && view->type != C_VIEW) {
 				return cmd_results_new(CMD_FAILURE, "move", "Can only move containers and views.");
 			}
@@ -65,7 +65,7 @@ struct cmd_results *cmd_move(int argc, char **argv) {
 				if (!view->children || view->children->length == 0) {
 					return cmd_results_new(CMD_FAILURE, "move", "Cannot move an empty workspace");
 				}
-				view = new_container(view, view->layout);
+				view = new_container(view, view->workspace_layout);
 			} else if (view->type != C_CONTAINER && view->type != C_VIEW) {
 				return cmd_results_new(CMD_FAILURE, "move", "Can only move containers and views.");
 			} else if (!(output = output_by_name(argv[3], &abs_pos))) {

--- a/sway/commands/split.c
+++ b/sway/commands/split.c
@@ -25,11 +25,11 @@ static struct cmd_results *_do_split(int argc, char **argv, int layout) {
 	/* Case that focus is on an workspace with 0/1 children.change its layout */
 	if (focused->type == C_WORKSPACE && focused->children->length <= 1) {
 		sway_log(L_DEBUG, "changing workspace layout");
-		focused->layout = layout;
+		swayc_change_layout(focused, layout);
 	} else if (focused->type != C_WORKSPACE && focused->parent->children->length == 1) {
 		/* Case of no siblings. change parent layout */
 		sway_log(L_DEBUG, "changing container layout");
-		focused->parent->layout = layout;
+		swayc_change_layout(focused->parent, layout);
 	} else {
 		/* regular case where new split container is build around focused container
 		 * or in case of workspace, container inherits its children */

--- a/sway/container.c
+++ b/sway/container.c
@@ -27,6 +27,7 @@ static swayc_t *new_swayc(enum swayc_types type) {
 	c->handle = -1;
 	c->gaps = -1;
 	c->layout = L_NONE;
+	c->workspace_layout = L_NONE;
 	c->type = type;
 	if (type != C_VIEW) {
 		c->children = create_list();
@@ -209,7 +210,8 @@ swayc_t *new_workspace(swayc_t *output, const char *name) {
 	swayc_t *workspace = new_swayc(C_WORKSPACE);
 
 	workspace->prev_layout = L_NONE;
-	workspace->layout = default_layout(output);
+	workspace->layout = L_HORIZ;
+	workspace->workspace_layout = default_layout(output);
 
 	workspace->x = output->x;
 	workspace->y = output->y;
@@ -262,7 +264,7 @@ swayc_t *new_container(swayc_t *child, enum swayc_layouts layout) {
 		// add container to workspace chidren
 		add_child(workspace, cont);
 		// give them proper layouts
-		cont->layout = workspace->layout;
+		cont->layout = workspace->workspace_layout;
 		cont->prev_layout = workspace->prev_layout;
 		/* TODO: might break shit in move_container!!! workspace->layout = layout; */
 		set_focused_container_for(workspace, get_focused_view(workspace));
@@ -928,4 +930,13 @@ swayc_t *swayc_tabbed_stacked_parent(swayc_t *con) {
 		return con->parent;
 	}
 	return NULL;
+}
+
+swayc_t *swayc_change_layout(swayc_t *container, enum swayc_layouts layout) {
+	if (container->type == C_WORKSPACE) {
+		container->workspace_layout = layout;
+	} else {
+		container->layout = layout;
+	}
+	return container;
 }

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -344,7 +344,7 @@ static bool handle_view_created(wlc_handle handle) {
 		} else {
 			if (focused->type == C_WORKSPACE &&
 				/* focused->children->length == 0 && */
-				(focused->layout == L_TABBED || focused->layout == L_STACKED)) {
+				(focused->workspace_layout == L_TABBED || focused->workspace_layout == L_STACKED)) {
 				// will wrap the view in a container later on
 				encapsulate_view = true;
 			}

--- a/sway/handlers.c
+++ b/sway/handlers.c
@@ -334,7 +334,6 @@ static bool handle_view_created(wlc_handle handle) {
 		wlc_view_get_geometry(handle)->size.h, wlc_view_get_title(handle),
 		wlc_view_get_class(handle), wlc_view_get_app_id(handle));
 
-	bool encapsulate_view = false;
 	// TODO properly figure out how each window should be handled.
 	switch (wlc_view_get_type(handle)) {
 	// regular view created regularly
@@ -342,12 +341,6 @@ static bool handle_view_created(wlc_handle handle) {
 		if (parent) {
 			newview = new_floating_view(handle);
 		} else {
-			if (focused->type == C_WORKSPACE &&
-				/* focused->children->length == 0 && */
-				(focused->workspace_layout == L_TABBED || focused->workspace_layout == L_STACKED)) {
-				// will wrap the view in a container later on
-				encapsulate_view = true;
-			}
 			newview = new_view(focused, handle);
 			wlc_view_set_state(handle, WLC_BIT_MAXIMIZED, true);
 		}
@@ -381,10 +374,6 @@ static bool handle_view_created(wlc_handle handle) {
 	suspend_workspace_cleanup = true;
 
 	if (newview) {
-		// first view on tabbed/stacked workspace was created, wrap it in a container
-		if (encapsulate_view && newview->parent) {
-			new_container(newview, newview->parent->workspace_layout);
-		}
 		ipc_event_window(newview, "new");
 		set_focused_container(newview);
 		wlc_view_set_mask(handle, VISIBLE);

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -302,7 +302,8 @@ void move_container(swayc_t *container, enum movement_direction dir) {
 		}
 		// Change parent layout if we need to
 		if (parent->children->length == 1 && parent->layout != layout) {
-			parent->layout = layout;
+			swayc_change_layout(parent, layout);
+			/* parent->layout = layout; */
 			continue;
 		}
 		if (parent->type == C_WORKSPACE) {

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -66,6 +66,11 @@ void add_child(swayc_t *parent, swayc_t *child) {
 	if (!parent->focused) {
 		parent->focused = child;
 	}
+
+	// wrap view into a container
+	if (parent->type == C_WORKSPACE && child->type == C_VIEW) {
+		new_container(child, parent->workspace_layout);
+	}
 }
 
 void insert_child(swayc_t *parent, swayc_t *child, int index) {
@@ -79,6 +84,11 @@ void insert_child(swayc_t *parent, swayc_t *child, int index) {
 	child->parent = parent;
 	if (!parent->focused) {
 		parent->focused = child;
+	}
+
+	// wrap view into a container
+	if (parent->type == C_WORKSPACE && child->type == C_VIEW) {
+		new_container(child, parent->workspace_layout);
 	}
 }
 


### PR DESCRIPTION
Fix #901. Minimal working example: default config, on empty workspace $mod+w, ```swaymsg exec nautilus```, Ctrl+i. Previously you'd get a segfault, after fixing that the popup would appear, but nautilus would become invisible. That's fixed in the second commit.