### PR TITLE
Improve configuration file processing

### DIFF
--- a/common/readline.c
+++ b/common/readline.c
@@ -7,33 +7,16 @@
 #include "readline.h"
 #include "stringop.h"
 
-/***************************************************************************//**
-*
-*	\brief	Read one line of the file. Lines beginning with '#' are skipped.
-*		Whitespace is stripped.
-*
-*	\param[in]	file	Pointer to the already open configuration file. If NULL is
-*		passed, no operation is performed.
-*
-*	\return		String containing one single line from the file.
-*
-******************************************************************************/
 inline char* read_line(FILE* restrict const file) {
 	char* line = NULL;
 	if (file) {
 		size_t line_length = 0u;
 		const ssize_t bytes_read = getline(&line, &line_length, file);
-		if (line) {
-			assert(line_length);
+		if (line && line_length) {
 			if (0 > bytes_read) {
 				free(line);
 				line = NULL;
 			} else {
-				strip_whitespace(line);
-				if (line[0] == '#') {
-					free(line);
-					line = NULL;
-				}
 			}
 		}
 	}

--- a/common/readline.c
+++ b/common/readline.c
@@ -9,15 +9,13 @@
 
 /***************************************************************************//**
 *
-* \brief			Read one line of the configuration file.
+*	\brief	Read one line of the file. Lines beginning with '#' are skipped.
+*		Whitespace is stripped.
 *
-* \param			file	Pointer to the already open configuration file. If NULL is
-*										passed, no operation is performed.
+*	\param[in]	file	Pointer to the already open configuration file. If NULL is
+*		passed, no operation is performed.
 *
-* \return			String containing one single line from the configuration file.
-*							This string is not necessarily in the format how it is expected
-*							for further processing of configuration commands. NULL is
-*							returned in case of failure or if NULL is passed for 'file'.
+*	\return		String containing one single line from the file.
 *
 ******************************************************************************/
 inline char* read_line(FILE* restrict const file) {

--- a/common/stringop.c
+++ b/common/stringop.c
@@ -10,22 +10,32 @@
 
 const char whitespace[] = " \f\n\r\t\v";
 
-char *strip_whitespace(char *_str) {
-	if (*_str == '\0')
-		return _str;
-	char *strold = _str;
-	while (*_str == ' ' || *_str == '\t') {
-		_str++;
+/**************************************************************************//**
+ *
+ * \brief		Strips the whitespace in front and rear of the string. If whitespace
+ *					is found in the middle of the string, all but one space is removed
+ *					between words.
+ *
+ * \param		str	Pointer to the char string that should be stripped. The string
+ *							is modified. If NULL is passed, no operation is performed.
+ *
+ ******************************************************************************/
+void strip_whitespace(char * restrict const str)
+{
+	if (NULL != str) {
+		unsigned int count = 0u;
+		for (unsigned int index = 0u; str[index]; ++index) {
+			if (' ' != str[index] && '\t' != str[index]) {
+				str[count++] = str[index];
+			} else if(0u < count && ' ' != str[count-1u] && '\t' != str[count-1u]) {
+				str[count++] = ' ';
+			}
+		}
+		str[count] = '\0';
+		if (0u < count && (' ' == str[count-1u] || '\t' == str[count-1u])) {
+			str[count-1u] = '\0';
+		}
 	}
-	char *str = strdup(_str);
-	free(strold);
-	int i;
-	for (i = 0; str[i] != '\0'; ++i);
-	do {
-		i--;
-	} while (i >= 0 && (str[i] == ' ' || str[i] == '\t'));
-	str[i + 1] = '\0';
-	return str;
 }
 
 void strip_quotes(char *str) {

--- a/common/stringop.c
+++ b/common/stringop.c
@@ -293,6 +293,24 @@ static bool has_whitespace(const char *str) {
 	return false;
 }
 
+
+/*
+ * Returns true if the string contains only whitespace and false otherwise.
+ */
+bool is_empty(const char *str) {
+	bool ret = true;
+	if (str) {
+		while (*str != '\0') {
+			if (!isspace(*(const unsigned char*)str)) {
+				ret = false;
+				break;
+			}
+			str++;
+		}
+	}
+	return ret;
+}
+
 /**
  * Add quotes around any argv with whitespaces.
  */

--- a/common/stringop.c
+++ b/common/stringop.c
@@ -20,20 +20,19 @@ const char whitespace[] = " \f\n\r\t\v";
  *							is modified. If NULL is passed, no operation is performed.
  *
  ******************************************************************************/
-void strip_whitespace(char * restrict const str)
-{
-	if (NULL != str) {
-		unsigned int count = 0u;
-		for (unsigned int index = 0u; str[index]; ++index) {
+void strip_whitespace(char * restrict const str) {
+	if (str) {
+		size_t count = 0;
+		for (size_t index = 0; str[index]; ++index) {
 			if (' ' != str[index] && '\t' != str[index]) {
 				str[count++] = str[index];
-			} else if(0u < count && ' ' != str[count-1u] && '\t' != str[count-1u]) {
+			} else if(0 < count && ' ' != str[count - 1] && '\t' != str[count - 1]) {
 				str[count++] = ' ';
 			}
 		}
 		str[count] = '\0';
-		if (0u < count && (' ' == str[count-1u] || '\t' == str[count-1u])) {
-			str[count-1u] = '\0';
+		if (0 < count && (' ' == str[count - 1] || '\t' == str[count - 1])) {
+			str[count - 1] = '\0';
 		}
 	}
 }
@@ -298,17 +297,16 @@ static bool has_whitespace(const char *str) {
  * Returns true if the string contains only whitespace and false otherwise.
  */
 bool is_empty(const char *str) {
-	bool ret = true;
-	if (str) {
-		while (*str != '\0') {
-			if (!isspace(*(const unsigned char*)str)) {
-				ret = false;
-				break;
-			}
-			str++;
-		}
+	if(!str) {
+		return true;
 	}
-	return ret;
+	while (*str != '\0') {
+		if (!isspace(*(unsigned char*)str)) {
+			return false;
+		}
+		str++;
+	}
+	return true;
 }
 
 /**

--- a/common/stringop.c
+++ b/common/stringop.c
@@ -10,24 +10,35 @@
 
 const char whitespace[] = " \f\n\r\t\v";
 
-/**************************************************************************//**
- *
- * \brief		Strips the whitespace in front and rear of the string. If whitespace
- *					is found in the middle of the string, all but one space is removed
- *					between words.
- *
- * \param		str	Pointer to the char string that should be stripped. The string
- *							is modified. If NULL is passed, no operation is performed.
- *
- ******************************************************************************/
-void strip_whitespace(char * restrict const str) {
+void strip_whitespace(char *str)
+{
 	if (str) {
 		size_t count = 0;
+		char quote = ' ';
 		for (size_t index = 0; str[index]; ++index) {
-			if (' ' != str[index] && '\t' != str[index]) {
+			if (quote != '\'' && quote != '\"') {
+				if (' ' != str[index] && '\t' != str[index]) {
+					str[count++] = str[index];
+					if (str[index] == '\'') {
+						quote = '\'';
+					} else if (str[index] == '\"') {
+						quote = '\"';
+					}
+				} else if(0 < count && ' ' != str[count - 1] && '\t' != str[count - 1]) {
+					str[count++] = ' ';
+				}
+			} else if (quote == '\'') {
 				str[count++] = str[index];
-			} else if(0 < count && ' ' != str[count - 1] && '\t' != str[count - 1]) {
-				str[count++] = ' ';
+				if (str[index] == '\'') {
+					quote = ' ';
+				}
+			} else if (quote == '\"') {
+				str[count++] = str[index];
+				if (str[index] == '\"') {
+					quote = ' ';
+				}
+			} else {
+				/* Unexpected value for quote. */
 			}
 		}
 		str[count] = '\0';
@@ -36,6 +47,7 @@ void strip_whitespace(char * restrict const str) {
 		}
 	}
 }
+
 
 void strip_quotes(char *str) {
 	bool in_str = false;

--- a/include/stringop.h
+++ b/include/stringop.h
@@ -1,5 +1,7 @@
 #ifndef _SWAY_STRINGOP_H
 #define _SWAY_STRINGOP_H
+
+#include <stdbool.h>
 #include "list.h"
 
 #if !HAVE_DECL_SETENV
@@ -13,6 +15,9 @@ extern const char whitespace[];
 void strip_whitespace(char *str);
 char *strip_comments(char *str);
 void strip_quotes(char *str);
+
+// Returns true if the string contains only whitespace.
+bool is_empty(const char *str);
 
 // strcmp that also handles null pointers.
 int lenient_strcmp(char *a, char *b);

--- a/include/stringop.h
+++ b/include/stringop.h
@@ -10,7 +10,7 @@ extern int setenv(const char *, const char *, int);
 // array of whitespace characters to use for delims
 extern const char whitespace[];
 
-char *strip_whitespace(char *str);
+void strip_whitespace(char *str);
 char *strip_comments(char *str);
 void strip_quotes(char *str);
 

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -482,6 +482,9 @@ struct cmd_results *config_command(char *exec, enum cmd_status block) {
 	sway_log(L_INFO, "handling config command '%s'", exec);
 	// Endblock
 	if (**argv == '}') {
+		if (1 != argc) {
+			sway_log(L_ERROR, "Note: Currently no other commands on lines with '}' are supported.");
+		}
 		results = cmd_results_new(CMD_BLOCK_END, NULL, NULL);
 		goto cleanup;
 	}

--- a/sway/config.c
+++ b/sway/config.c
@@ -632,11 +632,6 @@ bool read_config(FILE *file, struct sway_config *config) {
 			continue;
 		}
 		line_number++;
-		strip_whitespace(line);
-		if (line[0] == '#') {
-			free(line);
-			continue;
-		}
 		struct cmd_results *res;
 		if (block == CMD_BLOCK_COMMANDS) {
 			// Special case

--- a/sway/config.c
+++ b/sway/config.c
@@ -632,7 +632,7 @@ bool read_config(FILE *file, struct sway_config *config) {
 			continue;
 		}
 		line_number++;
-		line = strip_whitespace(line);
+		strip_whitespace(line);
 		if (line[0] == '#') {
 			free(line);
 			continue;


### PR DESCRIPTION
Currently there are multiple problems with the processing of the configuration file. Gerenrally, the impementation makes many assumptions that are not valid for all users. This pull request addresses two of them.

First, the current implementation fails to read options in the configuration file correctly if they contain too much whitespace between arguments. Errors emerges if the user aligns options for example. With this changes, the line is stripped from unnecessary whitespace so the assumtions of the following processing stay valid.

The second problem arises if the user places opening parentheses on a separate line. Although it is not intuitive, but in such case the current impementation fails in a very bad manner. This pull request introduces checks if the opening parentheses can be found in the next relevant line and appends it to the procesed line.

Although the behaviour is not perfect even after this changes, the rebustness of sway will be increased.