### PR TITLE
Add pretty printing to swaymsg

### DIFF
--- a/include/sway/ipc-json.h
+++ b/include/sway/ipc-json.h
@@ -10,5 +10,6 @@ json_object *ipc_json_describe_bar_config(struct bar_config *bar);
 json_object *ipc_json_describe_container(swayc_t *c);
 json_object *ipc_json_describe_container_recursive(swayc_t *c);
 json_object *ipc_json_describe_window(swayc_t *c);
+json_object *ipc_json_describe_input(struct libinput_device *device);
 
 #endif

--- a/sway/ipc-server.c
+++ b/sway/ipc-server.c
@@ -420,17 +420,9 @@ void ipc_client_handle_command(struct ipc_client *client) {
 		}
 		json_object *inputs = json_object_new_array();
 		if (input_devices) {
-			for(int i=0; i<input_devices->length; i++) {
+			for(int i = 0; i<input_devices->length; i++) {
 				struct libinput_device *device = input_devices->items[i];
-				char* identifier = libinput_dev_unique_id(device);
-				json_object *device_object = json_object_new_object();
-				if (!identifier) {
-					json_object_object_add(device_object, "identifier", NULL);
-				} else {
-					json_object_object_add(device_object, "identifier", json_object_new_string(identifier));
-				}
-				json_object_array_add(inputs, device_object);
-				free(identifier);
+				json_object_array_add(inputs, ipc_json_describe_input(device));
 			}
 		}
 		const char *json_string = json_object_to_json_string(inputs);

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -7,6 +7,7 @@
 #include <stdint.h>
 #include <sys/un.h>
 #include <sys/socket.h>
+#include <ctype.h>
 #include <unistd.h>
 #include <json-c/json.h>
 #include "stringop.h"
@@ -18,8 +19,169 @@ void sway_terminate(int exit_code) {
 	exit(exit_code);
 }
 
+static void pretty_print_cmd(json_object *r) {
+	bool _success;
+	json_object *success;
+	if (!json_object_object_get_ex(r, "success", &success)) {
+		_success = true;
+	} else {
+		_success = json_object_get_boolean(success);
+	}
+	if (!_success) {
+		json_object *error;
+		if (!json_object_object_get_ex(r, "error", &error)) {
+			printf("An unknkown error occured");
+		} else {
+			printf("Error: %s\n", json_object_get_string(error));
+		}
+	}
+}
+
+static void pretty_print_workspace(json_object *w) {
+	json_object *name, *rect, *visible, *output, *urgent, *layout, *focused;
+	json_object_object_get_ex(w, "name", &name);
+	json_object_object_get_ex(w, "rect", &rect);
+	json_object_object_get_ex(w, "visible", &visible);
+	json_object_object_get_ex(w, "output", &output);
+	json_object_object_get_ex(w, "urgent", &urgent);
+	json_object_object_get_ex(w, "layout", &layout);
+	json_object_object_get_ex(w, "focused", &focused);
+	printf(
+		"Workspace %s%s%s%s\n"
+		"  Output: %s\n"
+		"  Layout: %s\n\n",
+		json_object_get_string(name),
+		json_object_get_boolean(focused) ? " (focused)" : "",
+		!json_object_get_boolean(visible) ? " (off-screen)" : "",
+		json_object_get_boolean(urgent) ? " (urgent)" : "",
+		json_object_get_string(output),
+		json_object_get_string(layout)
+	);
+}
+
+static void pretty_print_input(json_object *i) {
+	json_object *id, *name, *size, *caps;
+	json_object_object_get_ex(i, "identifier", &id);
+	json_object_object_get_ex(i, "name", &name);
+	json_object_object_get_ex(i, "size", &size);
+	json_object_object_get_ex(i, "capabilities", &caps);
+
+	printf( "Input device %s\n  Type: ", json_object_get_string(name));
+
+	struct {
+		const char *a;
+		const char *b;
+	} cap_names[] = {
+		{ "keyboard", "Keyboard" },
+		{ "pointer", "Mouse" },
+		{ "touch", "Touch" },
+		{ "tablet_tool", "Tablet tool" },
+		{ "tablet_pad", "Tablet pad" },
+		{ "gesture", "Gesture" },
+		{ "switch", "Switch" },
+	};
+
+	size_t len = json_object_array_length(caps);
+	if (len == 0) {
+		printf("Unknown");
+	}
+
+	json_object *cap;
+	for (size_t i = 0; i < len; ++i) {
+		cap = json_object_array_get_idx(caps, i);
+		const char *cap_s = json_object_get_string(cap);
+		const char *_name = NULL;
+		for (size_t j = 0; j < sizeof(cap_names) / sizeof(cap_names[0]); ++i) {
+			if (strcmp(cap_names[i].a, cap_s) == 0) {
+				_name = cap_names[i].b;
+				break;
+			}
+		}
+		printf("%s%s", _name ? _name : cap_s, len > 1 && i != len - 1 ? ", " : "");
+	}
+	printf("\n  Sway ID: %s\n", json_object_get_string(id));
+	if (size) {
+		json_object *width, *height;
+		json_object_object_get_ex(size, "width", &width);
+		json_object_object_get_ex(size, "height", &height);
+		printf("  Size: %lfmm x %lfmm\n",
+				json_object_get_double(width), json_object_get_double(height));
+	}
+	printf("\n");
+}
+
+static void pretty_print_output(json_object *o) {
+	json_object *name, *rect, *focused, *active, *ws, *scale;
+	json_object_object_get_ex(o, "name", &name);
+	json_object_object_get_ex(o, "rect", &rect);
+	json_object_object_get_ex(o, "focused", &focused);
+	json_object_object_get_ex(o, "active", &active);
+	json_object_object_get_ex(o, "current_workspace", &ws);
+	json_object_object_get_ex(o, "scale", &scale);
+	json_object *x, *y, *width, *height;
+	json_object_object_get_ex(rect, "x", &x);
+	json_object_object_get_ex(rect, "y", &y);
+	json_object_object_get_ex(rect, "width", &width);
+	json_object_object_get_ex(rect, "height", &height);
+	printf(
+		"Output %s%s%s\n"
+		"  Geometry: %dx%d @ %d,%d\n"
+		"  Scale factor: %dx\n"
+		"  Workspace: %s\n\n",
+		json_object_get_string(name),
+		json_object_get_boolean(focused) ? " (focused)" : "",
+		!json_object_get_boolean(active) ? " (inactive)" : "",
+		json_object_get_int(width), json_object_get_int(height),
+		json_object_get_int(x), json_object_get_int(y),
+		json_object_get_int(scale),
+		json_object_get_string(ws)
+	);
+}
+
+static void pretty_print_version(json_object *v) {
+	json_object *ver;
+	json_object_object_get_ex(v, "human_readable", &ver);
+	printf("sway version %s\n", json_object_get_string(ver));
+}
+
+static void pretty_print(int type, json_object *resp) {
+	if (type != IPC_COMMAND && type != IPC_GET_WORKSPACES &&
+			type != IPC_GET_INPUTS && type != IPC_GET_OUTPUTS &&
+			type != IPC_GET_VERSION) {
+		printf("%s\n", json_object_to_json_string_ext(resp,
+			JSON_C_TO_STRING_PRETTY | JSON_C_TO_STRING_SPACED));
+		return;
+	}
+
+	if (type == IPC_GET_VERSION) {
+		pretty_print_version(resp);
+		return;
+	}
+
+	json_object *obj;
+	size_t len = json_object_array_length(resp);
+	for (size_t i = 0; i < len; ++i) {
+		obj = json_object_array_get_idx(resp, i);
+		switch (type) {
+		case IPC_COMMAND:
+			pretty_print_cmd(obj);
+			break;
+		case IPC_GET_WORKSPACES:
+			pretty_print_workspace(obj);
+			break;
+		case IPC_GET_INPUTS:
+			pretty_print_input(obj);
+			break;
+		case IPC_GET_OUTPUTS:
+			pretty_print_output(obj);
+			break;
+		}
+	}
+}
+
 int main(int argc, char **argv) {
 	static int quiet = 0;
+	static int raw = 0;
 	char *socket_path = NULL;
 	char *cmdtype = NULL;
 
@@ -28,9 +190,10 @@ int main(int argc, char **argv) {
 	static struct option long_options[] = {
 		{"help", no_argument, NULL, 'h'},
 		{"quiet", no_argument, NULL, 'q'},
-		{"version", no_argument, NULL, 'v'},
+		{"raw", no_argument, NULL, 'r'},
 		{"socket", required_argument, NULL, 's'},
 		{"type", required_argument, NULL, 't'},
+		{"version", no_argument, NULL, 'v'},
 		{0, 0, 0, 0}
 	};
 
@@ -39,20 +202,26 @@ int main(int argc, char **argv) {
 		"\n"
 		"  -h, --help             Show help message and quit.\n"
 		"  -q, --quiet            Be quiet.\n"
-		"  -v, --version          Show the version number and quit.\n"
+		"  -r, --raw              Use raw output even if using a tty\n"
 		"  -s, --socket <socket>  Use the specified socket.\n"
-		"  -t, --type <type>      Specify the message type.\n";
+		"  -t, --type <type>      Specify the message type.\n"
+		"  -v, --version          Show the version number and quit.\n";
+
+	raw = !isatty(STDOUT_FILENO);
 
 	int c;
 	while (1) {
 		int option_index = 0;
-		c = getopt_long(argc, argv, "hqvs:t:", long_options, &option_index);
+		c = getopt_long(argc, argv, "hqrs:t:v", long_options, &option_index);
 		if (c == -1) {
 			break;
 		}
 		switch (c) {
 		case 'q': // Quiet
 			quiet = 1;
+			break;
+		case 'r': // Raw
+			raw = 1;
 			break;
 		case 's': // Socket
 			socket_path = strdup(optarg);
@@ -125,7 +294,12 @@ int main(int argc, char **argv) {
 			printf("%s\n", resp);
 			ret = 1;
 		} else {
-			printf("%s\n", json_object_to_json_string_ext(obj, JSON_C_TO_STRING_PRETTY | JSON_C_TO_STRING_SPACED));
+			if (raw) {
+				printf("%s\n", json_object_to_json_string_ext(obj,
+					JSON_C_TO_STRING_PRETTY | JSON_C_TO_STRING_SPACED));
+			} else {
+				pretty_print(type, obj);
+			}
 			free(obj);
 		}
 	}

--- a/swaymsg/swaymsg.1.txt
+++ b/swaymsg/swaymsg.1.txt
@@ -23,8 +23,8 @@ Options
 *-q, \--quiet*::
 	Sends the IPC message but does not print the response from sway.
 
-*-v, \--version*::
-	Print the version (of swaymsg) and quit.
+*-r, \--raw*::
+	Use raw output even if using a tty.
 
 *-s, --socket* <path>::
 	Use the specified socket path. Otherwise, swaymsg will ask sway where the
@@ -32,6 +32,9 @@ Options
 
 *-t, \--type* <type>::
 	Specify the type of IPC message. See below.
+
+*-v, \--version*::
+	Print the version (of swaymsg) and quit.
 
 IPC Message Types
 -----------------


### PR DESCRIPTION
If stdout is a tty, it will pretty print unless -r (--raw) is given.

Sample outputs:

```
~/s/s/build > ./bin/swaymsg fullscreen toggle
Error: Permission denied for fullscreen toggle via IPC

~/s/s/build > ./bin/swaymsg -t get_workspaces
Workspace 3:三
  Output: DVI-I-1
  Layout: splith

Workspace 1:一 (off-screen)
  Output: HDMI-A-1
  Layout: splith

Workspace 5:五 (focused)
  Output: HDMI-A-1
  Layout: splith

~/s/s/build > ./bin/swaymsg -t get_inputs
Input device Metadot - Das Keyboard Das Keyboard
  Type: Keyboard
  Sway ID: 9456:320:Metadot_-_Das_Keyboard_Das_Keyb

Input device Wacom Intuos S 2 Pen
  Type: Tablet tool
  Sway ID: 1386:827:Wacom_Intuos_S_2

Input device Wacom Intuos S 2 Pad
  Type: Tablet pad
  Sway ID: 1386:827:Wacom_Intuos_S_2

Input device Logitech Gaming Mouse G502
  Type: Keyboard, Mouse
  Sway ID: 1133:49277:Logitech_Gaming_Mous

~/s/s/build > ./bin/swaymsg -t get_outputs
Output DVI-I-1
  Geometry: 1920x1080 @ 3840,0
  Scale factor: 1x
  Workspace: 3:三

Output DVI-D-1
  Geometry: 1920x1080 @ 0,0
  Scale factor: 1x
  Workspace: 4:四

Output HDMI-A-1
  Geometry: 1920x1080 @ 1920,0
  Scale factor: 1x
  Workspace: 5:五
```