### PR TITLE
Misc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Install dependencies:
 * [wlc](https://github.com/Cloudef/wlc)
 * wayland
 * xwayland
+* libinput >= 1.6.0
 * libcap
 * asciidoc
 * pcre

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -284,7 +284,9 @@ json_object *ipc_json_describe_input(struct libinput_device *device) {
 		{ LIBINPUT_DEVICE_CAP_TABLET_TOOL, "tablet_tool", NULL },
 		{ LIBINPUT_DEVICE_CAP_TABLET_PAD, "tablet_pad", NULL },
 		{ LIBINPUT_DEVICE_CAP_GESTURE, "gesture", NULL },
-		{ LIBINPUT_DEVICE_CAP_SWITCH, "switch", NULL }
+#ifdef LIBINPUT_DEVICE_CAP_SWITCH // libinput 1.7.0+
+		{ LIBINPUT_DEVICE_CAP_SWITCH, "switch", NULL },
+#endif		
 	};
 
 	json_object *_caps = json_object_new_array();

--- a/sway/sway-bar.5.txt
+++ b/sway/sway-bar.5.txt
@@ -50,17 +50,17 @@ Commands
 
 **wrap_scroll** <yes|no>::
 	Enables or disables wrapping when scrolling through workspaces with the
-	scroll wheel. Default is no.
+	scroll wheel. Default is _no_.
 
 **workspace_buttons** <yes|no>::
-	Enables or disables workspace buttons on the bar. Default is yes.
+	Enables or disables workspace buttons on the bar. Default is _yes_.
 
 **strip_workspace_numbers** <yes|no>::
 	If set to _yes_, then workspace numbers will be omitted from the workspace
-	button and only the custom name will be shown.
+	button and only the custom name will be shown. Default is _no_.
 
 **binding_mode_indicator** <yes|no>::
-	Enable or disable binding mode indicator. It's enabled by default.
+	Enable or disable binding mode indicator. Default is _yes_.
 
 **height** <height>::
 	Sets the height of the bar. Default height will match the font size.


### PR DESCRIPTION
(Was "Prep Work for swaybar hide mode", but #1169 beat me to it so I just kept the cleanup fixes)

I think b463fb8 (taken together with #1150)  shows a current weakness in the way version management/CI is handled. I'd suggest that an explicit version baseline for dependencies be defined and documented. The CI should then test at least against that baseline to make sure sway is in sync with the shipped versions of its dependencies in recent distros releases. my 2c.