### PR TITLE
remove unnecessary todo item

### DIFF
--- a/sway/commands/workspace.c
+++ b/sway/commands/workspace.c
@@ -42,11 +42,7 @@ struct cmd_results *cmd_workspace(int argc, char **argv) {
 		}
 		sway_log(L_DEBUG, "Assigning workspace %s to output %s", wso->workspace, wso->output);
 		list_add(config->workspace_outputs, wso);
-		if (!config->reading) {
-			// TODO: Move workspace to output. (don't do so when reloading)
-		}
-	}
-	else {
+	} else {
 		if (config->reading || !config->active) {
 			return cmd_results_new(CMD_DEFER, "workspace", NULL);
 		}


### PR DESCRIPTION
As best I can tell this todo was intended to add workspace movement to
the given output with the `workspace <ws> output <op>` command, but i3
does not behave this way.

see #1122 for some clarification