### PR TITLE
FreeBSD fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,10 @@ find_package(GdkPixbuf)
 find_package(PAM)
 
 find_package(LibInput REQUIRED)
-find_package(Libcap REQUIRED)
+
+if (CMAKE_SYSTEM_NAME STREQUAL Linux)
+	find_package(Libcap REQUIRED)
+endif (CMAKE_SYSTEM_NAME STREQUAL Linux)
 
 if (CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
 	find_package(EpollShim REQUIRED)

--- a/common/log.c
+++ b/common/log.c
@@ -1,4 +1,4 @@
-#define _POSIX_C_SOURCE 1
+#define _POSIX_C_SOURCE 199506L
 #include <errno.h>
 #include <libgen.h>
 #include <signal.h>

--- a/common/stringop.c
+++ b/common/stringop.c
@@ -1,4 +1,4 @@
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 700
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/common/util.c
+++ b/common/util.c
@@ -1,4 +1,4 @@
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 700
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/sway/border.c
+++ b/sway/border.c
@@ -1,4 +1,4 @@
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 700
 #include <wlc/wlc-render.h>
 #include <cairo/cairo.h>
 #include <pango/pangocairo.h>

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -1,4 +1,4 @@
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 700
 #include <xkbcommon/xkbcommon.h>
 #include <xkbcommon/xkbcommon-names.h>
 #include <wlc/wlc.h>

--- a/sway/commands/assign.c
+++ b/sway/commands/assign.c
@@ -1,4 +1,4 @@
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 700
 #include <stdio.h>
 #include <string.h>
 #include "sway/commands.h"
@@ -55,4 +55,3 @@ struct cmd_results *cmd_assign(int argc, char **argv) {
 	}
 	return error ? error : cmd_results_new(CMD_SUCCESS, NULL, NULL);
 }
-

--- a/sway/commands/set.c
+++ b/sway/commands/set.c
@@ -1,4 +1,4 @@
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 700
 #include <stdio.h>
 #include <string.h>
 #include <strings.h>

--- a/sway/config.c
+++ b/sway/config.c
@@ -1,5 +1,5 @@
 #define _POSIX_C_SOURCE 200809L
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 700
 #include <stdio.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -527,7 +527,7 @@ bool load_main_config(const char *file, bool is_active) {
 	list_add(config->config_chain, path);
 
 	config->reading = true;
-	
+
 	// Read security configs
 	bool success = true;
 	DIR *dir = opendir(SYSCONFDIR "/sway/security.d");

--- a/sway/criteria.c
+++ b/sway/criteria.c
@@ -1,4 +1,4 @@
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 700
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdbool.h>

--- a/sway/input.c
+++ b/sway/input.c
@@ -1,4 +1,4 @@
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 700
 #include <ctype.h>
 #include <float.h>
 #include <limits.h>
@@ -60,7 +60,7 @@ char *libinput_dev_unique_id(struct libinput_device *device) {
 	}
 
 	const char *fmt = "%d:%d:%s";
-	snprintf(identifier, len, fmt, vendor, product, name); 
+	snprintf(identifier, len, fmt, vendor, product, name);
 	free(name);
 	return identifier;
 }

--- a/sway/main.c
+++ b/sway/main.c
@@ -1,4 +1,4 @@
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 700
 #define _POSIX_C_SOURCE 200112L
 #include <stdio.h>
 #include <stdlib.h>
@@ -433,4 +433,3 @@ int main(int argc, char **argv) {
 
 	return exit_value;
 }
-

--- a/sway/security.c
+++ b/sway/security.c
@@ -1,4 +1,4 @@
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 700
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <string.h>

--- a/swaygrab/json.c
+++ b/swaygrab/json.c
@@ -1,4 +1,4 @@
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 700
 #include <string.h>
 #include <stdio.h>
 #include <stdbool.h>

--- a/swaygrab/main.c
+++ b/swaygrab/main.c
@@ -1,4 +1,4 @@
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 700
 #define _POSIX_C_SOURCE 199309L
 #include <stdio.h>
 #include <stdbool.h>


### PR DESCRIPTION
Increase _POSIX_SOURCE value for localtime_r access.
Increase _XOPEN_SOURCE value for lstat() and various printf() functions access.
Conditionally link to libcap (only on Linux).
Possibly some trailing whitespace fixes (automatic).