### PR TITLE
Change regex to use PCRE

### DIFF
--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -23,17 +23,16 @@ enum criteria_type { // *must* keep in sync with criteria_strings[]
 	CRIT_LAST
 };
 
-// this *must* match the ordering in criteria_type enum
-static const char * const criteria_strings[] = {
-	"class",
-	"con_mark",
-	"id",
-	"instance",
-	"title",
-	"urgent", // either "latest" or "oldest" ...
-	"window_role",
-	"window_type",
-	"workspace"
+static const char * const criteria_strings[CRIT_LAST] = {
+	[CRIT_CLASS] = "class",
+	[CRIT_CON_MARK] = "con_mark",
+	[CRIT_ID] = "id",
+	[CRIT_INSTANCE] = "instance",
+	[CRIT_TITLE] = "title",
+	[CRIT_URGENT] = "urgent", // either "latest" or "oldest" ...
+	[CRIT_WINDOW_ROLE] = "window_role",
+	[CRIT_WINDOW_TYPE] = "window_type",
+	[CRIT_WORKSPACE] = "workspace"
 };
 
 /**
@@ -240,7 +239,7 @@ ect_cleanup:
 }
 
 static int regex_cmp(const char *item, const pcre *regex) {
-    return pcre_exec(regex, NULL, item, strlen(item), 0, 0, NULL, 0);
+	return pcre_exec(regex, NULL, item, strlen(item), 0, 0, NULL, 0);
 }
 
 // test a single view if it matches list of criteria tokens (all of them).

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdbool.h>
-#include <regex.h>
+#include <pcre.h>
 #include "sway/criteria.h"
 #include "sway/container.h"
 #include "sway/config.h"
@@ -42,18 +42,13 @@ static const char * const criteria_strings[] = {
  */
 struct crit_token {
 	enum criteria_type type;
-	regex_t *regex;
+	pcre *regex;
 	char *raw;
 };
 
 static void free_crit_token(struct crit_token *crit) {
-	if (crit->regex) {
-		regfree(crit->regex);
-		free(crit->regex);
-	}
-	if (crit->raw) {
-		free(crit->raw);
-	}
+	pcre_free(crit->regex);
+	free(crit->raw);
 	free(crit);
 }
 
@@ -190,18 +185,17 @@ static char *parse_criteria_name(enum criteria_type *type, char *name) {
 }
 
 // Returns error string on failure or NULL otherwise.
-static char *generate_regex(regex_t **regex, char *value) {
-	*regex = calloc(1, sizeof(regex_t));
-	int err = regcomp(*regex, value, REG_NOSUB);
-	if (err != 0) {
-		char *reg_err = malloc(64);
-		regerror(err, *regex, reg_err, 64);
+static char *generate_regex(pcre **regex, char *value) {
+	const char *reg_err;
+	int offset;
 
+	*regex = pcre_compile(value, PCRE_UTF8 | PCRE_UCP, &reg_err, &offset, NULL);
+
+	if (!*regex) {
 		const char *fmt = "Regex compilation (for '%s') failed: %s";
 		int len = strlen(fmt) + strlen(value) + strlen(reg_err) - 3;
 		char *error = malloc(len);
 		snprintf(error, len, fmt, value, reg_err);
-		free(reg_err);
 		return error;
 	}
 	return NULL;
@@ -245,8 +239,8 @@ ect_cleanup:
 	return error;
 }
 
-static int regex_cmp(const char *item, const regex_t *regex) {
-    return regexec(regex, item, 0, NULL, 0);
+static int regex_cmp(const char *item, const pcre *regex) {
+    return pcre_exec(regex, NULL, item, strlen(item), 0, 0, NULL, 0);
 }
 
 // test a single view if it matches list of criteria tokens (all of them).
@@ -266,7 +260,7 @@ static bool criteria_test(swayc_t *cont, list_t *tokens) {
 				if (focused->class && strcmp(cont->class, focused->class) == 0) {
 					matches++;
 				}
-			} else if (crit->regex && regexec(crit->regex, cont->class, 0, NULL, 0) == 0) {
+			} else if (crit->regex && regex_cmp(cont->class, crit->regex) == 0) {
 				matches++;
 			}
 			break;
@@ -281,7 +275,7 @@ static bool criteria_test(swayc_t *cont, list_t *tokens) {
 		case CRIT_ID:
 			if (!cont->app_id) {
 				// ignore
-			} else if (crit->regex && regexec(crit->regex, cont->app_id, 0, NULL, 0) == 0) {
+			} else if (crit->regex && regex_cmp(cont->app_id, crit->regex) == 0) {
 				matches++;
 			}
 			break;
@@ -293,7 +287,7 @@ static bool criteria_test(swayc_t *cont, list_t *tokens) {
 				if (focused->instance && strcmp(cont->instance, focused->instance) == 0) {
 					matches++;
 				}
-			} else if (crit->regex && regexec(crit->regex, cont->instance, 0, NULL, 0) == 0) {
+			} else if (crit->regex && regex_cmp(cont->instance, crit->regex) == 0) {
 				matches++;
 			}
 			break;
@@ -305,7 +299,7 @@ static bool criteria_test(swayc_t *cont, list_t *tokens) {
 				if (focused->name && strcmp(cont->name, focused->name) == 0) {
 					matches++;
 				}
-			} else if (crit->regex && regexec(crit->regex, cont->name, 0, NULL, 0) == 0) {
+			} else if (crit->regex && regex_cmp(cont->name, crit->regex) == 0) {
 				matches++;
 			}
 			break;
@@ -325,7 +319,7 @@ static bool criteria_test(swayc_t *cont, list_t *tokens) {
 				if (focused_ws->name && strcmp(cont_ws->name, focused_ws->name) == 0) {
 					matches++;
 				}
-			} else if (crit->regex && regexec(crit->regex, cont_ws->name, 0, NULL, 0) == 0) {
+			} else if (crit->regex && regex_cmp(cont_ws->name, crit->regex) == 0) {
 				matches++;
 			}
 			break;


### PR DESCRIPTION
This changes the regex matching for criterias to use PCRE instead of POSIX. i3 uses PCRE, so this would be increase compatibility with it.
PCRE is already pulled in as a dependency so I don't think this will cause any issues.