### PR TITLE
Improve criteria handling

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -5,6 +5,9 @@
 #include <wlc/wlc.h>
 #include "config.h"
 
+// Container that a called command should act upon. Only valid in command functions.
+extern swayc_t *current_container;
+
 /**
  * Indicates the result of a command's execution.
  */

--- a/include/sway/criteria.h
+++ b/include/sway/criteria.h
@@ -33,4 +33,7 @@ char *extract_crit_tokens(list_t *tokens, const char *criteria);
 // been set with `for_window` commands and have an associated cmdlist.
 list_t *criteria_for(swayc_t *cont);
 
+// Returns a list of all containers that match the given list of tokens.
+list_t *container_for(list_t *tokens);
+
 #endif

--- a/sway/commands/border.c
+++ b/sway/commands/border.c
@@ -20,7 +20,7 @@ struct cmd_results *cmd_border(int argc, char **argv) {
 			"Expected 'border <normal|pixel|none|toggle> [<n>]");
 	}
 
-	swayc_t *view = get_focused_view(&root_container);
+	swayc_t *view = current_container;
 	enum swayc_border_types border = view->border_type;
 	int thickness = view->border_thickness;
 

--- a/sway/commands/floating.c
+++ b/sway/commands/floating.c
@@ -13,7 +13,7 @@ struct cmd_results *cmd_floating(int argc, char **argv) {
 	if ((error = checkarg(argc, "floating", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}
-	swayc_t *view = get_focused_container(&root_container);
+	swayc_t *view = current_container;
 	bool wants_floating;
 	if (strcasecmp(argv[0], "enable") == 0) {
 		wants_floating = true;

--- a/sway/commands/focus.c
+++ b/sway/commands/focus.c
@@ -30,6 +30,9 @@ struct cmd_results *cmd_focus(int argc, char **argv) {
 			}
 		}
 		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+	} else if (argc == 0) {
+		set_focused_container(current_container);
+		return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 	} else if ((error = checkarg(argc, "focus", EXPECTED_EQUAL_TO, 1))) {
 		return error;
 	}

--- a/sway/commands/fullscreen.c
+++ b/sway/commands/fullscreen.c
@@ -14,7 +14,7 @@ struct cmd_results *cmd_fullscreen(int argc, char **argv) {
 	if ((error = checkarg(argc, "fullscreen", EXPECTED_AT_LEAST, 0))) {
 		return error;
 	}
-	swayc_t *container = get_focused_view(&root_container);
+	swayc_t *container = current_container;
 	if(container->type != C_VIEW){
 		return cmd_results_new(CMD_INVALID, "fullscreen", "Only views can fullscreen");
 	}

--- a/sway/commands/kill.c
+++ b/sway/commands/kill.c
@@ -6,7 +6,7 @@ struct cmd_results *cmd_kill(int argc, char **argv) {
 	if (config->reading) return cmd_results_new(CMD_FAILURE, "kill", "Can't be used in config file.");
 	if (!config->active) return cmd_results_new(CMD_FAILURE, "kill", "Can only be used when sway is running.");
 
-	swayc_t *container = get_focused_container(&root_container);
+	swayc_t *container = current_container;
 	close_views(container);
 	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }

--- a/sway/commands/layout.c
+++ b/sway/commands/layout.c
@@ -16,7 +16,7 @@ struct cmd_results *cmd_layout(int argc, char **argv) {
 	if ((error = checkarg(argc, "layout", EXPECTED_MORE_THAN, 0))) {
 		return error;
 	}
-	swayc_t *parent = get_focused_container(&root_container);
+	swayc_t *parent = current_container;
 	if (parent->is_floating) {
 		return cmd_results_new(CMD_FAILURE, "layout", "Unable to change layout of floating windows");
 	}

--- a/sway/commands/mark.c
+++ b/sway/commands/mark.c
@@ -8,11 +8,11 @@
 struct cmd_results *cmd_mark(int argc, char **argv) {
 	struct cmd_results *error = NULL;
 	if (config->reading) return cmd_results_new(CMD_FAILURE, "mark", "Can't be used in config file.");
-	if ((error = checkarg(argc, "floating", EXPECTED_AT_LEAST, 1))) {
+	if ((error = checkarg(argc, "mark", EXPECTED_AT_LEAST, 1))) {
 		return error;
 	}
 
-	swayc_t *view = get_focused_container(&root_container);
+	swayc_t *view = current_container;
 	bool add = false;
 	bool toggle = false;
 

--- a/sway/commands/move.c
+++ b/sway/commands/move.c
@@ -20,7 +20,7 @@ struct cmd_results *cmd_move(int argc, char **argv) {
 		"'move <container|window> to workspace <name>' or "
 		"'move <container|window|workspace> to output <name|direction>' or "
 		"'move position mouse'";
-	swayc_t *view = get_focused_container(&root_container);
+	swayc_t *view = current_container;
 
 	if (argc == 2 || (argc == 3 && strcasecmp(argv[2], "px") == 0 )) {
 		char *inv;
@@ -125,7 +125,7 @@ struct cmd_results *cmd_move(int argc, char **argv) {
 		if (view->type != C_CONTAINER && view->type != C_VIEW) {
 			return cmd_results_new(CMD_FAILURE, "move scratchpad", "Can only move containers and views.");
 		}
-		swayc_t *view = get_focused_container(&root_container);
+		swayc_t *view = current_container;
 		int i;
 		for (i = 0; i < scratchpad->length; i++) {
 			if (scratchpad->items[i] == view) {

--- a/sway/commands/resize.c
+++ b/sway/commands/resize.c
@@ -19,7 +19,7 @@ enum resize_dim_types {
 };
 
 static bool set_size_floating(int new_dimension, bool use_width) {
-	swayc_t *view = get_focused_float(swayc_active_workspace());
+	swayc_t *view = current_container;
 	if (view) {
 		if (use_width) {
 			int current_width = view->width;
@@ -50,7 +50,7 @@ static bool set_size_floating(int new_dimension, bool use_width) {
 }
 
 static bool resize_floating(int amount, bool use_width) {
-	swayc_t *view = get_focused_float(swayc_active_workspace());
+	swayc_t *view = current_container;
 
 	if (view) {
 		if (use_width) {
@@ -64,7 +64,7 @@ static bool resize_floating(int amount, bool use_width) {
 }
 
 static bool resize_tiled(int amount, bool use_width) {
-	swayc_t *container = get_focused_view(swayc_active_workspace());
+	swayc_t *container = current_container;
 	swayc_t *parent = container->parent;
 	int idx_focused = 0;
 	bool use_major = false;
@@ -199,7 +199,7 @@ static bool resize_tiled(int amount, bool use_width) {
 
 static bool set_size_tiled(int amount, bool use_width) {
 	int desired;
-	swayc_t *focused = get_focused_view(swayc_active_workspace());
+	swayc_t *focused = current_container;
 
 	if (use_width) {
 		desired = amount - focused->width;
@@ -211,7 +211,7 @@ static bool set_size_tiled(int amount, bool use_width) {
 }
 
 static bool set_size(int dimension, bool use_width) {
-	swayc_t *focused = get_focused_view_include_floating(swayc_active_workspace());
+	swayc_t *focused = current_container;
 
 	if (focused) {
 		if (focused->is_floating) {
@@ -225,7 +225,7 @@ static bool set_size(int dimension, bool use_width) {
 }
 
 static bool resize(int dimension, bool use_width, enum resize_dim_types dim_type) {
-	swayc_t *focused = get_focused_view_include_floating(swayc_active_workspace());
+	swayc_t *focused = current_container;
 
 	// translate "10 ppt" (10%) to appropriate # of pixels in case we need it
 	float ppt_dim = (float)dimension / 100;

--- a/sway/commands/split.c
+++ b/sway/commands/split.c
@@ -17,7 +17,7 @@ static struct cmd_results *_do_split(int argc, char **argv, int layout) {
 	if ((error = checkarg(argc, name, EXPECTED_EQUAL_TO, 0))) {
 		return error;
 	}
-	swayc_t *focused = get_focused_container(&root_container);
+	swayc_t *focused = current_container;
 
 	// Case of floating window, don't split
 	if (focused->is_floating) {
@@ -66,7 +66,7 @@ struct cmd_results *cmd_split(int argc, char **argv) {
 	} else if (strcasecmp(argv[0], "h") == 0 || strcasecmp(argv[0], "horizontal") == 0) {
 		_do_split(argc - 1, argv + 1, L_HORIZ);
 	} else if (strcasecmp(argv[0], "t") == 0 || strcasecmp(argv[0], "toggle") == 0) {
-		swayc_t *focused = get_focused_container(&root_container);
+		swayc_t *focused = current_container;
 		if (focused->parent->layout == L_VERT) {
 			_do_split(argc - 1, argv + 1, L_HORIZ);
 		} else {
@@ -89,7 +89,7 @@ struct cmd_results *cmd_splith(int argc, char **argv) {
 }
 
 struct cmd_results *cmd_splitt(int argc, char **argv) {
-	swayc_t *focused = get_focused_container(&root_container);
+	swayc_t *focused = current_container;
 	if (focused->parent->layout == L_VERT) {
 		return _do_split(argc, argv, L_HORIZ);
 	} else {

--- a/sway/commands/unmark.c
+++ b/sway/commands/unmark.c
@@ -5,7 +5,7 @@
 #include "stringop.h"
 
 struct cmd_results *cmd_unmark(int argc, char **argv) {
-	swayc_t *view = get_focused_container(&root_container);
+	swayc_t *view = current_container;
 
 	if (view->marks) {
 		if (argc) {

--- a/sway/sway.5.txt
+++ b/sway/sway.5.txt
@@ -316,7 +316,7 @@ The default colors are:
 	If smart_gaps are _on_ then gaps will only be enabled if a workspace has more
 	than one child container.
 
-**mark** <--add|--replace> <--toggle> <identifier>::
+**mark** \<--add|--replace> \<--toggle> <identifier>::
 	Marks are arbitrary labels that can be used to identify certain windows and
 	then jump to them at a later time. By default, the **mark** command sets
 	_identifier_ as the only mark on a window. By specifying _--add_, mark will
@@ -425,6 +425,20 @@ A criteria is a string in the form of e.g.:
 The string contains one or more (space separated) attribute/value pairs and they
 are used by some commands filter which views to execute actions on. All attributes
 must match for the criteria string to match.
+
+Criteria may be used with either the **for_window** or **assign** commands to
+specify operations to perform on new views. A criteria may also be used to
+perform specific commands (ones that normally act upon one window) on all views
+that match that criteria. For example:
+
+Focus on a window with the mark "IRC":
+	[con_mark="IRC"] focus
+
+Kill all windows with the title "Emacs":
+	[class="Emacs"] kill
+
+Mark all Firefox windows with "Browser":
+	[class="Firefox"] mark Browser
 
 Currently supported attributes:
 


### PR DESCRIPTION
This commit changes how commands decide what container to act on.
Commands get the current container though `current_container`, a global
defined in sway/commands.c. If a criteria is given before a command,
then the following command will be run once for every container the
criteria matches with a reference to the matching container in
'current_container'. Commands should use this instead of
`get_focused_container()` from now on.

This commit also fixes a few (minor) mistakes made in implementing marks
such as non-escaped arrows in sway(5) and calling the "mark" command
"floating" by accident. It also cleans up `criteria.c` in a few places.

I have tested the changed commands and things seem to work.