### PR TITLE
Prevent race condition in the kill command

### DIFF
--- a/sway/container.c
+++ b/sway/container.c
@@ -849,7 +849,6 @@ int swayc_gap(swayc_t *container) {
 
 void container_map(swayc_t *container, void (*f)(swayc_t *view, void *data), void *data) {
 	if (container) {
-		f(container, data);
 		int i;
 		if (container->children)  {
 			for (i = 0; i < container->children->length; ++i) {
@@ -863,6 +862,7 @@ void container_map(swayc_t *container, void (*f)(swayc_t *view, void *data), voi
 				container_map(child, f, data);
 			}
 		}
+		f(container, data);
 	}
 }
 


### PR DESCRIPTION
When killing views with `close_views` a use-after-free can sometimes
occur because parent views are killed before their children. This commit
makes `container_map` run functions on child containers before their
parent, fixing the race.

Fixes #1302