### PR TITLE
Change layout toggle to default on horizontal split

### DIFF
--- a/sway/commands/layout.c
+++ b/sway/commands/layout.c
@@ -49,10 +49,10 @@ struct cmd_results *cmd_layout(int argc, char **argv) {
 		} else if (strcasecmp(argv[0], "splitv") == 0) {
 			parent->layout = L_VERT;
 		} else if (strcasecmp(argv[0], "toggle") == 0 && argc == 2 && strcasecmp(argv[1], "split") == 0) {
-			if (parent->layout == L_VERT) {
-				parent->layout = L_HORIZ;
-			} else {
+			if (parent->layout == L_HORIZ) {
 				parent->layout = L_VERT;
+			} else {
+				parent->layout = L_HORIZ;
 			}
 		}
 	}


### PR DESCRIPTION
This minor patch turns around an if-clause, which makes ```layout toggle``` default to horizontal instead of vertical split, which can be observed when issuing the command on a tabbed or stacked container.