### PR TITLE
Fix #926

### DIFF
--- a/include/sway/commands.h
+++ b/include/sway/commands.h
@@ -103,6 +103,7 @@ sway_cmd cmd_client_unfocused;
 sway_cmd cmd_client_urgent;
 sway_cmd cmd_client_placeholder;
 sway_cmd cmd_client_background;
+sway_cmd cmd_clipboard;
 sway_cmd cmd_commands;
 sway_cmd cmd_debuglog;
 sway_cmd cmd_default_border;

--- a/sway/commands.c
+++ b/sway/commands.c
@@ -165,6 +165,7 @@ static struct cmd_handler handlers[] = {
 	{ "client.placeholder", cmd_client_placeholder },
 	{ "client.unfocused", cmd_client_unfocused },
 	{ "client.urgent", cmd_client_urgent },
+	{ "clipboard", cmd_clipboard },
 	{ "commands", cmd_commands },
 	{ "debuglog", cmd_debuglog },
 	{ "default_border", cmd_default_border },

--- a/sway/commands/clipboard.c
+++ b/sway/commands/clipboard.c
@@ -1,0 +1,38 @@
+#include <wlc/wlc.h>
+#include <unistd.h>
+#include <string.h>
+#include "sway/commands.h"
+#include "stringop.h"
+
+static void send_clipboard(void *data, const char *type, int fd) {
+	if (strcmp(type, "text/plain") != 0
+			&& strcmp(type, "text/plain;charset=utf-8") != 0) {
+		close(fd);
+		return;
+	}
+
+	const char *str = data;
+	write(fd, str, strlen(str));
+	close(fd);
+}
+
+struct cmd_results *cmd_clipboard(int argc, char **argv) {
+	static char *current_data = NULL;
+
+	struct cmd_results *error = NULL;
+	if ((error = checkarg(argc, "clipboard", EXPECTED_AT_LEAST, 1))) {
+		return error;
+	}
+
+	static const char *types[2] = {
+		"text/plain",
+		"text/plain;charset=utf-8"
+	};
+
+	char *str = join_args(argv, argc);
+	wlc_set_selection(str, types, 2, &send_clipboard);
+
+	free(current_data);
+	current_data = str;
+	return cmd_results_new(CMD_SUCCESS, NULL, NULL);
+}


### PR DESCRIPTION
Adds the 'clipboard' command that can currently only be used
like this: 'swaymsg clipboard Some clipboard text here'. In future it could be extended to set non-text data or read from the clipboard but this would require extensions to wlc (or has to wait for wlroots).
Note that due to sway command arguments passing this will
not preserve whitespace in the clipboard text correctly (i.e. two spaces will be interpreted as one).
Requires Cloudef/wlc#272 to work correctly.

Still not too familiar with the sway codebase, I am not sure this is the correct way to add new commands to sway, or if they have to be added somewhere else.