### PR TITLE
Fix zsh completion for _swaylock

### DIFF
--- a/completions/zsh/_swaylock
+++ b/completions/zsh/_swaylock
@@ -6,7 +6,7 @@
 _arguments -s \
     '(-v --version)'{-v,--version}'[Show the version number and quit]' \
     '(-h --help)'{-h,--help}'[Show help message and quit]' \
-    '(-f --daemonize)'{-f, --daemonize}'[Detach from the controlling terminal]\
+    '(-f --daemonize)'{-f, --daemonize}'[Detach from the controlling terminal]'\
     '(-c --color)'{-c,--color}'[Specify a color (rrggbb)]' \
     '(-i --image)'{-i,--image}'[Display an image]:files:_files' \
     '(-s --scaling)'{-s,--scaling}'[Scaling mode]:mode:(stretch fill fit center tile)' \


### PR DESCRIPTION
There was a missing ' in _swaylock, prevents zsh from providing completion.