### PR TITLE
include stdint to be compaitable with musl

### DIFF
--- a/wayland/pango.c
+++ b/wayland/pango.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include "log.h"
 
 PangoLayout *get_pango_layout(cairo_t *cairo, const char *font, const char *text,


### PR DESCRIPTION
It doesn't comlile with musl if you don't include it explicitly