### PR TITLE
Add left_handed support for input devices

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -173,6 +173,7 @@ sway_cmd input_cmd_click_method;
 sway_cmd input_cmd_drag_lock;
 sway_cmd input_cmd_dwt;
 sway_cmd input_cmd_events;
+sway_cmd input_cmd_left_handed;
 sway_cmd input_cmd_middle_emulation;
 sway_cmd input_cmd_natural_scroll;
 sway_cmd input_cmd_pointer_accel;

--- a/include/sway/config.h
+++ b/include/sway/config.h
@@ -60,6 +60,7 @@ struct input_config {
 	int click_method;
 	int drag_lock;
 	int dwt;
+	int left_handed;
 	int middle_emulation;
 	int natural_scroll;
 	float pointer_accel;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -265,6 +265,7 @@ static struct cmd_handler input_handlers[] = {
 	{ "drag_lock", input_cmd_drag_lock },
 	{ "dwt", input_cmd_dwt },
 	{ "events", input_cmd_events },
+	{ "left_handed", input_cmd_left_handed },
 	{ "middle_emulation", input_cmd_middle_emulation },
 	{ "natural_scroll", input_cmd_natural_scroll },
 	{ "pointer_accel", input_cmd_pointer_accel },

--- a/sway/commands/input.c
+++ b/sway/commands/input.c
@@ -31,6 +31,8 @@ struct cmd_results *cmd_input(int argc, char **argv) {
 			res = input_cmd_dwt(argc_new, argv_new);
 		} else if (strcasecmp("events", argv[1]) == 0) {
 			res = input_cmd_events(argc_new, argv_new);
+		} else if (strcasecmp("left_handed", argv[1]) == 0) {
+			res = input_cmd_left_handed(argc_new, argv_new);
 		} else if (strcasecmp("middle_emulation", argv[1]) == 0) {
 			res = input_cmd_middle_emulation(argc_new, argv_new);
 		} else if (strcasecmp("natural_scroll", argv[1]) == 0) {

--- a/sway/commands/input/left_handed.c
+++ b/sway/commands/input/left_handed.c
@@ -1,0 +1,25 @@
+#include <string.h>
+#include "sway/commands.h"
+#include "sway/input.h"
+
+struct cmd_results *input_cmd_left_handed(int argc, char **argv) {
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "left_handed", EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+	if (!current_input_config) {
+		return cmd_results_new(CMD_FAILURE, "left_handed", "No input device defined.");
+	}
+	struct input_config *new_config = new_input_config(current_input_config->identifier);
+
+	if (strcasecmp(argv[0], "enabled") == 0) {
+		new_config->left_handed = 1;
+	} else if (strcasecmp(argv[0], "disabled") == 0) {
+		new_config->left_handed = 0;
+	} else {
+		return cmd_results_new(CMD_INVALID, "left_handed", "Expected 'left_handed <enabled|disabled>'");
+	}
+
+	input_cmd_apply(new_config);
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}

--- a/sway/config.c
+++ b/sway/config.c
@@ -832,6 +832,10 @@ void apply_input_config(struct input_config *ic, struct libinput_device *dev) {
 		sway_log(L_DEBUG, "apply_input_config(%s) dwt_set_enabled(%d)", ic->identifier, ic->dwt);
 		libinput_device_config_dwt_set_enabled(dev, ic->dwt);
 	}
+	if (ic->left_handed != INT_MIN) {
+		sway_log(L_DEBUG, "apply_input_config(%s) left_handed_set_enabled(%d)", ic->identifier, ic->left_handed);
+		libinput_device_config_left_handed_set(dev, ic->left_handed);
+	}
 	if (ic->middle_emulation != INT_MIN) {
 		sway_log(L_DEBUG, "apply_input_config(%s) middle_emulation_set_enabled(%d)", ic->identifier, ic->middle_emulation);
 		libinput_device_config_middle_emulation_set_enabled(dev, ic->middle_emulation);

--- a/sway/input.c
+++ b/sway/input.c
@@ -24,6 +24,7 @@ struct input_config *new_input_config(const char* identifier) {
 	input->accel_profile = INT_MIN;
 	input->pointer_accel = FLT_MIN;
 	input->scroll_method = INT_MIN;
+	input->left_handed = INT_MIN;
 
 	return input;
 }

--- a/sway/sway-input.5.txt
+++ b/sway/sway-input.5.txt
@@ -34,6 +34,9 @@ Commands
 	Enables or disables send_events for specified input device.
 	(Disabling  send_events disables the input device)
 
+**input** <identifier> left_handed <enabled|disabled>::
+	Enables or disables left handed mode for specified input device.
+
 **input** <identifier> middle_emulation <enabled|disabled>::
 	Enables or disables middle click emulation.
 


### PR DESCRIPTION
Some users may want to switch buttons on their input devices, turns out
libinput already supports it. Let's add a support for it in our config.

Signed-off-by: Michał Winiarski <knr@hardline.pl>