### PR TITLE
Add template for issues

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,27 @@
+
+### Current Behaviour
+
+### Expected Behaviour
+
+### Steps to reproduce
+
+### System information
+
+| Component          | Version       |
+|:-------------------|:--------------|
+| (Operating System) | -             |
+| sway               | -             |
+| wlc                | -             |
+| wayland            | -             |
+| xWayland           | -             |
+| libcap             | -             |
+| asciidoc           | -             |
+| pcre               | -             |
+| json-c             | -             |
+| pango              | -             |
+| cairo              | -             |
+| gdk-pixbuf2        | -             |
+| pam                | -             |
+| imagemagick        | -             |
+| ffmpeg             | -             |
+


### PR DESCRIPTION
Currently issues are written relying on the user providing all the necessary data.

With an issue template it is ensured that all the data of interest is actually available right from the start. The risk of the user not providing necessary information is reduced.