### PR TITLE
sway: extensions: make locking give back focus

### DIFF
--- a/sway/extensions.c
+++ b/sway/extensions.c
@@ -65,9 +65,11 @@ void lock_surface_destructor(struct wl_resource *resource) {
 		if (surface == resource) {
 			list_del(desktop_shell.lock_surfaces, i);
 			arrange_windows(&root_container, -1, -1);
-			desktop_shell.is_locked = false;
 			break;
 		}
+	}
+	if (desktop_shell.lock_surfaces->length == 0) {
+		desktop_shell.is_locked = false;
 	}
 }
 


### PR DESCRIPTION
Don't switch the internal tracking of focus to the swaylock surface,
to allow for switching back to the previously active window (or the
currently active window, if some new process changed).

Closes #998
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>