### PR TITLE
[swaybar] fix non-dbus build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ endif()
 
 if (enable-tray)
 	if (DBUS_FOUND)
-		set(ENABLE_TRAY)
+		set(ENABLE_TRAY TRUE)
 		add_definitions(-DENABLE_TRAY)
 	else()
 		message(WARNING "Tray required but DBus was not found. Tray will not be included")

--- a/swaybar/CMakeLists.txt
+++ b/swaybar/CMakeLists.txt
@@ -7,7 +7,7 @@ include_directories(
 	${XKBCOMMON_INCLUDE_DIRS}
 	${DBUS_INCLUDE_DIRS}
 )
-if (enable-tray)
+if (ENABLE_TRAY)
 	file(GLOB tray
 		tray/*.c
 	)


### PR DESCRIPTION
Swaybar's CMakeLists.txt uses the enable-tray option directly to decide whether to build the tray. This leads to a compilation error if dbus is not installed.
This patch uses the ENABLE_TRAY variable instead, which is only true if the user enabled the tray *and* dbus is available.