### PR TITLE
Add output wrapping

### DIFF
--- a/include/sway/output.h
+++ b/include/sway/output.h
@@ -7,6 +7,7 @@
 // Position is absolute coordinates on the edge where the adjacent output
 // should be searched for.
 swayc_t *output_by_name(const char* name, const struct wlc_point *abs_pos);
+swayc_t *swayc_opposite_output(enum movement_direction dir, const struct wlc_point *abs_pos);
 swayc_t *swayc_adjacent_output(swayc_t *output, enum movement_direction dir, const struct wlc_point *abs_pos, bool pick_closest);
 
 // Place absolute coordinates for given container into given wlc_point.


### PR DESCRIPTION
This fixes issue #733 . Now if the user focuses output right but is at
the rightmost monitor, the focus will wrap the the leftmost monitor
(or whatever direction was chosen).

This commit adds a new function, swayc_opposite_output, which selects
the opposite output given a position and a direction. Now, when calling
output_by_name, we first check if there is an adjacent output to switch
to. If that fails, we call swayc_opposite_output to handle wrapping.