### PR TITLE
Fix multiple issues in sway_assert

### DIFF
--- a/common/log.c
+++ b/common/log.c
@@ -63,7 +63,8 @@ void sway_abort(const char *format, ...) {
 	sway_terminate(EXIT_FAILURE);
 }
 
-void _sway_log(const char *filename, int line, log_importance_t verbosity, const char* format, ...) {
+void _sway_vlog(const char *filename, int line, log_importance_t verbosity,
+		const char *format, va_list args) {
 	if (verbosity <= v) {
 		// prefix the time to the log message
 		static struct tm result;
@@ -99,16 +100,20 @@ void _sway_log(const char *filename, int line, log_importance_t verbosity, const
 			fprintf(stderr, "[%s:%d] ", file, line);
 		}
 
-		va_list args;
-		va_start(args, format);
 		vfprintf(stderr, format, args);
-		va_end(args);
 
 		if (colored && isatty(STDERR_FILENO)) {
 			fprintf(stderr, "\x1B[0m");
 		}
 		fprintf(stderr, "\n");
 	}
+}
+
+void _sway_log(const char *filename, int line, log_importance_t verbosity, const char* format, ...) {
+	va_list args;
+	va_start(args, format);
+	_sway_vlog(filename, line, verbosity, format, args);
+	va_end(args);
 }
 
 void sway_log_errno(log_importance_t verbosity, char* format, ...) {
@@ -144,7 +149,7 @@ bool _sway_assert(bool condition, const char* format, ...) {
 
 	va_list args;
 	va_start(args, format);
-	sway_log(L_ERROR, format, args);
+	sway_vlog(L_ERROR, format, args);
 	va_end(args);
 
 #ifndef NDEBUG

--- a/common/log.c
+++ b/common/log.c
@@ -142,14 +142,14 @@ void sway_log_errno(log_importance_t verbosity, char* format, ...) {
 	}
 }
 
-bool _sway_assert(bool condition, const char* format, ...) {
+bool _sway_assert(bool condition, const char *filename, int line, const char* format, ...) {
 	if (condition) {
 		return true;
 	}
 
 	va_list args;
 	va_start(args, format);
-	sway_vlog(L_ERROR, format, args);
+	_sway_vlog(filename, line, L_ERROR, format, args);
 	va_end(args);
 
 #ifndef NDEBUG

--- a/include/log.h
+++ b/include/log.h
@@ -28,6 +28,9 @@ void _sway_log(const char *filename, int line, log_importance_t verbosity, const
 #define sway_log(VERBOSITY, FMT, ...) \
 	_sway_log(__FILE__, __LINE__, VERBOSITY, FMT, ##__VA_ARGS__)
 
+#define sway_vlog(VERBOSITY, FMT, VA_ARGS) \
+    _sway_vlog(__FILE__, __LINE__, VERBOSITY, FMT, VA_ARGS)
+
 void error_handler(int sig);
 
 #endif

--- a/include/log.h
+++ b/include/log.h
@@ -19,9 +19,9 @@ void sway_log_colors(int mode);
 void sway_log_errno(log_importance_t verbosity, char* format, ...) __attribute__((format(printf,2,3)));
 void sway_abort(const char* format, ...) __attribute__((format(printf,1,2)));
 
-bool _sway_assert(bool condition, const char* format, ...) __attribute__((format(printf,2,3)));
+bool _sway_assert(bool condition, const char *filename, int line, const char* format, ...) __attribute__((format(printf,4,5)));
 #define sway_assert(COND, FMT, ...) \
-	_sway_assert(COND, "%s:" FMT, __PRETTY_FUNCTION__, ##__VA_ARGS__)
+	_sway_assert(COND, __FILE__, __LINE__, "%s:" FMT, __PRETTY_FUNCTION__, ##__VA_ARGS__)
 
 void _sway_log(const char *filename, int line, log_importance_t verbosity, const char* format, ...) __attribute__((format(printf,4,5)));
 


### PR DESCRIPTION
- `_sway_assert` is a variadic function which tries to delegate to another variadic function. This requires a vprintf-style variant of the delegate. https://stackoverflow.com/a/150616
- DRY: _sway_log now delegates to _sway_vlog. 
- `sway_assert` did not correctly propagate the location information for the assert callsite. 

