### PR TITLE
Fix off-by-one error when checking workspace_layout arguments

### DIFF
--- a/sway/commands/workspace_layout.c
+++ b/sway/commands/workspace_layout.c
@@ -21,13 +21,13 @@ struct cmd_results *cmd_workspace_layout(int argc, char **argv) {
 			if ((error = checkarg(argc, "workspace_layout auto", EXPECTED_EQUAL_TO, 2))) {
 				return error;
 			}
-			if (strcasecmp(argv[0], "left") == 0) {
+			if (strcasecmp(argv[1], "left") == 0) {
 				config->default_layout = L_AUTO_LEFT;
-			} else if (strcasecmp(argv[0], "right") == 0) {
+			} else if (strcasecmp(argv[1], "right") == 0) {
 				config->default_layout = L_AUTO_RIGHT;
-			} else if (strcasecmp(argv[0], "top") == 0) {
+			} else if (strcasecmp(argv[1], "top") == 0) {
 				config->default_layout = L_AUTO_TOP;
-			} else if (strcasecmp(argv[0], "bottom") == 0) {
+			} else if (strcasecmp(argv[1], "bottom") == 0) {
 				config->default_layout = L_AUTO_BOTTOM;
 			} else {
 				return cmd_results_new(CMD_INVALID, "workspace_layout auto", "Expected 'workspace_layout auto <left|right|top|bottom>'");


### PR DESCRIPTION
If the configuration file contains:
```
workspace_layout auto left
```
or anything similar, the code checking the configuration will ignore the command and output an error.

The reason is easily confirmed with GDB:
```
(gdb) break cmd_workspace_layout
Breakpoint 1 at 0x16240: file /usr/src/debug/sway-master/sway/commands/workspace_layout.c, line 5.
(gdb) run
Starting program: /usr/bin/sway 
Missing separate debuginfos, use: dnf debuginfo-install glibc-2.24-4.fc25.x86_64
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
Detaching after fork from child process 8799.
Detaching after fork from child process 8800.

Breakpoint 1, cmd_workspace_layout (argc=2, argv=0x559a6f093d98)
    at /usr/src/debug/sway-master/sway/commands/workspace_layout.c:5
5	struct cmd_results *cmd_workspace_layout(int argc, char **argv) {
(gdb) print argv[0]
$1 = 0x559a6f0942a0 "auto"
(gdb) print argv[1]
$2 = 0x559a6f093780 "left"
```