### PR TITLE
Allow also 444 for security file mode

### DIFF
--- a/sway/config.c
+++ b/sway/config.c
@@ -547,8 +547,8 @@ bool load_main_config(const char *file, bool is_active) {
 		list_qsort(secconfigs, qstrcmp);
 		for (int i = 0; i < secconfigs->length; ++i) {
 			char *_path = secconfigs->items[i];
-			if (stat(_path, &s) || s.st_uid != 0 || s.st_gid != 0 || (s.st_mode & 0777) != 0644) {
-				sway_log(L_ERROR, "Refusing to load %s - it must be owned by root and mode 644", _path);
+			if (stat(_path, &s) || s.st_uid != 0 || s.st_gid != 0 || (((s.st_mode & 0777) != 0644) && (s.st_mode & 0777) != 0444)) {
+				sway_log(L_ERROR, "Refusing to load %s - it must be owned by root and mode 644 or 444", _path);
 				success = false;
 			} else {
 				success = success && load_config(_path, config);

--- a/sway/sway-security.7.txt
+++ b/sway/sway-security.7.txt
@@ -21,7 +21,7 @@ you must make a few changes external to sway first.
 
 Configuration of security features is limited to files in the security directory
 (this is likely /etc/sway/security.d/*, but depends on your installation prefix).
-Files in this directory must be owned by root:root and chmod 644. The default
+Files in this directory must be owned by root:root and chmod 644 or 444. The default
 security configuration is installed to /etc/sway/security.d/00-defaults, and
 should not be modified - it will be updated with the latest recommended security
 defaults between releases. To override the defaults, you should add more files to


### PR DESCRIPTION
Allow also 444 as security file mode in addition to 644.

This helps with systems like NixOS where nothing in /nix/store is writable to anyone.