### PR TITLE
Add libcap check to CMake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ arch:
     - cairo
     - gdk-pixbuf2
     - wlc-git
+    - libcap
   script:
     - "cmake ."
     - "make"

--- a/CMake/FindLibcap.cmake
+++ b/CMake/FindLibcap.cmake
@@ -1,0 +1,56 @@
+#.rst:
+# FindLibcap
+# -------
+#
+# Find Libcap library
+#
+# Try to find Libcap library. The following values are defined
+#
+# ::
+#
+#   Libcap_FOUND         - True if Libcap is available
+#   Libcap_INCLUDE_DIRS  - Include directories for Libcap
+#   Libcap_LIBRARIES     - List of libraries for Libcap
+#   Libcap_DEFINITIONS   - List of definitions for Libcap
+#
+# and also the following more fine grained variables
+#
+# ::
+#
+#   Libcap_VERSION
+#   Libcap_VERSION_MAJOR
+#   Libcap_VERSION_MINOR
+#
+#=============================================================================
+# Copyright (c) 2017 Jerzi Kaminsky
+#
+# Distributed under the OSI-approved BSD License (the "License");
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+
+include(FeatureSummary)
+set_package_properties(Libcap PROPERTIES
+   URL "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2"
+   DESCRIPTION "Library for getting and setting POSIX.1e capabilities")
+
+find_package(PkgConfig)
+pkg_check_modules(PC_CAP QUIET Libcap)
+find_library(Libcap_LIBRARIES NAMES cap HINTS ${PC_CAP_LIBRARY_DIRS})
+find_path(Libcap_INCLUDE_DIRS sys/capability.h HINTS ${PC_CAP_INCLUDE_DIRS})
+
+set(Libcap_VERSION ${PC_CAP_VERSION})
+string(REPLACE "." ";" VERSION_LIST "${PC_CAP_VERSION}")
+
+LIST(LENGTH VERSION_LIST n)
+if (n EQUAL 2)
+   list(GET VERSION_LIST 0 Libcap_VERSION_MAJOR)
+   list(GET VERSION_LIST 1 Libcap_VERSION_MINOR)
+endif ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Libcap DEFAULT_MSG Libcap_INCLUDE_DIRS Libcap_LIBRARIES)
+mark_as_advanced(Libcap_INCLUDE_DIRS Libcap_LIBRARIES Libcap_DEFINITIONS
+   Libcap_VERSION Libcap_VERSION_MAJOR Libcap_VERSION_MICRO Libcap_VERSION_MINOR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ find_package(GdkPixbuf)
 find_package(PAM)
 
 find_package(LibInput REQUIRED)
+find_package(Libcap REQUIRED)
 
 if (CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
 	find_package(EpollShim REQUIRED)

--- a/sway/main.c
+++ b/sway/main.c
@@ -11,8 +11,8 @@
 #include <signal.h>
 #include <unistd.h>
 #include <getopt.h>
-#include <sys/capability.h>
 #ifdef __linux__
+#include <sys/capability.h>
 #include <sys/prctl.h>
 #endif
 #include "sway/extensions.h"


### PR DESCRIPTION
- Moved <sys/capability.h> include inside `__linux__` guard, because all uses are similarly guarded.
- <sys/capability.h> is a part of optional devel package on at least fedora, so CMake now explicitly checks that libcap devel files are available.
- Added libcap to list of arch packages in .travis.yml, to make the dependency explicit. travis-ci installs the package by default, which is why this hasn't surfaced previously).
    