### PR TITLE
Add -DVERSION flag for release version numbers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,10 @@ endif()
 list(INSERT CMAKE_MODULE_PATH 0
 	${CMAKE_CURRENT_SOURCE_DIR}/CMake
 	)
-if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
+
+if (VERSION)
+	add_definitions(-DSWAY_VERSION=\"${VERSION}\")
+else()
 	execute_process(
 		COMMAND git describe --always --tags
 		OUTPUT_VARIABLE GIT_COMMIT_HASH
@@ -33,13 +36,10 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
 		OUTPUT_STRIP_TRAILING_WHITESPACE
 		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 		)
+
+	string(TIMESTAMP CURRENT_DATE "%Y-%m-%d" UTC)
+	add_definitions("-DSWAY_VERSION=\"${GIT_COMMIT_HASH} (${CURRENT_DATE}, branch \\\"${GIT_BRANCH}\\\")\"")
 endif()
-
-add_definitions(-DSWAY_GIT_VERSION=\"${GIT_COMMIT_HASH}\")
-add_definitions(-DSWAY_GIT_BRANCH=\"${GIT_BRANCH}\")
-
-string(TIMESTAMP CURRENT_DATE "%Y-%m-%d" UTC)
-add_definitions(-DSWAY_VERSION_DATE=\"${CURRENT_DATE}\")
 
 option(enable-swaylock "Enables the swaylock utility" YES)
 option(enable-swaybg "Enables the wallpaper utility" YES)

--- a/sway/ipc-json.c
+++ b/sway/ipc-json.c
@@ -306,39 +306,16 @@ json_object *ipc_json_describe_input(struct libinput_device *device) {
 }
 
 json_object *ipc_json_get_version() {
+	int major = 0, minor = 0, patch = 0;
 	json_object *version = json_object_new_object();
 
-#if defined SWAY_GIT_VERSION && defined SWAY_GIT_BRANCH && defined SWAY_VERSION_DATE
-	char *full_version = calloc(strlen(SWAY_GIT_VERSION) + strlen(SWAY_GIT_BRANCH) + strlen(SWAY_VERSION_DATE) + 20, 1);
-	if (!full_version) {
-		json_object_object_add(version, "human_readable",
-				json_object_new_string("Allocating version string failed"));
-		// TODO: it's stupid that we allocate this in the first place
-		json_object_object_add(version, "major", json_object_new_int(0));
-		json_object_object_add(version, "minor", json_object_new_int(0));
-		json_object_object_add(version, "patch", json_object_new_int(0));
-		return version;
-	}
-	strcat(full_version, SWAY_GIT_VERSION);
-	strcat(full_version, " (");
-	strcat(full_version, SWAY_VERSION_DATE);
-	strcat(full_version, ", branch \"");
-	strcat(full_version, SWAY_GIT_BRANCH);
-	strcat(full_version, "\")");
+	sscanf(SWAY_VERSION, "%u.%u.%u", &major, &minor, &patch);
 
-	json_object_object_add(version, "human_readable", json_object_new_string(full_version));
+	json_object_object_add(version, "human_readable", json_object_new_string(SWAY_VERSION));
 	json_object_object_add(version, "variant", json_object_new_string("sway"));
-	// Todo once we actually release a version
-	json_object_object_add(version, "major", json_object_new_int(0));
-	json_object_object_add(version, "minor", json_object_new_int(0));
-	json_object_object_add(version, "patch", json_object_new_int(1));
-	free(full_version);
-#else
-	json_object_object_add(version, "human_readable", json_object_new_string("version not found"));
-	json_object_object_add(version, "major", json_object_new_int(0));
-	json_object_object_add(version, "minor", json_object_new_int(0));
-	json_object_object_add(version, "patch", json_object_new_int(0));
-#endif
+	json_object_object_add(version, "major", json_object_new_int(major));
+	json_object_object_add(version, "minor", json_object_new_int(minor));
+	json_object_object_add(version, "patch", json_object_new_int(patch));
 
 	return version;
 }

--- a/sway/main.c
+++ b/sway/main.c
@@ -267,11 +267,7 @@ int main(int argc, char **argv) {
 			debug = 1;
 			break;
 		case 'v': // version
-#if defined SWAY_GIT_VERSION && defined SWAY_GIT_BRANCH && defined SWAY_VERSION_DATE
-			fprintf(stdout, "sway version %s (%s, branch \"%s\")\n", SWAY_GIT_VERSION, SWAY_VERSION_DATE, SWAY_GIT_BRANCH);
-#else
-			fprintf(stdout, "version not detected\n");
-#endif
+			fprintf(stdout, "sway version " SWAY_VERSION "\n");
 			exit(EXIT_SUCCESS);
 			break;
 		case 'V': // verbose
@@ -378,9 +374,7 @@ int main(int argc, char **argv) {
 	// prevent ipc from crashing sway
 	signal(SIGPIPE, SIG_IGN);
 
-#if defined SWAY_GIT_VERSION && defined SWAY_GIT_BRANCH && defined SWAY_VERSION_DATE
-	sway_log(L_INFO, "Starting sway version %s (%s, branch \"%s\")\n", SWAY_GIT_VERSION, SWAY_VERSION_DATE, SWAY_GIT_BRANCH);
-#endif
+	sway_log(L_INFO, "Starting sway version " SWAY_VERSION "\n");
 
 	init_layout();
 

--- a/swaybar/main.c
+++ b/swaybar/main.c
@@ -63,11 +63,7 @@ int main(int argc, char **argv) {
 			bar_id = strdup(optarg);
 			break;
 		case 'v':
-#if defined SWAY_GIT_VERSION && defined SWAY_GIT_BRANCH && defined SWAY_VERSION_DATE
-			fprintf(stdout, "sway version %s (%s, branch \"%s\")\n", SWAY_GIT_VERSION, SWAY_VERSION_DATE, SWAY_GIT_BRANCH);
-#else
-			fprintf(stdout, "version not detected\n");
-#endif
+			fprintf(stdout, "sway version " SWAY_VERSION "\n");
 			exit(EXIT_SUCCESS);
 			break;
 		case 'd': // Debug

--- a/swaygrab/main.c
+++ b/swaygrab/main.c
@@ -201,11 +201,7 @@ int main(int argc, char **argv) {
 			framerate = atoi(optarg);
 			break;
 		case 'v':
-#if defined SWAY_GIT_VERSION && defined SWAY_GIT_BRANCH && defined SWAY_VERSION_DATE
-			fprintf(stdout, "sway version %s (%s, branch \"%s\")\n", SWAY_GIT_VERSION, SWAY_VERSION_DATE, SWAY_GIT_BRANCH);
-#else
-			fprintf(stdout, "version not detected\n");
-#endif
+			fprintf(stdout, "sway version " SWAY_VERSION "\n");
 			exit(EXIT_SUCCESS);
 			break;
 		default:

--- a/swaylock/main.c
+++ b/swaylock/main.c
@@ -451,11 +451,7 @@ int main(int argc, char **argv) {
 			socket_path = optarg;
 			break;
 		case 'v':
-#if defined SWAY_GIT_VERSION && defined SWAY_GIT_BRANCH && defined SWAY_VERSION_DATE
-			fprintf(stdout, "swaylock version %s (%s, branch \"%s\")\n", SWAY_GIT_VERSION, SWAY_VERSION_DATE, SWAY_GIT_BRANCH);
-#else
-			fprintf(stdout, "version not detected\n");
-#endif
+			fprintf(stdout, "swaylock version " SWAY_VERSION "\n");
 			exit(EXIT_SUCCESS);
 			break;
 		case 'u':

--- a/swaymsg/main.c
+++ b/swaymsg/main.c
@@ -230,11 +230,7 @@ int main(int argc, char **argv) {
 			cmdtype = strdup(optarg);
 			break;
 		case 'v':
-#if defined SWAY_GIT_VERSION && defined SWAY_GIT_BRANCH && defined SWAY_VERSION_DATE
-			fprintf(stdout, "sway version %s (%s, branch \"%s\")\n", SWAY_GIT_VERSION, SWAY_VERSION_DATE, SWAY_GIT_BRANCH);
-#else
-			fprintf(stdout, "version not detected\n");
-#endif
+			fprintf(stdout, "sway version " SWAY_VERSION "\n");
 			exit(EXIT_SUCCESS);
 			break;
 		default:


### PR DESCRIPTION
Currently, the version number (as shown by `sway --version` and used in other places) is based on
`git describe`. But when packaging sway for Debian, where it is built outside of git, these information aren't available. Moreover, the version string contains information, such as date and branch, that aren't relevant for release builds, not to mention that the boilerplate to generate that version string is duplicated across the code base, which I fixed as well by having `CMakeList.txt` generate the version string. Finally, while on it, I also fixed the JSON version information in the IPC code.

Note that I removed the code path for when `SWAY_GIT_VERSION` and `SWAY_GIT_BRANCH` aren't defined. This was dead code anyway, as `CMakeList.txt` always defined these macros, but merely with an empty string if running outside of git. Moreover, I think it is preferable having the build fail if neither `-DVERSION` was given nor when building from git. Otherwise, package maintainers will easily forget to use `-DVERSION`.