### PR TITLE
swaybar: Group child processes for signalling

### DIFF
--- a/swaybar/bar.c
+++ b/swaybar/bar.c
@@ -34,6 +34,7 @@ static void spawn_status_cmd_proc(struct bar *bar) {
 			close(pipefd[0]);
 			dup2(pipefd[1], STDOUT_FILENO);
 			close(pipefd[1]);
+			setpgid(bar->status_command_pid, 0);
 			char *const cmd[] = {
 				"sh",
 				"-c",
@@ -274,7 +275,7 @@ static void free_outputs(list_t *outputs) {
 static void terminate_status_command(pid_t pid) {
 	if (pid) {
 		// terminate status_command process
-		int ret = kill(pid, SIGTERM);
+		int ret = killpg(pid, SIGTERM);
 		if (ret != 0) {
 			sway_log(L_ERROR, "Unable to terminate status_command [pid: %d]", pid);
 		} else {


### PR DESCRIPTION
Fixes child proccess killing, when status_command is a complex command
like "i3status | wrapper.sh".

Set the process group id of the child process by calling `setpgid` after
forking and before calling `exec`.

The process group ID will be set to the process ID of the forked
process. Processes spawned by this child process will also have this
group ID.

Send signals to the process group with `killpg`. This will send the
signal to all of the process group.