### PR TITLE
Fix #1099: Allow spaces in worspace names

### DIFF
--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -12,12 +12,44 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 	if ((error = checkarg(argc, "workspace", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
-	if (argc == 1 || (argc >= 2 && strcasecmp(argv[0], "number") == 0) ) {
+
+	int output_location = -1;
+
+	for (int i = 0; i < argc; ++i) {
+		if (strcasecmp(argv[i], "output") == 0) {
+			output_location = i;
+			break;
+		}
+	}
+	if (output_location >= 0) {
+		if ((error = checkarg(argc, "workspace", EXPECTED_EQUAL_TO, output_location + 2))) {
+			return error;
+		}
+		struct workspace_output *wso = calloc(1, sizeof(struct workspace_output));
+		if (!wso) {
+			return cmd_results_new(CMD_FAILURE, "workspace output",
+					"Unable to allocate workspace output");
+		}
+		wso->workspace = join_args(argv, argc - 2);
+		wso->output = strdup(argv[output_location]);
+		int i = -1;
+		if ((i = list_seq_find(config->workspace_outputs, workspace_output_cmp_workspace, wso)) != -1) {
+			struct workspace_output *old = config->workspace_outputs->items[i];
+			free(old); // workspaces can only be assigned to a single output
+			list_del(config->workspace_outputs, i);
+		}
+		sway_log(L_DEBUG, "Assigning workspace %s to output %s", wso->workspace, wso->output);
+		list_add(config->workspace_outputs, wso);
+		if (!config->reading) {
+			// TODO: Move workspace to output. (don't do so when reloading)
+		}
+	}
+	else {
 		if (config->reading || !config->active) {
 			return cmd_results_new(CMD_DEFER, "workspace", NULL);
 		}
 		swayc_t *ws = NULL;
-		if (argc >= 2) {
+		if (strcasecmp(argv[0], "number") == 0) {
 			if (!(ws = workspace_by_number(argv[1]))) {
 				char *name = join_args(argv + 1, argc - 1);
 				ws = workspace_create(name);
@@ -41,9 +73,11 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 				ws = workspace_create(prev_workspace_name);
 			}
 		} else {
-			if (!(ws = workspace_by_name(argv[0]))) {
-				ws = workspace_create(argv[0]);
+			char *name = join_args(argv, argc);
+			if (!(ws = workspace_by_name(name))) {
+				ws = workspace_create(name);
 			}
+			free(name);
 		}
 		swayc_t *old_output = swayc_active_output();
 		workspace_switch(ws);
@@ -53,30 +87,6 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 			swayc_t *focused = get_focused_view(ws);
 			if (focused && focused->type == C_VIEW) {
 				center_pointer_on(focused);
-			}
-		}
-	} else {
-		if (strcasecmp(argv[1], "output") == 0) {
-			if ((error = checkarg(argc, "workspace", EXPECTED_EQUAL_TO, 3))) {
-				return error;
-			}
-			struct workspace_output *wso = calloc(1, sizeof(struct workspace_output));
-			if (!wso) {
-				return cmd_results_new(CMD_FAILURE, "workspace output",
-						"Unable to allocate workspace output");
-			}
-			wso->workspace = strdup(argv[0]);
-			wso->output = strdup(argv[2]);
-			int i = -1;
-			if ((i = list_seq_find(config->workspace_outputs, workspace_output_cmp_workspace, wso)) != -1) {
-				struct workspace_output *old = config->workspace_outputs->items[i];
-				free(old); // workspaces can only be assigned to a single output
-				list_del(config->workspace_outputs, i);
-			}
-			sway_log(L_DEBUG, "Assigning workspace %s to output %s", argv[0], argv[2]);
-			list_add(config->workspace_outputs, wso);
-			if (!config->reading) {
-				// TODO: Move workspace to output. (don't do so when reloading)
 			}
 		}
 	}

--- a/sway/sway.5.txt
+++ b/sway/sway.5.txt
@@ -364,8 +364,11 @@ The default colors are:
 	be configured with perfectly aligned adjacent positions for this option to
 	have any effect.
 
-**workspace** <name>::
-	Switches to the specified workspace.
+**workspace** [number] <name>::
+	Switches to the specified workspace. The string "number" is optional. The
+	worspace _name_, if unquoted, may not contain the string "output", as sway
+	will assume that the command is moving a worspace to an output, as described
+	below.
 
 **workspace** <prev|next>::
 	Switches to the next workspace on the current output or on the next output


### PR DESCRIPTION
This commit allows unquoted spaces in worspace names in order to keep
compatability with i3. The names _must not_ contain the string "output"
which is documented in 'sway.5' because how sway detects the `move
<workspace> output <output>` command. Also I documented that "number"
may be used before the worspace name without affecting how the name is
evaluated.