### PR TITLE
Fix memory leaks in swaybar tray

### DIFF
--- a/swaybar/event_loop.c
+++ b/swaybar/event_loop.c
@@ -105,6 +105,7 @@ static int timer_item_timer_cmp(const void *_timer_item, const void *_timer) {
 bool remove_timer(timer_t timer) {
 	int index = list_seq_find(event_loop.timers, timer_item_timer_cmp, &timer);
 	if (index != -1) {
+		free(event_loop.timers->items[index]);
 		list_del(event_loop.timers, index);
 		return true;
 	}

--- a/swaybar/tray/dbus.c
+++ b/swaybar/tray/dbus.c
@@ -108,7 +108,7 @@ static dbus_bool_t add_timeout(DBusTimeout *timeout, void *_data) {
 
 	timer_settime(*timer, 0, &time, NULL);
 
-	dbus_timeout_set_data(timeout, timer, free);
+	dbus_timeout_set_data(timeout, timer, NULL);
 
 	sway_log(L_DEBUG, "Adding DBus timeout. Interval: %ds %dms", interval_sec, interval_msec);
 	add_timer(*timer, dispatch_timeout, timeout);
@@ -121,6 +121,8 @@ static void remove_timeout(DBusTimeout *timeout, void *_data) {
 
 	if (timer) {
 		remove_timer(*timer);
+		timer_delete(*timer);
+		free(timer);
 	}
 }
 

--- a/swaybar/tray/sni.c
+++ b/swaybar/tray/sni.c
@@ -160,6 +160,7 @@ static void reply_icon(DBusPendingCall *pending, void *_data) {
 		dirty = true;
 
 		dbus_message_unref(reply);
+		dbus_pending_call_unref(pending);
 		return;
 	} else {
 		sway_log(L_ERROR, "Could not create image surface");
@@ -170,6 +171,7 @@ bail:
 	if (reply) {
 		dbus_message_unref(reply);
 	}
+	dbus_pending_call_unref(pending);
 	sway_log(L_ERROR, "Could not get icon from item");
 	return;
 }
@@ -266,6 +268,7 @@ static void reply_icon_name(DBusPendingCall *pending, void *_data) {
 		dirty = true;
 
 		dbus_message_unref(reply);
+		dbus_pending_call_unref(pending);
 		return;
 	}
 
@@ -273,6 +276,7 @@ bail:
 	if (reply) {
 		dbus_message_unref(reply);
 	}
+	dbus_pending_call_unref(pending);
 	// Now try the pixmap
 	send_icon_msg(item);
 	return;

--- a/swaybar/tray/tray.c
+++ b/swaybar/tray/tray.c
@@ -99,6 +99,7 @@ static void get_items_reply(DBusPendingCall *pending, void *_data) {
 
 bail:
 	dbus_message_unref(reply);
+	dbus_pending_call_unref(pending);
 	return;
 }
 static void get_items() {


### PR DESCRIPTION
These are a few memory leaks in the tray I found while on the plane. Of the leaks that seem to come from the tray, there is one that occurs on `swaybar/tray/sni.c:81` that I could not figure out, but that's it. There are also many leaks that come from pango calls, and a few in glib, but I did not have the resources to investigate and fix these.