### PR TITLE
i3 feature support: Moving flotaing containers

### DIFF
--- a/include/sway/layout.h
+++ b/include/sway/layout.h
@@ -48,7 +48,7 @@ void swap_container(swayc_t *a, swayc_t *b);
 // 2 Containers geometry are swapped, used with `swap_container`
 void swap_geometry(swayc_t *a, swayc_t *b);
 
-void move_container(swayc_t* container, enum movement_direction direction);
+void move_container(swayc_t* container, enum movement_direction direction, int move_amt);
 void move_container_to(swayc_t* container, swayc_t* destination);
 void move_workspace_to(swayc_t* workspace, swayc_t* destination);
 

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -9,30 +9,40 @@
 
 struct cmd_results *cmd_move(int argc, char **argv) {
 	struct cmd_results *error = NULL;
+	int move_amt = 10;
+
 	if (config->reading) return cmd_results_new(CMD_FAILURE, "move", "Can't be used in config file.");
 	if ((error = checkarg(argc, "move", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
-	const char* expected_syntax = "Expected 'move <left|right|up|down|next|prev|first>' or "
+	const char* expected_syntax = "Expected 'move <left|right|up|down|next|prev|first> <[px] px>' or "
 		"'move <container|window> to workspace <name>' or "
 		"'move <container|window|workspace> to output <name|direction>' or "
 		"'move position mouse'";
 	swayc_t *view = get_focused_container(&root_container);
 
+	if (argc == 2 || (argc == 3 && strcasecmp(argv[2], "px") == 0 )) {
+		char *inv;
+		move_amt = (int)strtol(argv[1], &inv, 10);
+		if (*inv != '\0' && strcasecmp(inv, "px") != 0) {
+			move_amt = 10;
+		}
+	}
+
 	if (strcasecmp(argv[0], "left") == 0) {
-		move_container(view, MOVE_LEFT);
+		move_container(view, MOVE_LEFT, move_amt);
 	} else if (strcasecmp(argv[0], "right") == 0) {
-		move_container(view, MOVE_RIGHT);
+		move_container(view, MOVE_RIGHT, move_amt);
 	} else if (strcasecmp(argv[0], "up") == 0) {
-		move_container(view, MOVE_UP);
+		move_container(view, MOVE_UP, move_amt);
 	} else if (strcasecmp(argv[0], "down") == 0) {
-		move_container(view, MOVE_DOWN);
+		move_container(view, MOVE_DOWN, move_amt);
 	} else if (strcasecmp(argv[0], "next") == 0) {
-		move_container(view, MOVE_NEXT);
+		move_container(view, MOVE_NEXT, move_amt);
 	} else if (strcasecmp(argv[0], "prev") == 0) {
-		move_container(view, MOVE_PREV);
+		move_container(view, MOVE_PREV, move_amt);
 	} else if (strcasecmp(argv[0], "first") == 0) {
-		move_container(view, MOVE_FIRST);
+		move_container(view, MOVE_FIRST, move_amt);
 	} else if (strcasecmp(argv[0], "container") == 0 || strcasecmp(argv[0], "window") == 0) {
 		// "move container ...
 		if ((error = checkarg(argc, "move container/window", EXPECTED_AT_LEAST, 4))) {

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -349,10 +349,31 @@ static void swap_children(swayc_t *container, int a, int b) {
 	}
 }
 
-void move_container(swayc_t *container, enum movement_direction dir) {
+void move_container(swayc_t *container, enum movement_direction dir, int move_amt) {
 	enum swayc_layouts layout = L_NONE;
 	swayc_t *parent = container->parent;
-	if (container->is_floating || (container->type != C_VIEW && container->type != C_CONTAINER)) {
+	if (container->is_floating) {
+		swayc_t *output = swayc_parent_by_type(container, C_OUTPUT);
+		switch(dir) {
+		case MOVE_LEFT:
+			container->x = MAX(0, container->x - move_amt);
+			break;
+		case MOVE_RIGHT:
+			container->x = MIN(output->width - container->width, container->x + move_amt);
+			break;
+		case MOVE_UP:
+			container->y = MAX(0, container->y - move_amt);
+			break;
+		case MOVE_DOWN:
+			container->y = MIN(output->height - container->height, container->y + move_amt);
+			break;
+		default:
+			break;
+		}
+		update_geometry(container);
+		return;
+	}
+	if (container->type != C_VIEW && container->type != C_CONTAINER) {
 		return;
 	}
 	if (dir == MOVE_UP || dir == MOVE_DOWN) {

--- a/sway/sway.5.txt
+++ b/sway/sway.5.txt
@@ -100,9 +100,10 @@ They are expected to be used with **bindsym** or at runtime through **swaymsg**(
 **layout** toggle split::
 	Cycles between available split layouts.
 
-**move** <left|right|up|down> <[px] px>::
+**move** <left|right|up|down> <[px]>::
 	Moves the focused container _left_, _right_, _up_, or _down_. If the window
-	is floating it moves it _px_ in that direction.
+	is floating it moves it _px_ in that direction, defaulting to 10. Tiled
+	containers are moved the same regardless of the _px_ argument.
 
 **move** <next|prev|first>::
 	Moving to _prev_ or _next_ swaps the container with its sibling in the same

--- a/sway/sway.5.txt
+++ b/sway/sway.5.txt
@@ -100,11 +100,14 @@ They are expected to be used with **bindsym** or at runtime through **swaymsg**(
 **layout** toggle split::
 	Cycles between available split layouts.
 
-**move** <left|right|up|down|next|prev|first>::
-	Moves the focused container _left_, _right_, _up_, or _down_. Moving to _prev_
-	or _next_ swaps the container with its sibling in the same container. Move
-	_first_ exchanges the focused element in an auto layout with the first
-	element, i.e. promotes  the focused element to master position.
+**move** <left|right|up|down> <[px] px>::
+	Moves the focused container _left_, _right_, _up_, or _down_. If the window
+	is floating it moves it _px_ in that direction.
+
+**move** <next|prev|first>::
+	Moving to _prev_ or _next_ swaps the container with its sibling in the same
+	container. Move _first_ exchanges the focused element in an auto layout with
+	the first element, i.e. promotes the focused element to master position.
 
 **move** <container|window> to workspace <name>::
 	Moves the focused container to the workspace identified by _name_.


### PR DESCRIPTION
This commit lets the 'move' command apply to floating containers as well
as tiled ones. The command may be appended with a number of pixels and
then the string `px` (like '10 px') in order to move the container more
or fewer than the standard ten pixels.