### PR TITLE
Fix build on FreeBSD (tag 0.14-rc3)

### DIFF
--- a/swaybar/event_loop.c
+++ b/swaybar/event_loop.c
@@ -1,4 +1,4 @@
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 700
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>
@@ -96,7 +96,7 @@ bool remove_event(int fd) {
 static int timer_item_timer_cmp(const void *_timer_item, const void *_timer) {
 	const struct timer_item *timer_item = _timer_item;
 	const timer_t *timer = _timer;
-	if (timer_item->timer == timer) {
+	if (timer_item->timer == *timer) {
 		return 0;
 	} else {
 		return -1;

--- a/swaybar/tray/dbus.c
+++ b/swaybar/tray/dbus.c
@@ -1,4 +1,4 @@
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 700
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>

--- a/swaybar/tray/icon.c
+++ b/swaybar/tray/icon.c
@@ -1,4 +1,4 @@
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 700
 #define _POSIX_C_SOURCE 200809L
 #include <stdio.h>
 #include <stdlib.h>

--- a/swaybar/tray/tray.c
+++ b/swaybar/tray/tray.c
@@ -1,4 +1,4 @@
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 700
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Not sure about the timer comparison error. Getting this with clang 4.0.0: 
```
/home/johannes/dev/sway/swaybar/event_loop.c:102:24: error: comparison of distinct pointer types
      ('timer_t' (aka 'struct __timer *') and 'const timer_t *' (aka 'struct __timer *const *'))
      [-Werror,-Wcompare-distinct-pointer-types]
        if (timer_item->timer == timer) {
```
Are we comparing pointers or objects? 
