### PR TITLE
Superfluous include causes failures if WLC headers aren't installed globally

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -3,7 +3,6 @@
 
 #include <stdint.h>
 #include <unistd.h>
-#include <wlc/wlc.h>
 #include <xkbcommon/xkbcommon.h>
 
 /**


### PR DESCRIPTION
If the WLC headers aren't installed globally (e.g. somewhere in your home directory rather than in `/usr/includes`), despite `-DWLC_INCLUDE_DIRS` being passed correctly to `cmake`, `make` fails.

Apparently, the `CMakeList.txt` in some subdirectories are missing `WLC_INCLUDE_DIRS` in their `include_directories()` directive.