### PR TITLE
Use CMAKE_INSTALL_FULL_DATA{,ROOT}DIR

### DIFF
--- a/CMake/Manpage.cmake
+++ b/CMake/Manpage.cmake
@@ -25,7 +25,7 @@ function(add_manpage name section)
 
 	install(
 		FILES ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${name}.${section}
-		DESTINATION share/man/man${section}
+		DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/man/man${section}
 		COMPONENT documentation
 	)
 endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,14 +129,14 @@ if(zsh-completions)
 endif()
 install(
 	FILES ${CMAKE_CURRENT_SOURCE_DIR}/sway.desktop
-	DESTINATION share/wayland-sessions
+	DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/wayland-sessions
 	COMPONENT data
 	)
 
 if(default-wallpaper)
 	install(
         DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/assets/
-		DESTINATION share/sway
+		DESTINATION ${CMAKE_INSTALL_FULL_DATADIR}/sway
 		COMPONENT data
         FILES_MATCHING PATTERN "*Wallpaper*"
 		)

--- a/completions/zsh/CMakeLists.txt
+++ b/completions/zsh/CMakeLists.txt
@@ -1,4 +1,4 @@
 install(
 	FILES _sway _swaymsg _swaygrab _swaylock
-	DESTINATION share/zsh/site-functions/
+	DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/zsh/site-functions/
 )

--- a/config.in
+++ b/config.in
@@ -20,8 +20,8 @@ set $menu dmenu_run
 
 ### Output configuration
 #
-# Default wallpaper (more resolutions are available in /usr/share/sway/)
-output * bg /usr/share/sway/Sway_Wallpaper_Blue_1920x1080.png fill
+# Default wallpaper (more resolutions are available in __DATADIR__/sway/)
+output * bg __DATADIR__/sway/Sway_Wallpaper_Blue_1920x1080.png fill
 #
 # Example configuration:
 #

--- a/sway/CMakeLists.txt
+++ b/sway/CMakeLists.txt
@@ -74,7 +74,7 @@ function(add_config name source destination)
     add_custom_command(
         OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${name}
         COMMAND sed -r
-            's?__PREFIX__?${CMAKE_INSTALL_PREFIX}?g\; s?__SYSCONFDIR__?${CMAKE_INSTALL_FULL_SYSCONFDIR}?g'
+            's?__PREFIX__?${CMAKE_INSTALL_PREFIX}?g\; s?__SYSCONFDIR__?${CMAKE_INSTALL_FULL_SYSCONFDIR}?g\; s?__DATADIR__?${CMAKE_INSTALL_FULL_DATADIR}?g'
             ${PROJECT_SOURCE_DIR}/${source}.in > ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${name}
         DEPENDS ${PROJECT_SOURCE_DIR}/${source}.in
         COMMENT "Generating config file ${source}"


### PR DESCRIPTION
Exherbo installs architecture dependent data in a different place than architecture
independent data. More concretely: binaries go in /usr/$chost/{bin,lib},
data goes in /usr/share and configs in /etc, /etc is already configurable
through CMAKE_INSTALL_FULL_SYSCONFDIR but the datadir was not. This
patch fixes it so that things can be pushed in the right places.