### PR TITLE
Don't trust SNI names, fixes #1274

### DIFF
--- a/include/swaybar/tray/sni.h
+++ b/include/swaybar/tray/sni.h
@@ -28,6 +28,7 @@ void sni_icon_ref_free(struct sni_icon_ref *sni_ref);
 
 /**
  * Will return a new item and get its icon. (see warning below)
+ * May return `NULL` if `name` is not valid.
  */
 struct StatusNotifierItem *sni_create(const char *name);
 

--- a/swaybar/tray/sni.c
+++ b/swaybar/tray/sni.c
@@ -413,6 +413,12 @@ static void get_unique_name(struct StatusNotifierItem *item) {
 }
 
 struct StatusNotifierItem *sni_create(const char *name) {
+	// Make sure `name` is well formed
+	if (!dbus_validate_bus_name(name, NULL)) {
+		sway_log(L_INFO, "Name (%s) is not a bus name. We cannot create an item.", name);
+		return NULL;
+	}
+
 	struct StatusNotifierItem *item = malloc(sizeof(struct StatusNotifierItem));
 	item->name = strdup(name);
 	item->unique_name = NULL;

--- a/swaybar/tray/tray.c
+++ b/swaybar/tray/tray.c
@@ -90,9 +90,11 @@ static void get_items_reply(DBusPendingCall *pending, void *_data) {
 
 		struct StatusNotifierItem *item = sni_create(name);
 
-		sway_log(L_DEBUG, "Item registered with host: %s", name);
-		list_add(tray->items, item);
-		dirty = true;
+		if (item) {
+			sway_log(L_DEBUG, "Item registered with host: %s", name);
+			list_add(tray->items, item);
+			dirty = true;
+		}
 	}
 
 bail:
@@ -141,8 +143,10 @@ static DBusHandlerResult signal_handler(DBusConnection *connection,
 		if (list_seq_find(tray->items, sni_str_cmp, name) == -1) {
 			struct StatusNotifierItem *item = sni_create(name);
 
-			list_add(tray->items, item);
-			dirty = true;
+			if (item) {
+				list_add(tray->items, item);
+				dirty = true;
+			}
 		}
 
 		return DBUS_HANDLER_RESULT_HANDLED;


### PR DESCRIPTION
If an item doesn't have a well-formed name, it will not be added to the
tray.