### PR TITLE
Do not fail silently when background is not PNG

### DIFF
--- a/swaybg/main.c
+++ b/swaybg/main.c
@@ -97,6 +97,14 @@ int main(int argc, const char **argv) {
 		if (!image) {
 			sway_abort("Failed to read background image.");
 		}
+		if (cairo_surface_status(image) != CAIRO_STATUS_SUCCESS) {
+			sway_abort("Failed to read background image: %s."
+#ifndef WITH_GDK_PIXBUF
+					"\nSway was compiled without gdk_pixbuf support, so only"
+					"\nPNG images can be loaded. This is the likely cause."
+#endif //WITH_GDK_PIXBUF
+					, cairo_status_to_string(cairo_surface_status(image)));
+		}
 		double width = cairo_image_surface_get_width(image);
 		double height = cairo_image_surface_get_height(image);
 


### PR DESCRIPTION
#895 is caused by unclear documentation, which this fixes.

EDIT: actually swaybg should probably also report problems loading the image
EDIT2: actually it already does, but cairo doesn't seem to fail loading when given a jpeg instead of a png
EDIT3: Made swaybg break if background image can't be loaded