### PR TITLE
Fix move next crash

### DIFF
--- a/sway/container.c
+++ b/sway/container.c
@@ -218,7 +218,7 @@ swayc_t *new_workspace(swayc_t *output, const char *name) {
 	swayc_t *workspace = new_swayc(C_WORKSPACE);
 
 	workspace->prev_layout = L_NONE;
-	workspace->layout = L_HORIZ;
+	workspace->layout = default_layout(output);
 	workspace->workspace_layout = default_layout(output);
 
 	workspace->x = output->x;

--- a/sway/layout.c
+++ b/sway/layout.c
@@ -417,7 +417,7 @@ void move_container(swayc_t *container, enum movement_direction dir, int move_am
 		sway_log(L_DEBUG, "container:%p, parent:%p, child %p,",
 				container,parent,child);
 		if (parent->layout == layout
-			|| (layout == L_NONE && parent->type == C_CONTAINER) /* accept any layout for next/prev direction */
+			|| (layout == L_NONE && (parent->type == C_CONTAINER || parent->type == C_WORKSPACE)) /* accept any layout for next/prev direction */
 			|| (parent->layout == L_TABBED && layout == L_HORIZ)
 			|| (parent->layout == L_STACKED && layout == L_VERT)
 			|| is_auto_layout(parent->layout)) {


### PR DESCRIPTION
This pull request fixes #1120 for me.

The commit message contains an explanation of why I think it works.

It also includes a small behaviour change to workspace layouts, as I found it confusing that they would default to L_HORIZ despite the default of an output being something else. Perhaps there's a reason for this that I'm not seeing?

